### PR TITLE
Derive macros for Queue and Worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +556,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -700,6 +746,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "gethostname",
+ "oxanus-macros",
  "rand",
  "redis 1.0.2",
  "sentry-core",
@@ -712,6 +759,18 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "oxanus-macros"
+version = "0.7.0"
+dependencies = [
+ "darling",
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -777,6 +836,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1071,6 +1152,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["oxanus"]
+members = ["oxanus", "oxanus-macros"]
 resolver = "3"
 default-members = ["oxanus"]
 
@@ -8,3 +8,4 @@ rust-version = "1.75"
 
 [workspace.dependencies]
 oxanus = { path = "oxanus" }
+oxanus-macros = { path = "oxanus-macros" }

--- a/oxanus-macros/Cargo.toml
+++ b/oxanus-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oxanus-macros"
+version = "0.7.0"
+edition = "2024"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling = "0.23"
+heck = { version = "0.5", default-features = false }
+proc-macro-error2 = "2.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2", features = ["parsing", "proc-macro", "derive"] }
+
+[features]
+default = []

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -1,0 +1,23 @@
+mod queue;
+use queue::*;
+
+use proc_macro::TokenStream;
+use proc_macro_error2::proc_macro_error;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Generates impl for `oxanus::Queue`.
+///
+/// Example usage:
+/// ```
+/// #[derive(Serialize, oxanus::Queue)]
+/// #[oxanus(key = "my_queue")]
+/// #[oxanus(concurrency = 1)]
+/// pub struct MyQueue;
+/// ```
+#[proc_macro_error]
+#[proc_macro_derive(Queue, attributes(oxanus))]
+pub fn derive_queue(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_queue(input).into()
+}

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -1,5 +1,8 @@
 mod queue;
+mod worker;
+
 use queue::*;
+use worker::*;
 
 use proc_macro::TokenStream;
 use proc_macro_error2::proc_macro_error;
@@ -8,10 +11,11 @@ use syn::{DeriveInput, parse_macro_input};
 /// Generates impl for `oxanus::Queue`.
 ///
 /// Example usage:
-/// ```
+/// ```ignore
 /// #[derive(Serialize, oxanus::Queue)]
 /// #[oxanus(key = "my_queue")]
-/// #[oxanus(concurrency = 1)]
+/// #[oxanus(concurrency = 2)]
+/// #[oxanus(throttle(window_ms = 3, limit = 4))]
 /// pub struct MyQueue;
 /// ```
 #[proc_macro_error]
@@ -20,4 +24,23 @@ pub fn derive_queue(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     expand_derive_queue(input).into()
+}
+
+/// Generates impl for `oxanus::Worker`.
+///
+/// Example usage:
+/// ```ignore
+/// #[derive(Serialize, oxanus::Worker)]
+/// #[oxanus(max_retries = 3, on_conflict = Replace)]
+/// #[oxanus(unique_id = "test_worker_{id}")]
+/// struct TestWorkerUniqueId {
+///     id: i32,
+/// }
+/// ```
+#[proc_macro_error]
+#[proc_macro_derive(Worker, attributes(oxanus))]
+pub fn derive_worker(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_worker(input).into()
 }

--- a/oxanus-macros/src/queue.rs
+++ b/oxanus-macros/src/queue.rs
@@ -20,16 +20,6 @@ struct ThrottleArgs {
     limit: u64,
 }
 
-/// Generates impl for `oxanus::Queue`.
-///
-/// Example usage:
-/// ```ignore
-/// #[derive(Serialize, oxanus::Queue)]
-/// #[oxanus(key = "my_queue")]
-/// #[oxanus(concurrency = 2)]
-/// #[oxanus(throttle(window_ms = 3, limit = 4))]
-/// pub struct MyQueue;
-/// ```
 pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
     let args = match OxanusArgs::from_derive_input(&input) {
         Ok(v) => v,
@@ -88,6 +78,7 @@ pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
     };
 
     quote! {
+        #[automatically_derived]
         impl oxanus::Queue for #struct_ident {
             fn to_config() -> QueueConfig {
                 QueueConfig::#kind(#key)

--- a/oxanus-macros/src/queue.rs
+++ b/oxanus-macros/src/queue.rs
@@ -1,0 +1,99 @@
+use darling::{FromDeriveInput, FromMeta};
+use heck::ToSnakeCase;
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(oxanus), supports(struct_any))]
+struct OxanusArgs {
+    key: Option<String>,
+    prefix: Option<String>,
+    concurrency: Option<usize>,
+    throttle: Option<ThrottleArgs>,
+}
+
+#[derive(Debug, FromMeta)]
+struct ThrottleArgs {
+    window_ms: i64,
+    limit: u64,
+}
+
+/// Generates impl for `oxanus::Queue`.
+///
+/// Example usage:
+/// ```ignore
+/// #[derive(Serialize, oxanus::Queue)]
+/// #[oxanus(key = "my_queue")]
+/// #[oxanus(concurrency = 2)]
+/// #[oxanus(throttle(window_ms = 3, limit = 4))]
+/// pub struct MyQueue;
+/// ```
+pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
+    let args = match OxanusArgs::from_derive_input(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            // darling::Error -> emit nice compile errors
+            abort!(input.ident, "{}", e);
+        }
+    };
+
+    let num_fields = match &input.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(named) => named.named.len(),
+            Fields::Unnamed(unnamed) => unnamed.unnamed.len(),
+            Fields::Unit => 0,
+        },
+        _ => 0,
+    };
+
+    let struct_ident = &input.ident;
+
+    let kind = if args.prefix.is_some() {
+        if num_fields == 0 {
+            abort!(input.ident, "Dynamic queues must have struct fields.");
+        }
+        quote!(as_dynamic)
+    } else {
+        quote!(as_static)
+    };
+
+    let key = match (args.key, num_fields) {
+        (Some(k), 0) => k,
+        (Some(_), _) => abort!(input.ident, "Static queue cannot have struct fields."),
+        (None, 0) => struct_ident.to_string().to_snake_case(),
+        (None, _) => match args.prefix {
+            Some(k) => k,
+            None => abort!(
+                input.ident,
+                "`prefix` must be specified for dynamic queues."
+            ),
+        },
+    };
+
+    let concurrency = match args.concurrency {
+        Some(v) => quote!(.concurrency(#v)),
+        None => quote!(),
+    };
+
+    let throttle = match args.throttle {
+        Some(ThrottleArgs { window_ms, limit }) => quote! {
+            .throttle(oxanus::QueueThrottle {
+                window_ms: #window_ms,
+                limit: #limit,
+            })
+        },
+        None => quote!(),
+    };
+
+    quote! {
+        impl oxanus::Queue for #struct_ident {
+            fn to_config() -> QueueConfig {
+                QueueConfig::#kind(#key)
+                    #concurrency
+                    #throttle
+            }
+        }
+    }
+}

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -164,10 +164,10 @@ fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
             });
 
             quote! {
-                format!(
+                Some(format!(
                     #fmt,
                     #(#args),*
-                )
+                ))
             }
         }
 
@@ -175,10 +175,10 @@ fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
             let args = args.iter().map(|(name, expr)| quote!(#name = #expr));
 
             quote! {
-                format!(
+                Some(format!(
                     #fmt,
                     #(#args),*
-                )
+                ))
             }
         }
 
@@ -187,7 +187,7 @@ fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
 
     quote! {
         fn unique_id(&self) -> Option<String> {
-            Some(#formatter)
+            #formatter
         }
     }
 }

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -1,0 +1,193 @@
+use darling::{Error, FromDeriveInput, FromMeta};
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    Data, DeriveInput, Expr, Fields, Ident, LitStr, Meta, Path, Token, punctuated::Punctuated,
+};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(oxanus), supports(struct_any))]
+struct OxanusArgs {
+    context: Option<Path>,
+    error: Option<Path>,
+    max_retries: Option<u32>,
+    unique_id: Option<UniqueIdSpec>,
+    on_conflict: Option<Ident>,
+}
+
+#[derive(Debug)]
+enum UniqueIdSpec {
+    /// #[unique_id = "job_{id}"]
+    Shorthand(LitStr),
+
+    /// #[unique_id(fmt = "...", name = expr, ...)]
+    NamedFormatter {
+        fmt: LitStr,
+        args: Vec<(syn::Ident, Expr)>,
+    },
+
+    /// #[unique_id = mymod::func]
+    CustomFunc(Path),
+}
+
+impl FromMeta for UniqueIdSpec {
+    fn from_meta(meta: &Meta) -> darling::Result<Self> {
+        match meta {
+            Meta::NameValue(nv) => match &nv.value {
+                Expr::Lit(expr_lit) => {
+                    if let syn::Lit::Str(s) = &expr_lit.lit {
+                        Ok(UniqueIdSpec::Shorthand(s.clone()))
+                    } else {
+                        Err(Error::custom("unique_id must be a string literal"))
+                    }
+                }
+                Expr::Path(expr_path) => Ok(UniqueIdSpec::CustomFunc(expr_path.path.clone())),
+                _ => Err(Error::custom("Expected string literal or type path.")),
+            },
+            Meta::List(list) => {
+                let mut fmt = None;
+                let mut args = Vec::new();
+
+                let metas =
+                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+
+                for meta in metas {
+                    match meta {
+                        Meta::NameValue(nv) if nv.path.is_ident("fmt") => {
+                            if let syn::Expr::Lit(expr_lit) = nv.value {
+                                if let syn::Lit::Str(s) = expr_lit.lit {
+                                    fmt = Some(s);
+                                    continue;
+                                }
+                            }
+                            return Err(Error::custom("fmt must be a string literal"));
+                        }
+
+                        Meta::NameValue(nv) => {
+                            let ident = nv
+                                .path
+                                .get_ident()
+                                .ok_or_else(|| Error::custom("expected identifier"))?
+                                .clone();
+                            args.push((ident, nv.value));
+                        }
+
+                        _ => return Err(Error::custom("unsupported unique_id syntax")),
+                    }
+                }
+
+                let fmt = fmt.ok_or_else(|| Error::custom("missing fmt = \"...\""))?;
+                Ok(UniqueIdSpec::NamedFormatter { fmt, args })
+            }
+            _ => Err(Error::custom("invalid unique_id attribute")),
+        }
+    }
+}
+
+pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
+    let args = match OxanusArgs::from_derive_input(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            // darling::Error -> emit nice compile errors
+            abort!(input.ident, "{}", e);
+        }
+    };
+
+    let struct_ident = &input.ident;
+
+    let type_context = match args.context {
+        Some(context) => quote!(#context),
+        None => quote!(WorkerContext),
+    };
+
+    let type_error = match args.error {
+        Some(error) => quote!(#error),
+        None => quote!(WorkerError),
+    };
+
+    let max_retries = match args.max_retries {
+        Some(max_retries) => quote! {
+            fn max_retries(&self) -> u32 {
+                #max_retries
+            }
+        },
+        None => quote!(),
+    };
+
+    let on_conflict = match args.on_conflict {
+        Some(on_conflict) => quote! {
+            fn on_conflict(&self) -> oxanus::JobConflictStrategy {
+                oxanus::JobConflictStrategy::#on_conflict
+            }
+        },
+        None => quote!(),
+    };
+
+    let unique_id = match args.unique_id {
+        Some(unique_id) => expand_unique_id(
+            unique_id,
+            match &input.data {
+                Data::Struct(data_struct) => &data_struct.fields,
+                _ => abort!(input.ident, "Worker must be a struct."),
+            },
+        ),
+        None => quote!(),
+    };
+
+    quote! {
+        #[automatically_derived]
+        #[async_trait::async_trait]
+        impl oxanus::Worker for #struct_ident {
+            type Context = #type_context;
+            type Error = #type_error;
+
+            async fn process(&self, data: &oxanus::Context<Self::Context>) -> Result<(), Self::Error> {
+                self.process(data).await
+            }
+
+            #unique_id
+
+            #max_retries
+
+            #on_conflict
+        }
+    }
+}
+
+fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
+    let formatter = match spec {
+        UniqueIdSpec::Shorthand(fmt) => {
+            let args = fields.iter().filter_map(|f| {
+                let name = f.ident.as_ref()?;
+                Some(quote!(#name = self.#name))
+            });
+
+            quote! {
+                format!(
+                    #fmt,
+                    #(#args),*
+                )
+            }
+        }
+
+        UniqueIdSpec::NamedFormatter { fmt, args } => {
+            let args = args.iter().map(|(name, expr)| quote!(#name = #expr));
+
+            quote! {
+                format!(
+                    #fmt,
+                    #(#args),*
+                )
+            }
+        }
+
+        UniqueIdSpec::CustomFunc(path) => quote!(#path(self)),
+    };
+
+    quote! {
+        fn unique_id(&self) -> Option<String> {
+            Some(#formatter)
+        }
+    }
+}

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -55,6 +55,7 @@ impl FromMeta for UniqueIdSpec {
                 for meta in metas {
                     match meta {
                         Meta::NameValue(nv) if nv.path.is_ident("fmt") => {
+                            #[allow(clippy::collapsible_if)] // requires 1.88
                             if let syn::Expr::Lit(expr_lit) = nv.value {
                                 if let syn::Lit::Str(s) = expr_lit.lit {
                                     fmt = Some(s);

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -14,9 +14,10 @@ doctest = false
 test = true
 
 [features]
-default = ["sentry", "tracing-instrument"]
+default = ["sentry", "tracing-instrument", "macros"]
 sentry = ["sentry-core"]
 tracing-instrument = []
+macros = ["oxanus-macros"]
 
 [dependencies]
 async-trait = "0.1"
@@ -34,6 +35,8 @@ tokio = { version = "^1.46", features = ["full"] }
 tokio-util = { version = "^0.7" }
 tracing = { version = "^0.1", features = ["log"] }
 uuid = { version = "^1.17", features = ["serde", "v4"] }
+
+oxanus-macros = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan = "^0.1"

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -109,3 +109,6 @@ pub use crate::queue::{Queue, QueueConfig, QueueKind, QueueThrottle};
 pub use crate::storage::Storage;
 pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};
 pub use crate::worker::Worker;
+
+#[cfg(feature = "macros")]
+pub use oxanus_macros::Queue;

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -111,4 +111,4 @@ pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};
 pub use crate::worker::Worker;
 
 #[cfg(feature = "macros")]
-pub use oxanus_macros::Queue;
+pub use oxanus_macros::{Queue, Worker};

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -933,7 +933,7 @@ impl StorageInternal {
             }
 
             let scheduled_at = next.timestamp_micros();
-            let job_id = format!("{}-{}", job_name, scheduled_at);
+            let job_id = format!("{job_name}-{scheduled_at}");
             let envelope = JobEnvelope::new_cron(
                 cron_job.queue_key.clone(),
                 job_id,

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -59,9 +59,10 @@ mod tests {
 
         impl TestWorker {
             async fn process(&self, ctx: &Context<WorkerContext>) -> Result<(), WorkerError> {
-                *ctx.ctx.count.lock().map_err(|e| {
-                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-                })? += 1;
+                *ctx.ctx
+                    .count
+                    .lock()
+                    .map_err(|e| std::io::Error::other(e.to_string()))? += 1;
                 Ok(())
             }
         }

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -34,3 +34,181 @@ pub trait Worker: Send + Sync + UnwindSafe {
         JobConflictStrategy::Skip
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{JobConflictStrategy, Worker};
+    use crate::Context;
+    use crate::test_helper::create_worker_context;
+    use serde::Serialize;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct WorkerContext {
+        count: Arc<Mutex<usize>>,
+    }
+
+    #[cfg(feature = "macros")]
+    #[tokio::test]
+    async fn test_define_worker_with_macro() {
+        use crate as oxanus;
+        use std::io::Error as WorkerError;
+
+        #[derive(Serialize, oxanus::Worker)]
+        struct TestWorker {}
+
+        impl TestWorker {
+            async fn process(&self, ctx: &Context<WorkerContext>) -> Result<(), WorkerError> {
+                *ctx.ctx.count.lock().map_err(|e| {
+                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+                })? += 1;
+                Ok(())
+            }
+        }
+
+        assert_eq!(TestWorker {}.max_retries(), 2);
+        assert_eq!(TestWorker {}.on_conflict(), JobConflictStrategy::Skip);
+
+        let ctx = WorkerContext::default();
+        let context = create_worker_context(ctx.clone(), TestWorker {}).await;
+
+        Worker::process(&TestWorker {}, &context).await.unwrap();
+
+        assert_eq!(*ctx.count.lock().unwrap(), 1);
+
+        Worker::process(&TestWorker {}, &context).await.unwrap();
+
+        assert_eq!(*ctx.count.lock().unwrap(), 2);
+
+        #[derive(Serialize, oxanus::Worker)]
+        #[oxanus(error = std::fmt::Error)]
+        #[oxanus(max_retries = 3)]
+        #[oxanus(on_conflict = Replace)]
+        struct TestWorkerCustomError {}
+
+        impl TestWorkerCustomError {
+            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), std::fmt::Error> {
+                use std::fmt::Write;
+
+                let mut s = String::new();
+                write!(&mut s, "hi")
+            }
+        }
+
+        assert_eq!(TestWorkerCustomError {}.unique_id(), None);
+        assert_eq!(TestWorkerCustomError {}.max_retries(), 3);
+        assert_eq!(
+            TestWorkerCustomError {}.on_conflict(),
+            JobConflictStrategy::Replace
+        );
+
+        #[derive(Serialize, oxanus::Worker)]
+        #[oxanus(unique_id = "test_worker_{id}")]
+        struct TestWorkerUniqueId {
+            id: i32,
+        }
+
+        impl TestWorkerUniqueId {
+            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        assert_eq!(TestWorkerUniqueId { id: 1 }.max_retries(), 2);
+        assert_eq!(
+            TestWorkerUniqueId { id: 1 }.unique_id().unwrap(),
+            "test_worker_1"
+        );
+        assert_eq!(
+            TestWorkerUniqueId { id: 12 }.unique_id().unwrap(),
+            "test_worker_12"
+        );
+
+        #[derive(Serialize, oxanus::Worker)]
+        #[oxanus(unique_id(fmt = "test_worker_{id}_{task}", id = self.id, task = self.task.name))]
+        struct TestWorkerNestedUniqueId {
+            id: i32,
+            task: TestWorkerNestedTask,
+        }
+
+        #[derive(Serialize, Default)]
+        struct TestWorkerNestedTask {
+            name: String,
+        }
+
+        impl TestWorkerNestedUniqueId {
+            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        assert_eq!(
+            TestWorkerNestedUniqueId {
+                id: 1,
+                task: Default::default()
+            }
+            .max_retries(),
+            2
+        );
+        assert_eq!(
+            TestWorkerNestedUniqueId {
+                id: 1,
+                task: TestWorkerNestedTask {
+                    name: "task1".to_owned(),
+                }
+            }
+            .unique_id()
+            .unwrap(),
+            "test_worker_1_task1"
+        );
+        assert_eq!(
+            TestWorkerNestedUniqueId {
+                id: 2,
+                task: TestWorkerNestedTask {
+                    name: "task2".to_owned(),
+                }
+            }
+            .unique_id()
+            .unwrap(),
+            "test_worker_2_task2"
+        );
+
+        #[derive(Serialize, oxanus::Worker)]
+        #[oxanus(unique_id = Self::unique_id)]
+        struct TestWorkerCustomUniqueId {
+            id: i32,
+            task: TestWorkerNestedTask,
+        }
+
+        impl TestWorkerCustomUniqueId {
+            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+                Ok(())
+            }
+
+            fn unique_id(&self) -> String {
+                format!("worker_id_{}_task_{}", self.id, self.task.name)
+            }
+        }
+
+        assert_eq!(
+            Worker::unique_id(&TestWorkerCustomUniqueId {
+                id: 1,
+                task: TestWorkerNestedTask {
+                    name: "11".to_owned(),
+                }
+            })
+            .unwrap(),
+            "worker_id_1_task_11"
+        );
+        assert_eq!(
+            Worker::unique_id(&TestWorkerCustomUniqueId {
+                id: 2,
+                task: TestWorkerNestedTask {
+                    name: "22".to_owned(),
+                }
+            })
+            .unwrap(),
+            "worker_id_2_task_22"
+        );
+    }
+}

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -185,8 +185,8 @@ mod tests {
                 Ok(())
             }
 
-            fn unique_id(&self) -> String {
-                format!("worker_id_{}_task_{}", self.id, self.task.name)
+            fn unique_id(&self) -> Option<String> {
+                Some(format!("worker_id_{}_task_{}", self.id, self.task.name))
             }
         }
 

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -1,0 +1,31 @@
+use crate::shared::*;
+use deadpool_redis::redis::AsyncCommands;
+use testresult::TestResult;
+
+#[tokio::test]
+pub async fn test_cron() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let _: i64 = redis_conn.del("cron:counter").await?;
+
+    let ctx = oxanus::Context::value(WorkerState {
+        redis: redis_pool.clone(),
+    });
+
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxanus::Config::new(&storage)
+        .register_cron_worker::<CronWorkerRedisCounter>("* * * * * *", QueueOne)
+        .exit_when_processed(2);
+
+    oxanus::run(config, ctx).await?;
+
+    let value: Option<i64> = redis_conn.get("cron:counter").await?;
+
+    assert_eq!(value, Some(2));
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -24,8 +24,6 @@ pub async fn test_cron() -> TestResult {
     let value: Option<i64> = redis_conn.get("cron:counter").await?;
 
     assert_eq!(value, Some(2));
-    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
-    assert_eq!(storage.jobs_count().await?, 0);
 
     Ok(())
 }

--- a/oxanus/tests/integration/main.rs
+++ b/oxanus/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod cron;
 mod dead;
 mod drain;
 mod dynamic;

--- a/oxanus/tests/integration/shared.rs
+++ b/oxanus/tests/integration/shared.rs
@@ -52,6 +52,24 @@ impl oxanus::Worker for WorkerRedisSet {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CronWorkerRedisCounter {}
+
+#[async_trait::async_trait]
+impl oxanus::Worker for CronWorkerRedisCounter {
+    type Context = WorkerState;
+    type Error = WorkerError;
+
+    async fn process(
+        &self,
+        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
+    ) -> Result<(), WorkerError> {
+        let mut redis = ctx.redis.get().await?;
+        let _: () = redis.incr("cron:counter", 1).await?;
+        Ok(())
+    }
+}
+
 #[derive(Serialize)]
 pub struct QueueOne;
 


### PR DESCRIPTION
## Queue

Basic queue:

```rust
#[derive(Serialize, oxanus::Queue)]
struct DefaultQueue;

assert_eq!(DefaultQueue.key(), "default_queue");
```

With options:

```rust
#[derive(Serialize, oxanus::Queue)]
#[oxanus(key = "queue_with_throttle")]
#[oxanus(concurrency = 2)]
#[oxanus(throttle(window_ms = 3, limit = 4))]
struct QueueWithThrottle;

assert_eq!(QueueWithThrottle.key(), "queue_with_throttle");
assert_eq!(QueueWithThrottle.config().concurrency, 2);
assert_eq!(QueueWithThrottle.config().throttle.unwrap().window_ms, 3);
assert_eq!(QueueWithThrottle.config().throttle.unwrap().limit, 4);
```

Dynamic queue:

```rust
#[derive(Serialize, oxanus::Queue)]
#[oxanus(prefix = "dyn_queue", concurrency = 2)]
struct DynQueue {
    i: i32,
}

assert_eq!(DynQueue { i: 2 }.key(), "dyn_queue#i=2");
assert_eq!(DynQueue::to_config().concurrency, 2);
```

Using `key` on dynamic queue would result in compile error, and vice versa.

## Worker

Basic worker:

```rust
#[derive(Serialize, oxanus::Worker)]
struct TestWorker {}

impl TestWorker {
    async fn process(&self, ctx: &Context<WorkerContext>) -> Result<(), WorkerError> {
        Ok(())
    }
}
```

With options:

```rust
#[derive(Serialize, oxanus::Worker)]
#[oxanus(context = crate::WorkerContext, error = std::io::Error)]
#[oxanus(max_retries = 3, on_conflict = Replace)]
struct TestWorkerCustom {}

assert_eq!(TestWorkerCustom {}.max_retries(), 3);
assert_eq!(TestWorkerCustom {}.on_conflict(), JobConflictStrategy::Replace);
```

With unique_id:

```rust
#[derive(Serialize, oxanus::Worker)]
#[oxanus(unique_id = "test_worker_{id}")]
struct TestWorkerUniqueId {
    id: i32,
}

assert_eq!(
    TestWorkerUniqueId { id: 1 }.unique_id().unwrap(),
    "test_worker_1"
);
```