### PR TITLE
Change Cron worker API and update all examples

### DIFF
--- a/oxanus-macros/src/queue.rs
+++ b/oxanus-macros/src/queue.rs
@@ -80,8 +80,8 @@ pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
     quote! {
         #[automatically_derived]
         impl oxanus::Queue for #struct_ident {
-            fn to_config() -> QueueConfig {
-                QueueConfig::#kind(#key)
+            fn to_config() -> oxanus::QueueConfig {
+                oxanus::QueueConfig::#kind(#key)
                     #concurrency
                     #throttle
             }

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -60,8 +60,7 @@ impl FromMeta for RetryDelay {
                 }
                 Expr::Path(expr_path) => Ok(RetryDelay::CustomFunc(expr_path.path.clone())),
                 other => Err(Error::custom(format!(
-                    "unsupported retry_delay value: {:?}",
-                    other
+                    "Unsupported retry_delay value: {other:?}",
                 ))),
             },
             _ => Err(Error::custom("retry_delay must be a name-value attribute")),
@@ -112,14 +111,14 @@ impl FromMeta for UniqueIdSpec {
                             args.push((ident, nv.value));
                         }
 
-                        _ => return Err(Error::custom("unsupported unique_id syntax")),
+                        _ => return Err(Error::custom("Unsupported unique_id syntax")),
                     }
                 }
 
                 let fmt = fmt.ok_or_else(|| Error::custom("missing fmt = \"...\""))?;
                 Ok(UniqueIdSpec::NamedFormatter { fmt, args })
             }
-            _ => Err(Error::custom("invalid unique_id attribute")),
+            _ => Err(Error::custom("Invalid unique_id attribute")),
         }
     }
 }

--- a/oxanus/examples/cron.rs
+++ b/oxanus/examples/cron.rs
@@ -22,6 +22,10 @@ impl oxanus::Worker for TestWorker {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }
+
+    fn cron_schedule() -> Option<String> {
+        Some("*/5 * * * * *".to_string())
+    }
 }
 
 #[derive(Serialize)]
@@ -43,7 +47,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     let ctx = oxanus::Context::value(WorkerState {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<TestWorker>("*/5 * * * * *", QueueOne)
+        .register_cron_worker::<TestWorker>(QueueOne)
         .with_graceful_shutdown(tokio::signal::ctrl_c());
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -9,48 +9,26 @@ enum WorkerError {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-struct WorkerState {}
+struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(max_retries = 3, retry_delay = 0)]
+#[oxanus(cron(schedule = "*/10 * * * * *"))]
 struct TestWorker {}
 
-#[async_trait::async_trait]
-impl oxanus::Worker for TestWorker {
-    type Context = WorkerState;
-    type Error = WorkerError;
-
-    async fn process(
-        &self,
-        oxanus::Context { .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), WorkerError> {
+impl TestWorker {
+    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
         if rand::rng().random_bool(0.5) {
             Err(WorkerError::GenericError("foo".to_string()))
         } else {
             Ok(())
         }
     }
-
-    fn max_retries(&self) -> u32 {
-        3
-    }
-
-    fn retry_delay(&self, _retries: u32) -> u64 {
-        0
-    }
-
-    fn cron_schedule() -> Option<String> {
-        Some("*/10 * * * * *".to_string())
-    }
 }
 
-#[derive(Serialize)]
-struct QueueOne;
-
-impl oxanus::Queue for QueueOne {
-    fn to_config() -> oxanus::QueueConfig {
-        oxanus::QueueConfig::as_static("one")
-    }
-}
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(prefix = "two")]
+struct QueueDynamic(i32);
 
 #[tokio::main]
 pub async fn main() -> Result<(), oxanus::OxanusError> {
@@ -59,10 +37,10 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerState {});
+    let ctx = oxanus::Context::value(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<TestWorker>(QueueOne)
+        .register_cron_worker::<TestWorker>(QueueDynamic(2))
         .with_graceful_shutdown(tokio::signal::ctrl_c());
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -37,6 +37,10 @@ impl oxanus::Worker for TestWorker {
     fn retry_delay(&self, _retries: u32) -> u64 {
         0
     }
+
+    fn cron_schedule() -> Option<String> {
+        Some("*/10 * * * * *".to_string())
+    }
 }
 
 #[derive(Serialize)]
@@ -58,7 +62,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     let ctx = oxanus::Context::value(WorkerState {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<TestWorker>("*/10 * * * * *", QueueOne)
+        .register_cron_worker::<TestWorker>(QueueOne)
         .with_graceful_shutdown(tokio::signal::ctrl_c());
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/examples/dynamic.rs
+++ b/oxanus/examples/dynamic.rs
@@ -7,24 +7,19 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerState {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(context = WorkerState)]
 struct Worker2Sec {}
 
-#[async_trait::async_trait]
-impl oxanus::Worker for Worker2Sec {
-    type Context = WorkerState;
-    type Error = WorkerError;
-
-    async fn process(
-        &self,
-        oxanus::Context { .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), WorkerError> {
-        tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+impl Worker2Sec {
+    async fn process(&self, _: &oxanus::Context<WorkerState>) -> Result<(), WorkerError> {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(prefix = "two")]
 struct QueueDynamic(Animal, i32);
 
 #[derive(Debug, Serialize)]
@@ -32,12 +27,6 @@ enum Animal {
     Dog,
     Cat,
     Bird,
-}
-
-impl oxanus::Queue for QueueDynamic {
-    fn to_config() -> oxanus::QueueConfig {
-        oxanus::QueueConfig::as_dynamic("two")
-    }
 }
 
 #[tokio::main]

--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -57,12 +57,13 @@ impl<DT, ET> Config<DT, ET> {
         self
     }
 
-    pub fn register_cron_worker<T>(mut self, schedule: &str, queue: impl Queue) -> Self
+    pub fn register_cron_worker<W>(mut self, queue: impl Queue) -> Self
     where
-        T: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
+        W: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
     {
         self.queues.insert(queue.config());
-        self.registry.register_cron::<T>(schedule, queue.key());
+        let schedule = W::cron_schedule().expect("Cron Worker must have cron_schedule defined");
+        self.registry.register_cron::<W>(&schedule, queue.key());
         self
     }
 

--- a/oxanus/src/queue.rs
+++ b/oxanus/src/queue.rs
@@ -74,7 +74,7 @@ impl QueueConfig {
     pub fn static_key(&self) -> Option<String> {
         match &self.kind {
             QueueKind::Static { key } => Some(key.clone()),
-            _ => None,
+            QueueKind::Dynamic { .. } => None,
         }
     }
 }

--- a/oxanus/src/queue.rs
+++ b/oxanus/src/queue.rs
@@ -70,6 +70,13 @@ impl QueueConfig {
         self.throttle = Some(throttle);
         self
     }
+
+    pub fn static_key(&self) -> Option<String> {
+        match &self.kind {
+            QueueKind::Static { key } => Some(key.clone()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -33,6 +33,14 @@ pub trait Worker: Send + Sync + UnwindSafe {
     fn on_conflict(&self) -> JobConflictStrategy {
         JobConflictStrategy::Skip
     }
+
+    /// 6 part cron schedule: "* * * * * *"
+    fn cron_schedule() -> Option<String>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -1,5 +1,6 @@
 use crate::shared::*;
 use deadpool_redis::redis::AsyncCommands;
+use oxanus::{Queue, QueueConfig};
 use serde::{Deserialize, Serialize};
 use testresult::TestResult;
 
@@ -23,6 +24,10 @@ impl oxanus::Worker for CronWorkerRedisCounter {
     fn cron_schedule() -> Option<String> {
         Some("* * * * * *".to_string())
     }
+
+    fn cron_queue_config() -> Option<QueueConfig> {
+        Some(QueueOne::to_config())
+    }
 }
 
 #[tokio::test]
@@ -39,7 +44,7 @@ pub async fn test_cron() -> TestResult {
         .namespace(random_string())
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<CronWorkerRedisCounter>(QueueOne)
+        .register_worker::<CronWorkerRedisCounter>()
         .exit_when_processed(2);
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -1,6 +1,29 @@
 use crate::shared::*;
 use deadpool_redis::redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
 use testresult::TestResult;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CronWorkerRedisCounter {}
+
+#[async_trait::async_trait]
+impl oxanus::Worker for CronWorkerRedisCounter {
+    type Context = WorkerState;
+    type Error = WorkerError;
+
+    async fn process(
+        &self,
+        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
+    ) -> Result<(), WorkerError> {
+        let mut redis = ctx.redis.get().await?;
+        let _: () = redis.incr("cron:counter", 1).await?;
+        Ok(())
+    }
+
+    fn cron_schedule() -> Option<String> {
+        Some("* * * * * *".to_string())
+    }
+}
 
 #[tokio::test]
 pub async fn test_cron() -> TestResult {
@@ -16,7 +39,7 @@ pub async fn test_cron() -> TestResult {
         .namespace(random_string())
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<CronWorkerRedisCounter>("* * * * * *", QueueOne)
+        .register_cron_worker::<CronWorkerRedisCounter>(QueueOne)
         .exit_when_processed(2);
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/tests/integration/shared.rs
+++ b/oxanus/tests/integration/shared.rs
@@ -52,24 +52,6 @@ impl oxanus::Worker for WorkerRedisSet {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CronWorkerRedisCounter {}
-
-#[async_trait::async_trait]
-impl oxanus::Worker for CronWorkerRedisCounter {
-    type Context = WorkerState;
-    type Error = WorkerError;
-
-    async fn process(
-        &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
-        let _: () = redis.incr("cron:counter", 1).await?;
-        Ok(())
-    }
-}
-
 #[derive(Serialize)]
 pub struct QueueOne;
 


### PR DESCRIPTION
schedule is now part of Worker definition:

```rust
#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
#[oxanus(cron(schedule = "*/5 * * * * *", queue = QueueOne))]
struct TestWorker {}

impl TestWorker {
    async fn process(&self, _: &oxanus::Context<WorkerState>) -> Result<(), WorkerError> {
        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
        Ok(())
    }
}
```

it can be registered just like a normal worker:

```rust
let config = oxanus::Config::new(&storage).register_worker::<TestWorker>();
```

cron worker with dynamic queues is still supported with the old API:

```rust
#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
#[oxanus(max_retries = 3, retry_delay = 0)]
#[oxanus(cron(schedule = "*/10 * * * * *"))]
struct TestCronWorker {}

let config = oxanus::Config::new(&storage).register_cron_worker::<TestCronWorker>(QueueDynamic(2));
```