### PR TITLE
Queue and Worker Registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +755,8 @@ dependencies = [
  "dotenvy",
  "futures",
  "gethostname",
+ "inventory",
+ "oxanus",
  "oxanus-macros",
  "rand",
  "redis 1.0.2",

--- a/oxanus-macros/Cargo.toml
+++ b/oxanus-macros/Cargo.toml
@@ -17,3 +17,4 @@ syn = { version = "2", features = ["parsing", "proc-macro", "derive"] }
 
 [features]
 default = []
+registry = []

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -1,7 +1,9 @@
 mod queue;
+mod registry;
 mod worker;
 
 use queue::*;
+use registry::*;
 use worker::*;
 
 use proc_macro::TokenStream;
@@ -43,4 +45,13 @@ pub fn derive_worker(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     expand_derive_worker(input).into()
+}
+
+/// Helper to define a component registry.
+#[proc_macro_error]
+#[proc_macro_derive(Registry, attributes(oxanus))]
+pub fn derive_registry(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_registry(input).into()
 }

--- a/oxanus-macros/src/queue.rs
+++ b/oxanus-macros/src/queue.rs
@@ -83,7 +83,7 @@ pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
         None => quote!(ComponentRegistry),
     };
 
-    let registry = if cfg!(feature = "registry") {
+    let registry = if cfg!(feature = "registry") && component_registry.to_string() != "None" {
         quote! {
             oxanus::register_component! {
                 #component_registry(oxanus::ComponentRegistry {

--- a/oxanus-macros/src/registry.rs
+++ b/oxanus-macros/src/registry.rs
@@ -1,0 +1,52 @@
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, PathArguments, Type};
+
+pub fn expand_derive_registry(input: DeriveInput) -> TokenStream {
+    if !cfg!(feature = "registry") {
+        return quote!();
+    }
+
+    let inner_type = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => &fields.unnamed[0].ty,
+            _ => abort!(
+                input.ident,
+                "Expected a tuple struct with exactly one field",
+            ),
+        },
+        _ => abort!(input.ident, "Expected a struct",),
+    };
+
+    let type_path = match inner_type {
+        Type::Path(path) => path,
+        _ => abort!(input.ident, "Expected a struct with inner type",),
+    };
+
+    let generics = match type_path.path.segments.last() {
+        Some(segment) => match &segment.arguments {
+            PathArguments::AngleBracketed(args) => args,
+            _ => abort!(
+                inner_type,
+                "Expected generic arguments <WorkerContext, WorkerError>",
+            ),
+        },
+        _ => abort!(input.ident, "Expected a struct with inner type",),
+    };
+
+    let struct_ident = &input.ident;
+
+    quote! {
+        oxanus::create_component_registry!(#struct_ident);
+
+        impl #struct_ident {
+            pub fn build_config(storage: &oxanus::Storage) -> oxanus::Config::#generics {
+                oxanus::ComponentRegistry::#generics::build_config(
+                    &storage,
+                    oxanus::iterate_components::<#struct_ident>().map(|x| &x.0),
+                )
+            }
+        }
+    }
+}

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -11,6 +11,7 @@ use syn::{
 struct OxanusArgs {
     context: Option<Path>,
     error: Option<Path>,
+    registry: Option<Path>,
     max_retries: Option<u32>,
     retry_delay: Option<RetryDelay>,
     unique_id: Option<UniqueIdSpec>,
@@ -183,6 +184,31 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
         None => quote!(),
     };
 
+    let component_registry = match args.registry {
+        Some(registry) => quote!(#registry),
+        None => quote!(ComponentRegistry),
+    };
+
+    let registry = if cfg!(feature = "registry") {
+        quote! {
+            oxanus::register_component! {
+                #component_registry(oxanus::ComponentRegistry {
+                    module_path: module_path!(),
+                    type_name: stringify!(#struct_ident),
+                    definition: || {
+                        oxanus::ComponentDefinition::Worker(oxanus::WorkerConfig {
+                            name: std::any::type_name::<#struct_ident>().to_owned(),
+                            factory: oxanus::job_factory::<#struct_ident, #type_context, #type_error>,
+                            kind: <#struct_ident as oxanus::Worker>::to_config(),
+                        })
+                    }
+                })
+            }
+        }
+    } else {
+        quote!()
+    };
+
     quote! {
         #[automatically_derived]
         #[async_trait::async_trait]
@@ -204,6 +230,8 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
 
             #cron
         }
+
+        #registry
     }
 }
 

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -189,7 +189,7 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
         None => quote!(ComponentRegistry),
     };
 
-    let registry = if cfg!(feature = "registry") {
+    let registry = if cfg!(feature = "registry") && component_registry.to_string() != "None" {
         quote! {
             oxanus::register_component! {
                 #component_registry(oxanus::ComponentRegistry {

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -18,6 +18,7 @@ default = ["sentry", "tracing-instrument", "macros"]
 sentry = ["sentry-core"]
 tracing-instrument = []
 macros = ["oxanus-macros"]
+registry = ["inventory", "oxanus-macros?/registry"]
 
 [dependencies]
 async-trait = "0.1"
@@ -27,6 +28,7 @@ deadpool-redis = "^0.22"
 redis = { version = "^1.0", features = ["aio", "tokio-comp"] }
 futures = { version = "^0.3" }
 gethostname = "^1.0"
+inventory = { version = "0.3", optional = true }
 sentry-core = { version = "^0.46", optional = true }
 serde = { version = "^1.0.218", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
@@ -44,6 +46,8 @@ dotenvy = "^0.15"
 rand = "^0.9"
 testresult = "^0.4"
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
+
+oxanus = { path = ".", features = ["registry"] }
 
 [[bench]]
 name = "concurrency"

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -12,6 +12,7 @@ enum WorkerError {
 struct WorkerContext {}
 
 #[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(registry = None)]
 #[oxanus(max_retries = 3, retry_delay = 0)]
 #[oxanus(cron(schedule = "*/10 * * * * *"))]
 struct TestWorker {}
@@ -27,6 +28,7 @@ impl TestWorker {
 }
 
 #[derive(Serialize, oxanus::Queue)]
+#[oxanus(registry = None)]
 #[oxanus(prefix = "two")]
 struct QueueDynamic(i32);
 

--- a/oxanus/examples/foo.rs
+++ b/oxanus/examples/foo.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
 #[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
 struct Worker1Sec {
     id: usize,
@@ -80,15 +83,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
 
     let ctx = oxanus::Context::value(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
-    let config = oxanus::Config::new(&storage.clone())
-        .register_queue::<QueueOne>()
-        .register_queue::<QueueTwo>()
-        .register_queue::<QueueThrottled>()
-        .register_worker::<Worker1Sec>()
-        .register_worker::<Worker2Sec>()
-        .register_worker::<WorkerInstant>()
-        .register_worker::<WorkerInstant2>()
-        .exit_when_processed(12);
+    let config = ComponentRegistry::build_config(&storage).exit_when_processed(12);
 
     storage
         .enqueue(

--- a/oxanus/examples/minimal.rs
+++ b/oxanus/examples/minimal.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
 #[derive(Debug, thiserror::Error)]
 enum WorkerError {}
 
@@ -32,9 +35,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
 
     let ctx = oxanus::Context::value(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
-    let config = oxanus::Config::new(&storage)
-        .register_queue::<QueueOne>()
-        .register_worker::<TestWorker>()
+    let config = ComponentRegistry::build_config(&storage)
         .with_graceful_shutdown(tokio::signal::ctrl_c())
         .exit_when_processed(1);
 

--- a/oxanus/examples/unique.rs
+++ b/oxanus/examples/unique.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
 #[derive(Debug, thiserror::Error)]
 enum WorkerError {}
 
@@ -33,9 +36,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
 
     let ctx = oxanus::Context::value(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
-    let config = oxanus::Config::new(&storage)
-        .register_queue::<QueueOne>()
-        .register_worker::<Worker2Sec>();
+    let config = ComponentRegistry::build_config(&storage);
 
     storage.enqueue(QueueOne, Worker2Sec { id: 1 }).await?;
     storage.enqueue(QueueOne, Worker2Sec { id: 1 }).await?;

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -96,6 +96,9 @@ mod worker;
 mod worker_event;
 mod worker_registry;
 
+#[cfg(feature = "registry")]
+mod registry;
+
 #[cfg(test)]
 mod test_helper;
 
@@ -109,6 +112,10 @@ pub use crate::queue::{Queue, QueueConfig, QueueKind, QueueThrottle};
 pub use crate::storage::Storage;
 pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};
 pub use crate::worker::Worker;
+pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_factory};
+
+#[cfg(feature = "registry")]
+pub use registry::*;
 
 #[cfg(feature = "macros")]
-pub use oxanus_macros::{Queue, Worker};
+pub use oxanus_macros::{Queue, Registry, Worker};

--- a/oxanus/src/queue.rs
+++ b/oxanus/src/queue.rs
@@ -195,6 +195,10 @@ mod tests {
     fn test_define_queue_with_macro() {
         use crate as oxanus; // needed for unit test
 
+        #[derive(oxanus::Registry)]
+        #[allow(dead_code)]
+        struct ComponentRegistry(oxanus::ComponentRegistry<(), ()>);
+
         #[derive(Serialize, oxanus::Queue)]
         struct DefaultQueue;
 

--- a/oxanus/src/registry.rs
+++ b/oxanus/src/registry.rs
@@ -1,0 +1,48 @@
+use crate::{Config, QueueConfig, Storage, worker_registry::WorkerConfig};
+
+pub struct ComponentRegistry<DT, ET> {
+    /// `module_path!()`
+    pub module_path: &'static str,
+    /// `stringify!(MyStruct)`
+    pub type_name: &'static str,
+    pub definition: fn() -> ComponentDefinition<DT, ET>,
+}
+
+pub enum ComponentDefinition<DT, ET> {
+    Queue(QueueConfig),
+    Worker(WorkerConfig<DT, ET>),
+}
+
+/// Macro to create a component registry
+pub use inventory::collect as create_component_registry;
+
+/// Macro to register a Queue or Worker
+pub use inventory::submit as register_component;
+
+/// Helper type to iterate components
+pub use inventory::iter as iterate_components;
+
+impl<DT, ET> ComponentRegistry<DT, ET>
+where
+    DT: 'static,
+    ET: 'static,
+{
+    pub fn build_config(
+        storage: &Storage,
+        items: impl Iterator<Item = &'static Self>,
+    ) -> Config<DT, ET> {
+        let mut config = Config::new(storage);
+        for component in items {
+            tracing::info!(
+                "Registering {}::{}",
+                component.module_path,
+                component.type_name
+            );
+            match (component.definition)() {
+                ComponentDefinition::Queue(q) => config.register_queue_with(q),
+                ComponentDefinition::Worker(w) => config.register_worker_with(w),
+            }
+        }
+        config
+    }
+}

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -53,6 +53,7 @@ pub trait Worker: Send + Sync + UnwindSafe {
     where
         Self: Sized,
     {
+        #[allow(clippy::collapsible_if)] // requires 1.88
         if let (Some(schedule), Some(queue_config)) =
             (Self::cron_schedule(), Self::cron_queue_config())
         {

--- a/oxanus/tests/integration/main.rs
+++ b/oxanus/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod dead;
 mod drain;
 mod dynamic;
 mod panic;
+mod registry;
 mod retry;
 mod shared;
 mod standard;

--- a/oxanus/tests/integration/registry.rs
+++ b/oxanus/tests/integration/registry.rs
@@ -1,0 +1,73 @@
+use crate::shared::{WorkerError, WorkerState as WorkerContext, random_string, setup};
+use deadpool_redis::redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use testresult::TestResult;
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "two")]
+struct QueueTwo;
+
+#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
+pub struct WorkerCounter {
+    pub key: String,
+}
+
+impl WorkerCounter {
+    async fn process(&self, ctx: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+        let mut redis = ctx.ctx.redis.get().await?;
+        let _: () = redis.incr(&self.key, 1).await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(cron(schedule = "* * * * * *", queue = QueueTwo))]
+pub struct CronWorkerCounter {}
+
+impl CronWorkerCounter {
+    async fn process(&self, ctx: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+        let mut redis = ctx.ctx.redis.get().await?;
+        let _: () = redis.incr("test_worker:counter", 1).await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+pub async fn test_registry() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let _: i64 = redis_conn.del("test_worker:counter").await?;
+
+    let ctx = oxanus::Context::value(WorkerContext {
+        redis: redis_pool.clone(),
+    });
+
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+
+    let config = ComponentRegistry::build_config(&storage).exit_when_processed(2);
+
+    // no need to manually register, here we verify they were registered
+    assert!(config.has_registered_queue::<QueueTwo>());
+    assert!(config.has_registered_worker::<WorkerCounter>());
+    assert!(config.has_registered_worker::<CronWorkerCounter>());
+
+    let worker = WorkerCounter {
+        key: "test_worker:counter".to_owned(),
+    };
+
+    storage.enqueue(QueueTwo, worker).await?;
+
+    oxanus::run(config, ctx).await?;
+
+    let mut redis_conn = redis_pool.get().await?;
+    let value: Option<i64> = redis_conn.get("test_worker:counter").await?;
+
+    assert_eq!(value, Some(2));
+
+    Ok(())
+}


### PR DESCRIPTION
`ComponentRegistry` has to be in scope when Queue and Worker are derived, in which they will automatically be registered to it.

Then on runtime we can use `ComponentRegistry::build_config` to construct the config object.

This removes the need to manually register and thus wouldn't "forget" about them.

```log
INFO oxanus::registry: Registering foo::QueueThrottled
INFO oxanus::registry: Registering foo::QueueTwo
INFO oxanus::registry: Registering foo::QueueOne
INFO oxanus::registry: Registering foo::WorkerInstant2
INFO oxanus::registry: Registering foo::WorkerInstant
INFO oxanus::registry: Registering foo::Worker2Sec
INFO oxanus::registry: Registering foo::Worker1Sec
INFO oxanus::launcher: Starting worker (namespace: oxanus)
```