### PR TITLE
DX rework

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -219,24 +219,23 @@ impl IndexWorker {
 }
 
 #[derive(oxanus::BatchProcessor)]
-#[oxanus(batch_size = 10, batch_linger_ms = 500)]
-struct IndexBatch {
-    jobs: Vec<IndexJob>,   // Vec of job types, not workers
-}
+#[oxanus(args = IndexJob, batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatchProcessor;
 
-impl IndexBatch {
-    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
-        let ids: Vec<u64> = self.jobs.iter().map(|j| j.document_id).collect();
+impl IndexBatchProcessor {
+    async fn process_batch(&self, jobs: &[IndexJob], _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let ids: Vec<u64> = jobs.iter().map(|j| j.document_id).collect();
         Ok(())
     }
 }
 ```
 
 Key changes:
-- The `Vec` field holds **job** types, not worker types
-- The batch processor no longer derives `Serialize, Deserialize`
-- `process_batch` takes `&oxanus::JobContext` instead of `&oxanus::Context<T>`
-- A corresponding `Worker` derive is needed for the job's worker
+- The batch processor uses `#[oxanus(args = JobType)]` to specify the item type (like Worker)
+- `process_batch` now takes `jobs: &[JobType]` as its first argument and `&oxanus::JobContext` as the second
+- The batch processor no longer holds a `Vec` of items as a field -- items are passed to `process_batch`
+- Context injection works the same as Worker: add a field for the context if needed
+- A corresponding `Worker` derive is still needed for the job's worker
 
 ### 8. Update resumable jobs
 
@@ -306,8 +305,8 @@ struct WorkerContext { db: DatabasePool }
 - [ ] Move application context access from `ctx.value` to a field on the worker struct
 - [ ] Update `oxanus::Context::value(...)` to `oxanus::ContextValue::new(...)`
 - [ ] Update enqueue calls to pass job instances instead of worker instances
-- [ ] Update batch processor `Vec` fields from worker types to job types
-- [ ] Update `process_batch` signature to take `&oxanus::JobContext`
+- [ ] Add `#[oxanus(args = JobType)]` to batch processors and remove `Vec` field
+- [ ] Update `process_batch` signature to `(&self, jobs: &[JobType], ctx: &oxanus::JobContext)`
 - [ ] Remove unnecessary `Serialize, Deserialize` from `WorkerContext`
 
 ## Unchanged

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,324 @@
+# Migration Guide
+
+This guide covers migrating from the old API (where worker structs contained both job data and processing logic) to the new API (where jobs and workers are separate).
+
+## Overview of Changes
+
+The core change is **separating job data from worker logic**:
+
+| Concept | Old API | New API |
+|---------|---------|---------|
+| Job data | Fields on the worker struct | Separate `Job` struct |
+| Worker | `#[derive(Serialize, Deserialize, oxanus::Worker)]` on data struct | `#[derive(oxanus::Worker)]` with `#[oxanus(args = MyJob)]` |
+| Process signature | `process(&self, ctx: &oxanus::Context<T>)` | `process(&self, job: &MyJob, ctx: &oxanus::JobContext)` |
+| Context constructor | `oxanus::Context::value(ctx)` | `oxanus::ContextValue::new(ctx)` |
+| Enqueue | `storage.enqueue(Queue, worker_instance)` | `storage.enqueue(Queue, job_instance)` |
+
+## Step-by-Step Migration
+
+### 1. Split worker struct into Job + Worker
+
+**Before:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+impl SendEmail {
+    async fn process(&self, ctx: &oxanus::Context<MyCtx>) -> Result<(), MyError> {
+        send_email(&self.to, &self.subject).await
+    }
+}
+```
+
+**After:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct SendEmailJob {
+    to: String,
+    subject: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = SendEmailJob)]
+struct SendEmailWorker;
+
+impl SendEmailWorker {
+    async fn process(&self, job: &SendEmailJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        send_email(&job.to, &job.subject).await
+    }
+}
+```
+
+Key changes:
+- Job struct keeps `Serialize, Deserialize` but drops `oxanus::Worker`
+- Worker struct gets `#[derive(oxanus::Worker)]` and `#[oxanus(args = JobType)]`
+- Worker struct does **not** need `Serialize` or `Deserialize`
+- `process` now takes `job: &JobType` as the first argument and `ctx: &oxanus::JobContext` as the second
+- Job data accessed via `self.field` becomes `job.field`
+
+### 2. Update the process method signature
+
+**Before:**
+
+```rust
+async fn process(&self, ctx: &oxanus::Context<MyCtx>) -> Result<(), MyError> {
+    let app_ctx = &ctx.value;     // application context
+    let meta = &ctx.meta;         // job metadata
+    let state = &ctx.state;       // resumable state
+    let data = &self.some_field;  // job data from self
+    // ...
+}
+```
+
+**After:**
+
+```rust
+async fn process(&self, job: &MyJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+    let meta = &ctx.meta;         // job metadata (unchanged)
+    let state = &ctx.state;       // resumable state (unchanged)
+    let data = &job.some_field;   // job data now from `job` parameter
+    // application context lives on `self` if the worker has fields (see step 5)
+}
+```
+
+The new `JobContext` contains only `meta` and `state` -- no application context. Application context is now injected into the worker struct itself (see step 5).
+
+### 3. Update enqueue calls
+
+**Before:**
+
+```rust
+storage.enqueue(MyQueue, SendEmail { to: "a@b.com".into(), subject: "hi".into() }).await?;
+```
+
+**After:**
+
+```rust
+storage.enqueue(MyQueue, SendEmailJob { to: "a@b.com".into(), subject: "hi".into() }).await?;
+```
+
+You now pass the **job** instance, not the worker. The same applies to `enqueue_in` and `enqueue_at`.
+
+### 4. Update ContextValue construction
+
+**Before:**
+
+```rust
+let ctx = oxanus::Context::value(MyCtx { db: pool });
+```
+
+**After:**
+
+```rust
+let ctx = oxanus::ContextValue::new(MyCtx { db: pool });
+```
+
+### 5. Inject application context into workers (if needed)
+
+If your worker needs access to application context (database pools, config, etc.), add a field to the worker struct. The derive macro generates the necessary `FromContext` implementation.
+
+**Before:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+struct MyWorker { id: u64 }
+
+impl MyWorker {
+    async fn process(&self, ctx: &oxanus::Context<MyCtx>) -> Result<(), MyError> {
+        ctx.value.db.query(&self.id).await  // context accessed via ctx.value
+    }
+}
+```
+
+**After:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct MyJob { id: u64 }
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]
+struct MyWorker {
+    ctx: MyCtx,  // automatically populated from ContextValue
+}
+
+impl MyWorker {
+    async fn process(&self, job: &MyJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        self.ctx.db.query(&job.id).await  // context accessed via self
+    }
+}
+```
+
+Unit struct workers (no fields) don't need any context injection and work as-is:
+
+```rust
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]
+struct StatelessWorker;
+```
+
+### 6. Update worker attributes
+
+All `#[oxanus(...)]` attributes remain on the **worker** struct, with the addition of the required `args` attribute:
+
+```rust
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]                                           // NEW: required
+#[oxanus(max_retries = 5, retry_delay = 10)]                      // unchanged
+#[oxanus(unique_id = "sync:{user_id}", on_conflict = Skip)]       // unchanged (references job fields)
+#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]       // unchanged
+#[oxanus(resurrect = false)]                                      // unchanged
+#[oxanus(context = MyCtx)]                                        // unchanged
+#[oxanus(error = MyError, registry = MyRegistry)]                 // unchanged
+struct MyWorker;
+```
+
+Note: `unique_id` format placeholders like `{user_id}` reference fields on the **job** struct (the `args` type), not the worker.
+
+### 7. Update batch processors
+
+**Before:**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
+struct IndexWorker { document_id: u64 }
+
+#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[oxanus(batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatch {
+    workers: Vec<IndexWorker>,
+}
+
+impl IndexBatch {
+    async fn process_batch(&self, _ctx: &oxanus::Context<MyCtx>) -> Result<(), MyError> {
+        let ids: Vec<u64> = self.workers.iter().map(|w| w.document_id).collect();
+        Ok(())
+    }
+}
+```
+
+**After:**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IndexJob { document_id: u64 }
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = IndexJob)]
+struct IndexWorker;
+
+impl IndexWorker {
+    async fn process(&self, _job: &IndexJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        Ok(())
+    }
+}
+
+#[derive(oxanus::BatchProcessor)]
+#[oxanus(batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatch {
+    jobs: Vec<IndexJob>,   // Vec of job types, not workers
+}
+
+impl IndexBatch {
+    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let ids: Vec<u64> = self.jobs.iter().map(|j| j.document_id).collect();
+        Ok(())
+    }
+}
+```
+
+Key changes:
+- The `Vec` field holds **job** types, not worker types
+- The batch processor no longer derives `Serialize, Deserialize`
+- `process_batch` takes `&oxanus::JobContext` instead of `&oxanus::Context<T>`
+- A corresponding `Worker` derive is needed for the job's worker
+
+### 8. Update resumable jobs
+
+The state API itself is unchanged, only the access path differs.
+
+**Before:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(max_retries = 10, retry_delay = 3)]
+struct ImportWorker {}
+
+impl ImportWorker {
+    async fn process(&self, ctx: &oxanus::Context<MyCtx>) -> Result<(), MyError> {
+        let progress = ctx.state.get::<u64>().await?;
+        ctx.state.update(progress.unwrap_or(0) + 1).await?;
+        Ok(())
+    }
+}
+```
+
+**After:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct ImportJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = ImportJob)]
+#[oxanus(max_retries = 10, retry_delay = 3)]
+struct ImportWorker;
+
+impl ImportWorker {
+    async fn process(&self, _job: &ImportJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let progress = ctx.state.get::<u64>().await?;
+        ctx.state.update(progress.unwrap_or(0) + 1).await?;
+        Ok(())
+    }
+}
+```
+
+### 9. WorkerContext no longer needs Serialize/Deserialize
+
+In the old API, `WorkerContext` often derived `Serialize` and `Deserialize`. This is no longer required:
+
+**Before:**
+
+```rust
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct WorkerContext { db: DatabasePool }
+```
+
+**After:**
+
+```rust
+#[derive(Debug, Clone)]
+struct WorkerContext { db: DatabasePool }
+```
+
+## Quick Reference Checklist
+
+- [ ] Split each `#[derive(oxanus::Worker)]` struct into a Job (data) + Worker (logic)
+- [ ] Add `#[oxanus(args = JobType)]` to every worker
+- [ ] Remove `Serialize, Deserialize` from worker structs
+- [ ] Update `process` signatures: add `job: &JobType` parameter, change `ctx` to `&oxanus::JobContext`
+- [ ] Replace `self.field` with `job.field` for job data access inside `process`
+- [ ] Move application context access from `ctx.value` to a field on the worker struct
+- [ ] Update `oxanus::Context::value(...)` to `oxanus::ContextValue::new(...)`
+- [ ] Update enqueue calls to pass job instances instead of worker instances
+- [ ] Update batch processor `Vec` fields from worker types to job types
+- [ ] Update `process_batch` signature to take `&oxanus::JobContext`
+- [ ] Remove unnecessary `Serialize, Deserialize` from `WorkerContext`
+
+## Unchanged
+
+The following remain the same:
+
+- Queue definitions (`#[derive(oxanus::Queue)]` and all queue attributes)
+- Registry definitions (`#[derive(oxanus::Registry)]`)
+- `Storage` builder and all storage methods
+- `oxanus::run(config, ctx)` call
+- `ComponentRegistry::build_config(&storage)` and config builder methods
+- Cron schedule syntax and queue attribute
+- Throttling configuration
+- Dynamic queue usage

--- a/README.v2.md
+++ b/README.v2.md
@@ -371,22 +371,36 @@ struct IndexJob {
     document_id: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[derive(oxanus::Worker)]
 #[oxanus(args = IndexJob)]
 struct IndexWorker;
 
-#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
-#[oxanus(batch_size = 10, batch_linger_ms = 500)]
-struct IndexBatchProcessor {
-    jobs: Vec<IndexJob>,
+impl IndexWorker {
+    async fn process(&self, _job: &IndexJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        Ok(())
+    }
 }
 
+#[derive(oxanus::BatchProcessor)]
+#[oxanus(args = IndexJob, batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatchProcessor;
+
 impl IndexBatchProcessor {
-    async fn process_batch(&self, ctx: &oxanus::JobContext) -> Result<(), MyError> {
-        let ids: Vec<u64> = self.jobs.iter().map(|j| j.document_id).collect();
+    async fn process_batch(&self, jobs: &[IndexJob], ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let ids: Vec<u64> = jobs.iter().map(|j| j.document_id).collect();
         // Bulk index all documents at once
         Ok(())
     }
+}
+```
+
+Batch processors support context injection just like workers:
+
+```rust
+#[derive(oxanus::BatchProcessor)]
+#[oxanus(args = IndexJob, batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatchProcessor {
+    ctx: MyContext, // auto-populated from ContextValue
 }
 ```
 

--- a/README.v2.md
+++ b/README.v2.md
@@ -1,0 +1,401 @@
+# Oxanus
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pragmaplatform/oxanus/test.yml?branch=main)](https://github.com/pragmaplatform/oxanus/actions)
+[![Latest Version](https://img.shields.io/crates/v/oxanus.svg)](https://crates.io/crates/oxanus)
+[![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=oxanus&color=blue&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K)](https://docs.rs/oxanus/latest)
+
+
+<p align="center">
+  <picture>
+    <img alt="Oxanus logo" src="https://raw.githubusercontent.com/pragmaplatform/oxanus/refs/heads/main/logo.jpg" width="320">
+  </picture>
+</p>
+
+Oxanus is job processing library written in Rust doesn't suck (or at least sucks in a completely different way than other options).
+
+Oxanus goes for simplicity and depth over breadth. It only aims to support a single backend with a simple flow.
+
+## Key Features
+
+- **Isolated Queues**: Separate job processing queues with independent configurations
+- **Retrying**: Automatic retry of failed jobs with configurable backoff
+- **Scheduled Jobs**: Schedule jobs to run at specific times or after delays
+- **Dynamic Queues**: Create and manage queues at runtime
+- **Throttling**: Control job processing rates with queue-based throttling
+- **Unique Jobs**: Ensure only one instance of a job runs at a time
+- **Resilient Jobs**: Jobs that can survive worker crashes and restarts
+- **Graceful Shutdown**: Clean shutdown of workers with in-progress job handling
+- **Periodic Jobs**: Run jobs on a schedule using cron-like expressions
+- **Resumable Jobs**: Jobs that can be resumed from where they left off when they are retried
+- **Batch Processing**: Group multiple jobs together for efficient batch execution
+
+## Quick Start
+
+```rust
+use oxanus::Storage;
+use serde::{Serialize, Deserialize};
+
+// Define your component registry
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<MyContext, MyError>);
+
+// Define your error type
+#[derive(Debug, thiserror::Error)]
+enum MyError {}
+
+// Define your application context
+#[derive(Debug, Clone)]
+struct MyContext {}
+
+// Define your job -- a plain serializable data struct
+#[derive(Debug, Serialize, Deserialize)]
+struct MyJob {
+    data: String,
+}
+
+// Define your worker -- the processor for your job
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]
+struct MyWorker;
+
+impl MyWorker {
+    async fn process(&self, job: &MyJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        println!("Processing: {}", job.data);
+        Ok(())
+    }
+}
+
+// Define your queue using the derive macro
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "my_queue", concurrency = 2)]
+struct MyQueue;
+
+// Run your worker
+#[tokio::main]
+async fn main() -> Result<(), oxanus::OxanusError> {
+    let ctx = oxanus::ContextValue::new(MyContext {});
+    let storage = Storage::builder().build_from_env()?;
+    let config = ComponentRegistry::build_config(&storage)
+        .with_graceful_shutdown(tokio::signal::ctrl_c());
+
+    // Enqueue some jobs
+    storage.enqueue(MyQueue, MyJob { data: "hello".into() }).await?;
+
+    // Run the worker
+    oxanus::run(config, ctx).await?;
+    Ok(())
+}
+```
+
+For more detailed usage examples, check out the [examples directory](https://github.com/pragmaplatform/oxanus/tree/main/oxanus/examples).
+
+
+## Core Concepts
+
+### Jobs and Workers
+
+Oxanus separates **jobs** (data) from **workers** (processors):
+
+- A **Job** is a plain serializable struct representing the work to be done. It carries the data needed for processing.
+- A **Worker** is a struct that processes jobs. It holds application-level dependencies (database connections, API clients, configuration) and defines the processing logic.
+
+```rust
+// Job -- just data
+#[derive(Debug, Serialize, Deserialize)]
+struct SendEmailJob {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+// Worker -- the processor
+#[derive(oxanus::Worker)]
+#[oxanus(args = SendEmailJob)]
+struct SendEmailWorker;
+
+impl SendEmailWorker {
+    async fn process(&self, job: &SendEmailJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        // Send the email using job.to, job.subject, job.body
+        Ok(())
+    }
+}
+```
+
+Workers can also hold application context for accessing shared resources:
+
+```rust
+#[derive(oxanus::Worker)]
+#[oxanus(args = SendEmailJob)]
+struct SendEmailWorker {
+    ctx: MyContext, // application context is injected automatically
+}
+
+impl SendEmailWorker {
+    async fn process(&self, job: &SendEmailJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        // Access self.ctx for database connections, etc.
+        // Access job for the job-specific data
+        // Access ctx.meta for job metadata (retries, timestamps, etc.)
+        // Access ctx.state for resumable job state
+        Ok(())
+    }
+}
+```
+
+Worker attributes:
+- `#[oxanus(args = MyJob)]` - Specify the job type this worker processes (required)
+- `#[oxanus(max_retries = 3)]` - Set maximum retry attempts
+- `#[oxanus(retry_delay = 5)]` - Set retry delay in seconds
+- `#[oxanus(unique_id = "email_{to}")]` - Define unique job identifiers (references job struct fields)
+- `#[oxanus(on_conflict = Skip)]` - Handle job conflicts (Skip or Replace)
+- `#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - Schedule periodic jobs
+- `#[oxanus(resurrect = false)]` - Disable job resurrection after crashes
+
+### Queues
+
+Queues are the channels through which jobs flow. They can be defined using the `#[derive(oxanus::Queue)]` macro or by implementing the [`Queue`] trait manually.
+
+Queues can be:
+
+- **Static**: Defined at compile time with a fixed key
+- **Dynamic**: Created at runtime with each instance being a separate queue (requires struct fields)
+
+```rust
+// Static queue
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "emails", concurrency = 5)]
+struct EmailQueue;
+
+// Dynamic queue -- each (region, priority) combination is a separate queue
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(prefix = "orders")]
+struct OrderQueue(Region, u32);
+```
+
+Queue attributes:
+- `#[oxanus(key = "my_queue")]` - Set static queue key
+- `#[oxanus(prefix = "dynamic")]` - Set prefix for dynamic queues
+- `#[oxanus(concurrency = 2)]` - Set concurrency limit
+- `#[oxanus(throttle(window_ms = 2000, limit = 5))]` - Configure throttling
+
+### Component Registry
+
+The component registry automatically discovers and registers all workers and queues in your application. Use `#[derive(oxanus::Registry)]` to create a registry and `ComponentRegistry::build_config()` to build the configuration.
+
+```rust
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<MyContext, MyError>);
+
+let config = ComponentRegistry::build_config(&storage);
+```
+
+### Storage
+
+[`Storage`] provides the interface for job persistence. It handles:
+
+- Job enqueueing
+- Job scheduling
+- Job state management
+- Queue monitoring
+
+Storage is built using `Storage::builder().build_from_env()` which reads the `REDIS_URL` environment variable.
+
+```rust
+let storage = oxanus::Storage::builder().build_from_env()?;
+
+// Enqueue a job for immediate processing
+storage.enqueue(MyQueue, MyJob { data: "hello".into() }).await?;
+
+// Schedule a job to run in 5 minutes
+storage.enqueue_in(MyQueue, MyJob { data: "delayed".into() }, 300).await?;
+
+// Schedule a job for a specific time
+storage.enqueue_at(MyQueue, MyJob { data: "scheduled".into() }, target_time).await?;
+```
+
+### JobContext
+
+The `JobContext` is available in every worker's `process` method. It provides:
+
+- `ctx.meta` -- Job metadata (id, retries, timestamps, latency)
+- `ctx.state` -- Resumable job state (read and update persistent state across retries)
+
+```rust
+impl MyWorker {
+    async fn process(&self, job: &MyJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        println!("Job ID: {}", ctx.meta.id);
+        println!("Retry #{}", ctx.meta.retries);
+        println!("Latency: {}ms", ctx.meta.latency_millis());
+
+        // Resumable state
+        let progress: Option<u32> = ctx.state.get().await?;
+        ctx.state.update(progress.unwrap_or(0) + 1).await?;
+
+        Ok(())
+    }
+}
+```
+
+### Application Context (ContextValue)
+
+Application-level dependencies are passed via `ContextValue` and automatically injected into workers that have fields:
+
+```rust
+#[derive(Debug, Clone)]
+struct MyContext {
+    db: DatabasePool,
+    config: AppConfig,
+}
+
+let ctx = oxanus::ContextValue::new(MyContext {
+    db: create_pool().await?,
+    config: load_config()?,
+});
+
+oxanus::run(config, ctx).await?;
+```
+
+Workers with a single field receive the context automatically:
+
+```rust
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]
+struct MyWorker {
+    ctx: MyContext, // auto-populated from ContextValue
+}
+```
+
+Workers without fields (unit structs) don't need any context:
+
+```rust
+#[derive(oxanus::Worker)]
+#[oxanus(args = MyJob)]
+struct StatelessWorker;
+```
+
+### Configuration
+
+Configuration is done through the [`Config`] builder, which allows you to:
+
+- Automatically register queues and workers via the component registry
+- Set up graceful shutdown
+- Configure exit conditions
+
+```rust
+let config = ComponentRegistry::build_config(&storage)
+    .with_graceful_shutdown(tokio::signal::ctrl_c())
+    .exit_when_processed(100);
+```
+
+### Error Handling
+
+Oxanus uses a custom error type [`OxanusError`] that covers all possible error cases in the library.
+Workers can define their own error type that implements `std::error::Error`.
+
+```rust
+#[derive(Debug, thiserror::Error)]
+enum MyError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("Validation error: {0}")]
+    Validation(String),
+}
+```
+
+### Unique Jobs
+
+Ensure only one instance of a job runs at a time by defining a unique identifier:
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct DeduplicatedJob {
+    user_id: u64,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = DeduplicatedJob)]
+#[oxanus(unique_id = "sync_user:{user_id}", on_conflict = Skip)]
+struct SyncUserWorker;
+```
+
+The `unique_id` format string references fields from the **job** struct. When a job with the same unique ID is already enqueued, the conflict strategy determines the behavior:
+- `Skip` -- discard the new job
+- `Replace` -- replace the existing job with the new one
+
+### Cron / Periodic Jobs
+
+Schedule workers to run periodically using 6-part cron expressions:
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct CleanupJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = CleanupJob)]
+#[oxanus(cron(schedule = "0 */5 * * * *", queue = MaintenanceQueue))]
+struct CleanupWorker;
+```
+
+### Resumable Jobs
+
+Jobs can persist state across retries, allowing them to resume from where they left off:
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+struct ImportJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = ImportJob, max_retries = 10, retry_delay = 3)]
+struct ImportWorker;
+
+impl ImportWorker {
+    async fn process(&self, _job: &ImportJob, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let offset: Option<u64> = ctx.state.get().await?;
+        let start = offset.unwrap_or(0);
+
+        for i in start..1000 {
+            // Process item i...
+            ctx.state.update(i + 1).await?;
+        }
+
+        Ok(())
+    }
+}
+```
+
+### Batch Processing
+
+Group multiple jobs together for efficient batch execution:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IndexJob {
+    document_id: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(args = IndexJob)]
+struct IndexWorker;
+
+#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[oxanus(batch_size = 10, batch_linger_ms = 500)]
+struct IndexBatchProcessor {
+    jobs: Vec<IndexJob>,
+}
+
+impl IndexBatchProcessor {
+    async fn process_batch(&self, ctx: &oxanus::JobContext) -> Result<(), MyError> {
+        let ids: Vec<u64> = self.jobs.iter().map(|j| j.document_id).collect();
+        // Bulk index all documents at once
+        Ok(())
+    }
+}
+```
+
+### Prometheus Metrics
+
+Enable the `prometheus` feature to expose metrics:
+
+```rust
+let metrics = storage.metrics().await?;
+let output = metrics.encode_to_string()?;
+// Serve `output` on your metrics endpoint
+```

--- a/oxanus-macros/src/batch_processor.rs
+++ b/oxanus-macros/src/batch_processor.rs
@@ -2,30 +2,17 @@ use darling::FromDeriveInput;
 use proc_macro_error2::abort;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, GenericArgument, Path, PathArguments, Type};
+use syn::{Data, DeriveInput, Fields, Path};
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(attributes(oxanus), supports(struct_named))]
+#[darling(attributes(oxanus), supports(struct_any))]
 struct BatchProcessorArgs {
+    args: Option<Path>,
     context: Option<Path>,
     error: Option<Path>,
     registry: Option<Path>,
     batch_size: usize,
     batch_linger_ms: u64,
-}
-
-fn extract_vec_field(fields: &Fields) -> Option<(syn::Ident, syn::Type)> {
-    for field in fields.iter() {
-        if let Type::Path(type_path) = &field.ty
-            && let Some(segment) = type_path.path.segments.last()
-            && segment.ident == "Vec"
-            && let PathArguments::AngleBracketed(args) = &segment.arguments
-            && let Some(GenericArgument::Type(inner_ty)) = args.args.first()
-        {
-            return Some((field.ident.clone()?, inner_ty.clone()));
-        }
-    }
-    None
 }
 
 pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
@@ -40,35 +27,128 @@ pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
     let batch_size = args.batch_size;
     let batch_linger_ms = args.batch_linger_ms;
 
-    let type_context = match args.context {
+    let item_type = match &args.args {
+        Some(path) => quote!(#path),
+        None => abort!(
+            input.ident,
+            "BatchProcessor must have #[oxanus(args = MyJob)] attribute specifying the item type"
+        ),
+    };
+
+    let type_context = match &args.context {
         Some(context) => quote!(#context),
         None => quote!(WorkerContext),
     };
 
-    let type_error = match args.error {
+    let type_error = match &args.error {
         Some(error) => quote!(#error),
         None => quote!(WorkerError),
     };
 
+    let batch_impl = expand_batch_impl(struct_ident, &item_type, &type_error, batch_size, batch_linger_ms);
+    let from_context_impl = expand_from_context_impl(struct_ident, &type_context, &input);
+    let registry_impl = expand_registry(struct_ident, &item_type, &type_context, &type_error, &args, batch_size, batch_linger_ms);
+
+    quote! {
+        #batch_impl
+        #from_context_impl
+        #registry_impl
+    }
+}
+
+fn expand_batch_impl(
+    struct_ident: &syn::Ident,
+    item_type: &TokenStream,
+    type_error: &TokenStream,
+    batch_size: usize,
+    batch_linger_ms: u64,
+) -> TokenStream {
+    quote! {
+        #[automatically_derived]
+        #[async_trait::async_trait]
+        impl oxanus::BatchProcessor for #struct_ident {
+            type Item = #item_type;
+            type Error = #type_error;
+
+            async fn process_batch(
+                &self,
+                items: &[Self::Item],
+                ctx: &oxanus::JobContext,
+            ) -> Result<(), Self::Error> {
+                self.process_batch(items, ctx).await
+            }
+
+            fn batch_size() -> usize {
+                #batch_size
+            }
+
+            fn batch_linger_ms() -> u64 {
+                #batch_linger_ms
+            }
+        }
+    }
+}
+
+fn expand_from_context_impl(
+    struct_ident: &syn::Ident,
+    type_context: &TokenStream,
+    input: &DeriveInput,
+) -> TokenStream {
     let fields = match &input.data {
         Data::Struct(data_struct) => &data_struct.fields,
         _ => abort!(input.ident, "BatchProcessor must be a struct."),
     };
 
-    let (field_name, item_type) = match extract_vec_field(fields) {
-        Some(v) => v,
-        None => abort!(
-            input.ident,
-            "BatchProcessor must have a Vec<T> field for batch items."
-        ),
+    let constructor = match fields {
+        Fields::Unit => quote!(Self),
+        Fields::Named(named) if named.named.is_empty() => quote!(Self {}),
+        Fields::Named(named) if named.named.len() == 1 => {
+            let field = named.named.first().expect("checked len == 1");
+            let field_name = field.ident.as_ref().expect("named field has ident");
+            quote!(Self { #field_name: ctx.clone() })
+        }
+        Fields::Named(named) => {
+            abort!(
+                input.ident,
+                "BatchProcessor structs with {} fields cannot auto-derive FromContext. \
+                 Implement oxanus::FromContext<{}> manually.",
+                named.named.len(),
+                type_context
+            );
+        }
+        Fields::Unnamed(_) => {
+            abort!(
+                input.ident,
+                "Tuple batch processor structs are not supported. Use named fields or a unit struct."
+            );
+        }
     };
 
-    let component_registry = match args.registry {
+    quote! {
+        #[automatically_derived]
+        impl oxanus::FromContext<#type_context> for #struct_ident {
+            fn from_context(ctx: &#type_context) -> Self {
+                #constructor
+            }
+        }
+    }
+}
+
+fn expand_registry(
+    struct_ident: &syn::Ident,
+    item_type: &TokenStream,
+    type_context: &TokenStream,
+    type_error: &TokenStream,
+    args: &BatchProcessorArgs,
+    batch_size: usize,
+    batch_linger_ms: u64,
+) -> TokenStream {
+    let component_registry = match &args.registry {
         Some(registry) => quote!(#registry),
         None => quote!(ComponentRegistry),
     };
 
-    let registry = if cfg!(feature = "registry") && component_registry.to_string() != "None" {
+    if cfg!(feature = "registry") && component_registry.to_string() != "None" {
         quote! {
             oxanus::register_component! {
                 #component_registry(oxanus::ComponentRegistry {
@@ -87,48 +167,5 @@ pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
         }
     } else {
         quote!()
-    };
-
-    quote! {
-        #[automatically_derived]
-        #[async_trait::async_trait]
-        impl oxanus::Processable for #struct_ident {
-            type Error = #type_error;
-
-            async fn process(&self, ctx: &oxanus::JobContext) -> Result<(), Self::Error> {
-                self.process_batch(ctx).await
-            }
-
-            fn max_retries(&self) -> u32 {
-                2
-            }
-
-            fn retry_delay(&self, retries: u32) -> u64 {
-                u64::pow(5, retries + 2)
-            }
-        }
-
-        #[automatically_derived]
-        impl oxanus::BatchProcessor for #struct_ident {
-            type Item = #item_type;
-
-            fn from_args(args: Vec<serde_json::Value>) -> Result<Self, oxanus::OxanusError> {
-                let items: Vec<#item_type> = args
-                    .into_iter()
-                    .map(|a| serde_json::from_value(a))
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(Self { #field_name: items })
-            }
-
-            fn batch_size() -> usize {
-                #batch_size
-            }
-
-            fn batch_linger_ms() -> u64 {
-                #batch_linger_ms
-            }
-        }
-
-        #registry
     }
 }

--- a/oxanus-macros/src/batch_processor.rs
+++ b/oxanus-macros/src/batch_processor.rs
@@ -1,0 +1,133 @@
+use darling::FromDeriveInput;
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, GenericArgument, Path, PathArguments, Type};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(oxanus), supports(struct_named))]
+struct BatchProcessorArgs {
+    context: Option<Path>,
+    error: Option<Path>,
+    registry: Option<Path>,
+    batch_size: usize,
+    batch_linger_ms: u64,
+}
+
+fn extract_vec_field(fields: &Fields) -> Option<(syn::Ident, syn::Type)> {
+    for field in fields.iter() {
+        if let Type::Path(type_path) = &field.ty
+            && let Some(segment) = type_path.path.segments.last()
+            && segment.ident == "Vec"
+            && let PathArguments::AngleBracketed(args) = &segment.arguments
+            && let Some(GenericArgument::Type(inner_ty)) = args.args.first()
+        {
+            return Some((field.ident.clone()?, inner_ty.clone()));
+        }
+    }
+    None
+}
+
+pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
+    let args = match BatchProcessorArgs::from_derive_input(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            abort!(input.ident, "{}", e);
+        }
+    };
+
+    let struct_ident = &input.ident;
+    let batch_size = args.batch_size;
+    let batch_linger_ms = args.batch_linger_ms;
+
+    let type_context = match args.context {
+        Some(context) => quote!(#context),
+        None => quote!(WorkerContext),
+    };
+
+    let type_error = match args.error {
+        Some(error) => quote!(#error),
+        None => quote!(WorkerError),
+    };
+
+    let fields = match &input.data {
+        Data::Struct(data_struct) => &data_struct.fields,
+        _ => abort!(input.ident, "BatchProcessor must be a struct."),
+    };
+
+    let (field_name, item_type) = match extract_vec_field(fields) {
+        Some(v) => v,
+        None => abort!(
+            input.ident,
+            "BatchProcessor must have a Vec<T> field for batch items."
+        ),
+    };
+
+    let component_registry = match args.registry {
+        Some(registry) => quote!(#registry),
+        None => quote!(ComponentRegistry),
+    };
+
+    let registry = if cfg!(feature = "registry") && component_registry.to_string() != "None" {
+        quote! {
+            oxanus::register_component! {
+                #component_registry(oxanus::ComponentRegistry {
+                    module_path: module_path!(),
+                    type_name: stringify!(#struct_ident),
+                    definition: || {
+                        oxanus::ComponentDefinition::BatchProcessor(oxanus::BatchProcessorConfig {
+                            worker_name: std::any::type_name::<#item_type>().to_owned(),
+                            batch_size: #batch_size,
+                            batch_linger_ms: #batch_linger_ms,
+                            factory: oxanus::batch_factory::<#struct_ident, #type_context, #type_error>,
+                        })
+                    }
+                })
+            }
+        }
+    } else {
+        quote!()
+    };
+
+    quote! {
+        #[automatically_derived]
+        #[async_trait::async_trait]
+        impl oxanus::Worker for #struct_ident {
+            type Context = #type_context;
+            type Error = #type_error;
+
+            async fn process(&self, data: &oxanus::Context<Self::Context>) -> Result<(), Self::Error> {
+                self.process_batch(data).await
+            }
+        }
+
+        #[automatically_derived]
+        impl oxanus::BatchProcessor for #struct_ident {
+            type Item = #item_type;
+
+            fn from_args(args: Vec<serde_json::Value>) -> Result<Self, oxanus::OxanusError> {
+                let items: Vec<#item_type> = args
+                    .into_iter()
+                    .map(|a| serde_json::from_value(a))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self { #field_name: items })
+            }
+
+            fn batch_size() -> usize {
+                #batch_size
+            }
+
+            fn batch_linger_ms() -> u64 {
+                #batch_linger_ms
+            }
+        }
+
+        impl #item_type {
+            async fn process(&self, data: &oxanus::Context<#type_context>) -> Result<(), #type_error> {
+                #struct_ident { #field_name: vec![self.clone()] }.process_batch(data).await
+            }
+        }
+
+        #registry
+    }
+}

--- a/oxanus-macros/src/batch_processor.rs
+++ b/oxanus-macros/src/batch_processor.rs
@@ -76,7 +76,7 @@ pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
                     type_name: stringify!(#struct_ident),
                     definition: || {
                         oxanus::ComponentDefinition::BatchProcessor(oxanus::BatchProcessorConfig {
-                            worker_name: std::any::type_name::<#item_type>().to_owned(),
+                            worker_name: <#item_type as oxanus::Job>::worker_name().to_owned(),
                             batch_size: #batch_size,
                             batch_linger_ms: #batch_linger_ms,
                             factory: oxanus::batch_factory::<#struct_ident, #type_context, #type_error>,
@@ -92,12 +92,19 @@ pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
     quote! {
         #[automatically_derived]
         #[async_trait::async_trait]
-        impl oxanus::Worker for #struct_ident {
-            type Context = #type_context;
+        impl oxanus::Processable for #struct_ident {
             type Error = #type_error;
 
-            async fn process(&self, data: &oxanus::Context<Self::Context>) -> Result<(), Self::Error> {
-                self.process_batch(data).await
+            async fn process(&self, ctx: &oxanus::JobContext) -> Result<(), Self::Error> {
+                self.process_batch(ctx).await
+            }
+
+            fn max_retries(&self) -> u32 {
+                2
+            }
+
+            fn retry_delay(&self, retries: u32) -> u64 {
+                u64::pow(5, retries + 2)
             }
         }
 
@@ -119,12 +126,6 @@ pub fn expand_derive_batch_processor(input: DeriveInput) -> TokenStream {
 
             fn batch_linger_ms() -> u64 {
                 #batch_linger_ms
-            }
-        }
-
-        impl #item_type {
-            async fn process(&self, data: &oxanus::Context<#type_context>) -> Result<(), #type_error> {
-                #struct_ident { #field_name: vec![self.clone()] }.process_batch(data).await
             }
         }
 

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -1,7 +1,9 @@
+mod batch_processor;
 mod queue;
 mod registry;
 mod worker;
 
+use batch_processor::*;
 use queue::*;
 use registry::*;
 use worker::*;
@@ -54,4 +56,22 @@ pub fn derive_registry(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     expand_derive_registry(input).into()
+}
+
+/// Generates impl for `oxanus::BatchProcessor` and `oxanus::Worker`.
+///
+/// Example usage:
+/// ```ignore
+/// #[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+/// #[oxanus(batch_size = 3, batch_linger_ms = 1000)]
+/// struct TestBatchProcessor {
+///     workers: Vec<TestWorker>,
+/// }
+/// ```
+#[proc_macro_error]
+#[proc_macro_derive(BatchProcessor, attributes(oxanus))]
+pub fn derive_batch_processor(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_batch_processor(input).into()
 }

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -30,15 +30,23 @@ pub fn derive_queue(input: TokenStream) -> TokenStream {
     expand_derive_queue(input).into()
 }
 
-/// Generates impl for `oxanus::Worker`.
+/// Generates impls for `oxanus::Worker<Args>`, `oxanus::Job`, and `oxanus::FromContext`.
 ///
 /// Example usage:
 /// ```ignore
-/// #[derive(Serialize, oxanus::Worker)]
+/// #[derive(Debug, Serialize, Deserialize)]
+/// struct MyJob { id: i32 }
+///
+/// #[derive(oxanus::Worker)]
+/// #[oxanus(args = MyJob)]
 /// #[oxanus(max_retries = 3, on_conflict = Replace)]
-/// #[oxanus(unique_id = "test_worker_{id}")]
-/// struct TestWorkerUniqueId {
-///     id: i32,
+/// #[oxanus(unique_id = "my_job_{id}")]
+/// struct MyWorker;
+///
+/// impl MyWorker {
+///     async fn process(&self, job: &MyJob, ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+///         Ok(())
+///     }
 /// }
 /// ```
 #[proc_macro_error]
@@ -58,14 +66,14 @@ pub fn derive_registry(input: TokenStream) -> TokenStream {
     expand_derive_registry(input).into()
 }
 
-/// Generates impl for `oxanus::BatchProcessor` and `oxanus::Worker`.
+/// Generates impl for `oxanus::BatchProcessor` and `oxanus::Processable`.
 ///
 /// Example usage:
 /// ```ignore
-/// #[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+/// #[derive(oxanus::BatchProcessor)]
 /// #[oxanus(batch_size = 3, batch_linger_ms = 1000)]
 /// struct TestBatchProcessor {
-///     workers: Vec<TestWorker>,
+///     jobs: Vec<TestJob>,
 /// }
 /// ```
 #[proc_macro_error]

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -66,14 +66,18 @@ pub fn derive_registry(input: TokenStream) -> TokenStream {
     expand_derive_registry(input).into()
 }
 
-/// Generates impl for `oxanus::BatchProcessor` and `oxanus::Processable`.
+/// Generates impl for `oxanus::BatchProcessor` and `oxanus::FromContext`.
 ///
 /// Example usage:
 /// ```ignore
 /// #[derive(oxanus::BatchProcessor)]
-/// #[oxanus(batch_size = 3, batch_linger_ms = 1000)]
-/// struct TestBatchProcessor {
-///     jobs: Vec<TestJob>,
+/// #[oxanus(args = TestJob, batch_size = 3, batch_linger_ms = 1000)]
+/// struct TestBatchProcessor;
+///
+/// impl TestBatchProcessor {
+///     async fn process_batch(&self, jobs: &[TestJob], ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+///         Ok(())
+///     }
 /// }
 /// ```
 #[proc_macro_error]

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -9,6 +9,7 @@ use syn::{
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(oxanus), supports(struct_any))]
 struct OxanusArgs {
+    args: Option<Path>,
     context: Option<Path>,
     error: Option<Path>,
     registry: Option<Path>,
@@ -144,58 +145,85 @@ impl FromMeta for UniqueIdSpec {
     }
 }
 
+fn extract_format_placeholders(fmt_str: &str) -> Vec<syn::Ident> {
+    let mut result = Vec::new();
+    let mut chars = fmt_str.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            let mut name = String::new();
+            for inner in chars.by_ref() {
+                if inner == '}' {
+                    break;
+                }
+                name.push(inner);
+            }
+            if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                result.push(syn::Ident::new(&name, proc_macro2::Span::call_site()));
+            }
+        }
+    }
+    result
+}
+
 pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
     let args = match OxanusArgs::from_derive_input(&input) {
         Ok(v) => v,
         Err(e) => {
-            // darling::Error -> emit nice compile errors
             abort!(input.ident, "{}", e);
         }
     };
 
     let struct_ident = &input.ident;
 
-    let type_context = match args.context {
+    let type_args = match &args.args {
+        Some(path) => quote!(#path),
+        None => abort!(
+            input.ident,
+            "Worker must have #[oxanus(args = MyJob)] attribute specifying the job type"
+        ),
+    };
+
+    let type_context = match &args.context {
         Some(context) => quote!(#context),
         None => quote!(WorkerContext),
     };
 
-    let type_error = match args.error {
+    let type_error = match &args.error {
         Some(error) => quote!(#error),
         None => quote!(WorkerError),
     };
 
-    let max_retries = match args.max_retries {
+    let worker_impl = expand_worker_impl(struct_ident, &type_args, &type_error, &args);
+    let job_impl = expand_job_impl(struct_ident, &type_args, &args);
+    let from_context_impl = expand_from_context_impl(struct_ident, &type_context, &input);
+    let registry_impl =
+        expand_registry(struct_ident, &type_args, &type_context, &type_error, &args);
+
+    quote! {
+        #worker_impl
+        #job_impl
+        #from_context_impl
+        #registry_impl
+    }
+}
+
+fn expand_worker_impl(
+    struct_ident: &Ident,
+    type_args: &TokenStream,
+    type_error: &TokenStream,
+    args: &OxanusArgs,
+) -> TokenStream {
+    let max_retries = match &args.max_retries {
         Some(max_retries) => expand_max_retries(max_retries),
         None => quote!(),
     };
 
-    let retry_delay = match args.retry_delay {
+    let retry_delay = match &args.retry_delay {
         Some(retry_delay) => expand_retry_delay(retry_delay),
         None => quote!(),
     };
 
-    let on_conflict = match args.on_conflict {
-        Some(on_conflict) => quote! {
-            fn on_conflict(&self) -> oxanus::JobConflictStrategy {
-                oxanus::JobConflictStrategy::#on_conflict
-            }
-        },
-        None => quote!(),
-    };
-
-    let unique_id = match args.unique_id {
-        Some(unique_id) => expand_unique_id(
-            unique_id,
-            match &input.data {
-                Data::Struct(data_struct) => &data_struct.fields,
-                _ => abort!(input.ident, "Worker must be a struct."),
-            },
-        ),
-        None => quote!(),
-    };
-
-    let cron = match args.cron {
+    let cron = match &args.cron {
         Some(cron) => expand_cron(cron),
         None => quote!(),
     };
@@ -212,12 +240,135 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
         None => quote!(),
     };
 
-    let component_registry = match args.registry {
+    quote! {
+        #[automatically_derived]
+        #[async_trait::async_trait]
+        impl oxanus::Worker<#type_args> for #struct_ident {
+            type Error = #type_error;
+
+            async fn process(&self, job: &#type_args, ctx: &oxanus::JobContext) -> Result<(), Self::Error> {
+                self.process(job, ctx).await
+            }
+
+            #max_retries
+
+            #retry_delay
+
+            #cron
+
+            #resurrect
+        }
+    }
+}
+
+fn expand_job_impl(
+    struct_ident: &Ident,
+    type_args: &TokenStream,
+    args: &OxanusArgs,
+) -> TokenStream {
+    let unique_id = match &args.unique_id {
+        Some(unique_id) => expand_unique_id(unique_id),
+        None => quote!(),
+    };
+
+    let on_conflict = match &args.on_conflict {
+        Some(on_conflict) => quote! {
+            fn on_conflict(&self) -> oxanus::JobConflictStrategy {
+                oxanus::JobConflictStrategy::#on_conflict
+            }
+        },
+        None => quote!(),
+    };
+
+    let resurrect = match args.resurrect {
+        Some(value) => quote! {
+            fn should_resurrect() -> bool
+            where
+                Self: Sized,
+            {
+                #value
+            }
+        },
+        None => quote!(),
+    };
+
+    quote! {
+        #[automatically_derived]
+        impl oxanus::Job for #type_args {
+            fn worker_name() -> &'static str
+            where
+                Self: Sized,
+            {
+                std::any::type_name::<#struct_ident>()
+            }
+
+            #unique_id
+
+            #on_conflict
+
+            #resurrect
+        }
+    }
+}
+
+fn expand_from_context_impl(
+    struct_ident: &Ident,
+    type_context: &TokenStream,
+    input: &DeriveInput,
+) -> TokenStream {
+    let fields = match &input.data {
+        Data::Struct(data_struct) => &data_struct.fields,
+        _ => abort!(input.ident, "Worker must be a struct."),
+    };
+
+    let constructor = match fields {
+        Fields::Unit => quote!(Self),
+        Fields::Named(named) if named.named.is_empty() => quote!(Self {}),
+        Fields::Named(named) if named.named.len() == 1 => {
+            let field = named.named.first().expect("checked len == 1");
+            let field_name = field.ident.as_ref().expect("named field has ident");
+            quote!(Self { #field_name: ctx.clone() })
+        }
+        Fields::Named(named) => {
+            abort!(
+                input.ident,
+                "Worker structs with {} fields cannot auto-derive FromContext. \
+                 Implement oxanus::FromContext<{}> manually.",
+                named.named.len(),
+                type_context
+            );
+        }
+        Fields::Unnamed(_) => {
+            abort!(
+                input.ident,
+                "Tuple worker structs are not supported. Use named fields or a unit struct."
+            );
+        }
+    };
+
+    quote! {
+        #[automatically_derived]
+        impl oxanus::FromContext<#type_context> for #struct_ident {
+            fn from_context(ctx: &#type_context) -> Self {
+                #constructor
+            }
+        }
+    }
+}
+
+fn expand_registry(
+    struct_ident: &Ident,
+    type_args: &TokenStream,
+    type_context: &TokenStream,
+    type_error: &TokenStream,
+    args: &OxanusArgs,
+) -> TokenStream {
+    let component_registry = match &args.registry {
         Some(registry) => quote!(#registry),
         None => quote!(ComponentRegistry),
     };
 
-    let registry = if cfg!(feature = "registry") && component_registry.to_string() != "None" {
+    if cfg!(feature = "registry") && component_registry.to_string() != "None" {
         quote! {
             oxanus::register_component! {
                 #component_registry(oxanus::ComponentRegistry {
@@ -226,8 +377,8 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
                     definition: || {
                         oxanus::ComponentDefinition::Worker(oxanus::WorkerConfig {
                             name: std::any::type_name::<#struct_ident>().to_owned(),
-                            factory: oxanus::job_factory::<#struct_ident, #type_context, #type_error>,
-                            kind: <#struct_ident as oxanus::Worker>::to_config(),
+                            factory: oxanus::job_factory::<#struct_ident, #type_args, #type_context, #type_error>,
+                            kind: <#struct_ident as oxanus::Worker<#type_args>>::to_config(),
                         })
                     }
                 })
@@ -235,37 +386,10 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
         }
     } else {
         quote!()
-    };
-
-    quote! {
-        #[automatically_derived]
-        #[async_trait::async_trait]
-        impl oxanus::Worker for #struct_ident {
-            type Context = #type_context;
-            type Error = #type_error;
-
-            async fn process(&self, data: &oxanus::Context<Self::Context>) -> Result<(), Self::Error> {
-                self.process(data).await
-            }
-
-            #unique_id
-
-            #max_retries
-
-            #retry_delay
-
-            #on_conflict
-
-            #cron
-
-            #resurrect
-        }
-
-        #registry
     }
 }
 
-fn expand_max_retries(max_retries: MaxRetries) -> TokenStream {
+fn expand_max_retries(max_retries: &MaxRetries) -> TokenStream {
     match max_retries {
         MaxRetries::Value(value) => {
             quote! {
@@ -284,7 +408,7 @@ fn expand_max_retries(max_retries: MaxRetries) -> TokenStream {
     }
 }
 
-fn expand_retry_delay(retry_delay: RetryDelay) -> TokenStream {
+fn expand_retry_delay(retry_delay: &RetryDelay) -> TokenStream {
     match retry_delay {
         RetryDelay::Value(value) => {
             quote! {
@@ -303,18 +427,12 @@ fn expand_retry_delay(retry_delay: RetryDelay) -> TokenStream {
     }
 }
 
-fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
+fn expand_unique_id(spec: &UniqueIdSpec) -> TokenStream {
     let formatter = match spec {
         UniqueIdSpec::Shorthand(fmt) => {
             let fmt_str = fmt.value();
-            let args = fields.iter().filter_map(|f| {
-                let name = f.ident.as_ref()?;
-                if fmt_str.contains(&format!("{{{name}}}")) {
-                    Some(quote!(#name = self.#name))
-                } else {
-                    None
-                }
-            });
+            let placeholders = extract_format_placeholders(&fmt_str);
+            let args = placeholders.iter().map(|name| quote!(#name = self.#name));
 
             quote! {
                 Some(format!(
@@ -345,9 +463,9 @@ fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
     }
 }
 
-fn expand_cron(cron: Cron) -> TokenStream {
-    let cron_schedule = cron.schedule;
-    let cron_queue_config = match cron.queue {
+fn expand_cron(cron: &Cron) -> TokenStream {
+    let cron_schedule = &cron.schedule;
+    let cron_queue_config = match &cron.queue {
         Some(queue) => quote! {
             fn cron_queue_config() -> Option<oxanus::QueueConfig>
             where

--- a/oxanus/benches/concurrency.rs
+++ b/oxanus/benches/concurrency.rs
@@ -6,7 +6,7 @@ fn main() {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerNoop {
+pub struct NoopJob {
     pub sleep_ms: u64,
 }
 
@@ -18,6 +18,30 @@ pub enum ServiceError {
 
 #[derive(Debug, Clone)]
 pub struct WorkerState {}
+
+pub struct NoopWorker;
+
+impl oxanus::Job for NoopJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<NoopWorker>()
+    }
+}
+
+#[async_trait::async_trait]
+impl oxanus::Worker<NoopJob> for NoopWorker {
+    type Error = ServiceError;
+
+    async fn process(&self, job: &NoopJob, _ctx: &oxanus::JobContext) -> Result<(), ServiceError> {
+        tokio::time::sleep(std::time::Duration::from_millis(job.sleep_ms)).await;
+        Ok(())
+    }
+}
+
+impl oxanus::FromContext<WorkerState> for NoopWorker {
+    fn from_context(_: &WorkerState) -> Self {
+        Self
+    }
+}
 
 #[derive(Serialize)]
 pub struct QueueOne;
@@ -34,75 +58,77 @@ impl oxanus::Queue for QueueOne {
     }
 }
 
-const JOBS_COUNT: u64 = 1000;
-const CONCURRENCY: &[usize] = &[1, 2, 4, 8, 12, 16, 512];
+const JOBS_COUNTS: &[u64] = &[1000, 10_000];
+const CONCURRENCY: &[usize] = &[4, 8, 12, 16, 512];
 
-#[async_trait::async_trait]
-impl oxanus::Worker for WorkerNoop {
-    type Context = WorkerState;
-    type Error = ServiceError;
-
-    async fn process(
-        &self,
-        oxanus::Context { .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), ServiceError> {
-        tokio::time::sleep(std::time::Duration::from_millis(self.sleep_ms)).await;
-        Ok(())
-    }
-}
-
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_0_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
+#[divan::bench(consts = JOBS_COUNTS, args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+fn run_jobs_taking_0_ms<const JOBS_COUNT: u64>(bencher: divan::Bencher, n: usize) {
+    let rt = &tokio::runtime::Runtime::new().expect("Failed to create runtime");
     let sleep_ms = 0;
     let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
+    rt.block_on(async {
+        setup(config, JOBS_COUNT, sleep_ms)
+            .await
+            .expect("setup failed")
+    });
 
     bencher.bench(|| {
         rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
+            execute(n, JOBS_COUNT).await.expect("execute failed");
         })
     });
 }
 
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_1_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
+#[divan::bench(consts = JOBS_COUNTS, args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+fn run_jobs_taking_1_ms<const JOBS_COUNT: u64>(bencher: divan::Bencher, n: usize) {
+    let rt = &tokio::runtime::Runtime::new().expect("Failed to create runtime");
     let sleep_ms = 1;
     let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
+    rt.block_on(async {
+        setup(config, JOBS_COUNT, sleep_ms)
+            .await
+            .expect("setup failed")
+    });
 
     bencher.bench(|| {
         rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
+            execute(n, JOBS_COUNT).await.expect("execute failed");
         })
     });
 }
 
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_2_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
+#[divan::bench(consts = JOBS_COUNTS, args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+fn run_jobs_taking_2_ms<const JOBS_COUNT: u64>(bencher: divan::Bencher, n: usize) {
+    let rt = &tokio::runtime::Runtime::new().expect("Failed to create runtime");
     let sleep_ms = 2;
     let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
+    rt.block_on(async {
+        setup(config, JOBS_COUNT, sleep_ms)
+            .await
+            .expect("setup failed")
+    });
 
     bencher.bench(|| {
         rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
+            execute(n, JOBS_COUNT).await.expect("execute failed");
         })
     });
 }
 
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_10_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
+#[divan::bench(consts = JOBS_COUNTS, args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+fn run_jobs_taking_10_ms<const JOBS_COUNT: u64>(bencher: divan::Bencher, n: usize) {
+    let rt = &tokio::runtime::Runtime::new().expect("Failed to create runtime");
     let sleep_ms = 10;
     let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
+    rt.block_on(async {
+        setup(config, JOBS_COUNT, sleep_ms)
+            .await
+            .expect("setup failed")
+    });
 
     bencher.bench(|| {
         rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
+            execute(n, JOBS_COUNT).await.expect("execute failed");
         })
     });
 }
@@ -115,7 +141,7 @@ async fn setup(
     for _ in 0..jobs_count {
         config
             .storage
-            .enqueue(QueueOne, WorkerNoop { sleep_ms })
+            .enqueue(QueueOne, NoopJob { sleep_ms })
             .await?;
     }
 
@@ -124,7 +150,7 @@ async fn setup(
 
 async fn execute(concurrency: usize, jobs_count: u64) -> Result<(), oxanus::OxanusError> {
     let config = build_config(concurrency).exit_when_processed(jobs_count);
-    let ctx = oxanus::Context::value(WorkerState {});
+    let ctx = oxanus::ContextValue::new(WorkerState {});
 
     let stats = oxanus::run(config, ctx).await?;
 
@@ -153,5 +179,5 @@ fn build_config(concurrency: usize) -> oxanus::Config<WorkerState, ServiceError>
         .expect("Failed to build storage");
     oxanus::Config::new(&storage)
         .register_queue_with_concurrency::<QueueOne>(concurrency)
-        .register_worker::<WorkerNoop>()
+        .register_worker::<NoopWorker, NoopJob>()
 }

--- a/oxanus/examples/batch.rs
+++ b/oxanus/examples/batch.rs
@@ -17,30 +17,38 @@ struct TestJob {
 
 #[derive(oxanus::Worker)]
 #[oxanus(args = TestJob)]
-struct TestWorker;
+struct TestWorker {
+    ctx: WorkerContext,
+}
 
 impl TestWorker {
     async fn process(&self, _job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        dbg!(&self.ctx);
         Ok(())
     }
 }
 
 #[derive(oxanus::BatchProcessor)]
-#[oxanus(batch_size = 3, batch_linger_ms = 1000)]
+#[oxanus(args = TestJob, batch_size = 3, batch_linger_ms = 1000)]
 struct TestBatchProcessor {
-    jobs: Vec<TestJob>,
+    ctx: WorkerContext,
 }
 
 impl TestBatchProcessor {
-    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
-        let ids = self.jobs.iter().map(|job| job.id).collect::<Vec<_>>();
+    async fn process_batch(
+        &self,
+        jobs: &[TestJob],
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        dbg!(&self.ctx);
+        let ids = jobs.iter().map(|job| job.id).collect::<Vec<_>>();
         dbg!(&ids);
         Ok(())
     }
 }
 
 #[derive(Serialize, oxanus::Queue)]
-#[oxanus(key = "one", concurrency = 1)]
+#[oxanus(key = "one", concurrency = 3)]
 struct QueueOne;
 
 #[tokio::main]

--- a/oxanus/examples/batch.rs
+++ b/oxanus/examples/batch.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
+struct TestWorker {
+    id: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[oxanus(batch_size = 3, batch_linger_ms = 1000)]
+struct TestBatchProcessor {
+    workers: Vec<TestWorker>,
+}
+
+impl TestBatchProcessor {
+    async fn process_batch(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+        let ids = self
+            .workers
+            .iter()
+            .map(|worker| worker.id)
+            .collect::<Vec<_>>();
+        dbg!(&ids);
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "one", concurrency = 1)]
+struct QueueOne;
+
+#[tokio::main]
+pub async fn main() -> Result<(), oxanus::OxanusError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let ctx = oxanus::Context::value(WorkerContext {});
+    let storage = oxanus::Storage::builder().build_from_env()?;
+    let config = ComponentRegistry::build_config(&storage)
+        .with_graceful_shutdown(tokio::signal::ctrl_c())
+        .exit_when_processed(10);
+
+    storage.enqueue(QueueOne, TestWorker { id: 1 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 2 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 3 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 4 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 5 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 6 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 7 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 8 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 9 }).await?;
+    storage.enqueue(QueueOne, TestWorker { id: 10 }).await?;
+
+    oxanus::run(config, ctx).await?;
+
+    Ok(())
+}

--- a/oxanus/examples/batch.rs
+++ b/oxanus/examples/batch.rs
@@ -10,24 +10,30 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
-struct TestWorker {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TestJob {
     id: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[derive(oxanus::Worker)]
+#[oxanus(args = TestJob)]
+struct TestWorker;
+
+impl TestWorker {
+    async fn process(&self, _job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+#[derive(oxanus::BatchProcessor)]
 #[oxanus(batch_size = 3, batch_linger_ms = 1000)]
 struct TestBatchProcessor {
-    workers: Vec<TestWorker>,
+    jobs: Vec<TestJob>,
 }
 
 impl TestBatchProcessor {
-    async fn process_batch(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
-        let ids = self
-            .workers
-            .iter()
-            .map(|worker| worker.id)
-            .collect::<Vec<_>>();
+    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        let ids = self.jobs.iter().map(|job| job.id).collect::<Vec<_>>();
         dbg!(&ids);
         Ok(())
     }
@@ -44,22 +50,22 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage)
         .with_graceful_shutdown(tokio::signal::ctrl_c())
         .exit_when_processed(10);
 
-    storage.enqueue(QueueOne, TestWorker { id: 1 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 2 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 3 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 4 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 5 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 6 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 7 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 8 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 9 }).await?;
-    storage.enqueue(QueueOne, TestWorker { id: 10 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 1 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 2 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 3 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 4 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 5 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 6 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 7 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 8 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 9 }).await?;
+    storage.enqueue(QueueOne, TestJob { id: 10 }).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/cron.rs
+++ b/oxanus/examples/cron.rs
@@ -10,14 +10,22 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[derive(Debug, Serialize, Deserialize)]
+struct CronJobArgs {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = CronJobArgs)]
 #[oxanus(context = WorkerContext)]
 #[oxanus(resurrect = false)]
 #[oxanus(cron(schedule = "*/5 * * * * *", queue = QueueOne))]
-struct TestWorker {}
+struct CronWorker;
 
-impl TestWorker {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+impl CronWorker {
+    async fn process(
+        &self,
+        _job: &CronJobArgs,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }
@@ -34,7 +42,7 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config =
         ComponentRegistry::build_config(&storage).with_graceful_shutdown(tokio::signal::ctrl_c());

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -2,6 +2,9 @@ use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
 #[derive(Debug, thiserror::Error)]
 enum WorkerError {
     #[error("Generic error: {0}")]
@@ -11,14 +14,21 @@ enum WorkerError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-#[oxanus(registry = None)]
-#[oxanus(max_retries = 3, retry_delay = 0)]
-#[oxanus(cron(schedule = "*/10 * * * * *"))]
-struct TestWorker {}
+#[derive(Debug, Serialize, Deserialize)]
+struct CronJobArgs {}
 
-impl TestWorker {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+#[derive(oxanus::Worker)]
+#[oxanus(args = CronJobArgs)]
+#[oxanus(max_retries = 3, retry_delay = 0)]
+#[oxanus(cron(schedule = "*/10 * * * * *", queue = QueueOne))]
+struct CronWorker;
+
+impl CronWorker {
+    async fn process(
+        &self,
+        _job: &CronJobArgs,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         if rand::rng().random_bool(0.5) {
             Err(WorkerError::GenericError("foo".to_string()))
         } else {
@@ -28,9 +38,8 @@ impl TestWorker {
 }
 
 #[derive(Serialize, oxanus::Queue)]
-#[oxanus(registry = None)]
-#[oxanus(prefix = "two")]
-struct QueueDynamic(i32);
+#[oxanus(key = "one")]
+struct QueueOne;
 
 #[tokio::main]
 pub async fn main() -> Result<(), oxanus::OxanusError> {
@@ -39,11 +48,10 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
-    let config = oxanus::Config::new(&storage)
-        .register_cron_worker::<TestWorker>(QueueDynamic(2))
-        .with_graceful_shutdown(tokio::signal::ctrl_c());
+    let config =
+        ComponentRegistry::build_config(&storage).with_graceful_shutdown(tokio::signal::ctrl_c());
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/dynamic.rs
+++ b/oxanus/examples/dynamic.rs
@@ -10,11 +10,15 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct Worker2Sec {}
+#[derive(Debug, Serialize, Deserialize)]
+struct Job2Sec {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = Job2Sec)]
+struct Worker2Sec;
 
 impl Worker2Sec {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(&self, _job: &Job2Sec, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }
@@ -38,24 +42,24 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(5);
 
     storage
-        .enqueue(QueueDynamic(Animal::Cat, 2), Worker2Sec {})
+        .enqueue(QueueDynamic(Animal::Cat, 2), Job2Sec {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Dog, 1), Worker2Sec {})
+        .enqueue(QueueDynamic(Animal::Dog, 1), Job2Sec {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Cat, 2), Worker2Sec {})
+        .enqueue(QueueDynamic(Animal::Cat, 2), Job2Sec {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Bird, 1), Worker2Sec {})
+        .enqueue(QueueDynamic(Animal::Bird, 1), Job2Sec {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Dog, 1), Worker2Sec {})
+        .enqueue(QueueDynamic(Animal::Dog, 1), Job2Sec {})
         .await?;
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/examples/experiment.rs
+++ b/oxanus/examples/experiment.rs
@@ -23,6 +23,7 @@ struct FooWorker {
 
 impl FooWorker {
     async fn process(&self, job: &FooJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        dbg!(&self.ctx);
         dbg!(&job);
         Ok(())
     }

--- a/oxanus/examples/experiment.rs
+++ b/oxanus/examples/experiment.rs
@@ -7,52 +7,45 @@ struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
 #[derive(Debug, thiserror::Error)]
 enum WorkerError {}
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct WorkerContext {
-    foo: String,
-}
+#[derive(Debug, Clone)]
+struct WorkerContext {}
 
 #[derive(Debug, Serialize, Deserialize)]
-struct TestJob {
-    sleep_s: u64,
+struct FooJob {
+    id: u64,
 }
 
 #[derive(oxanus::Worker)]
-#[oxanus(args = TestJob)]
-#[oxanus(context = WorkerContext)]
-struct TestWorker {
+#[oxanus(args = FooJob)]
+struct FooWorker {
     ctx: WorkerContext,
 }
 
-impl TestWorker {
-    async fn process(&self, job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
-        dbg!(&self.ctx);
-        tokio::time::sleep(std::time::Duration::from_secs(job.sleep_s)).await;
+impl FooWorker {
+    async fn process(&self, job: &FooJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        dbg!(&job);
         Ok(())
     }
 }
 
 #[derive(Serialize, oxanus::Queue)]
-#[oxanus(key = "one", concurrency = 2)]
+#[oxanus(key = "one")]
 struct QueueOne;
 
 #[tokio::main]
-pub async fn main() -> Result<(), oxanus::OxanusError> {
+async fn main() -> Result<(), oxanus::OxanusError> {
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::ContextValue::new(WorkerContext {
-        foo: "bar".to_string(),
-    });
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage)
         .with_graceful_shutdown(tokio::signal::ctrl_c())
         .exit_when_processed(1);
 
-    storage.enqueue(QueueOne, TestJob { sleep_s: 10 }).await?;
-    storage.enqueue(QueueOne, TestJob { sleep_s: 5 }).await?;
+    storage.enqueue(QueueOne, FooJob { id: 1 }).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/foo.rs
+++ b/oxanus/examples/foo.rs
@@ -4,52 +4,76 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 #[derive(oxanus::Registry)]
 struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct Worker1Sec {
-    id: usize,
-    payload: String,
-}
-
 #[derive(Debug, thiserror::Error)]
 enum WorkerError {}
 
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
+#[derive(Debug, Serialize, Deserialize)]
+struct Job1Sec {
+    id: usize,
+    payload: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = Job1Sec)]
+struct Worker1Sec;
+
 impl Worker1Sec {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(&self, _job: &Job1Sec, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct Worker2Sec {
+#[derive(Debug, Serialize, Deserialize)]
+struct Job2Sec {
     id: usize,
     foo: i32,
 }
 
+#[derive(oxanus::Worker)]
+#[oxanus(args = Job2Sec)]
+struct Worker2Sec;
+
 impl Worker2Sec {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(&self, _job: &Job2Sec, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct WorkerInstant {}
+#[derive(Debug, Serialize, Deserialize)]
+struct InstantJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = InstantJob)]
+struct WorkerInstant;
 
 impl WorkerInstant {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(
+        &self,
+        _job: &InstantJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct WorkerInstant2 {}
+#[derive(Debug, Serialize, Deserialize)]
+struct InstantJob2 {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = InstantJob2)]
+struct WorkerInstant2;
 
 impl WorkerInstant2 {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(
+        &self,
+        _job: &InstantJob2,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
@@ -81,38 +105,38 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(12);
 
     storage
         .enqueue(
             QueueOne,
-            Worker1Sec {
+            Job1Sec {
                 id: 1,
                 payload: "test".to_string(),
             },
         )
         .await?;
     storage
-        .enqueue(QueueTwo(Animal::Dog, 1), Worker2Sec { id: 2, foo: 42 })
+        .enqueue(QueueTwo(Animal::Dog, 1), Job2Sec { id: 2, foo: 42 })
         .await?;
     storage
         .enqueue(
             QueueOne,
-            Worker1Sec {
+            Job1Sec {
                 id: 3,
                 payload: "test".to_string(),
             },
         )
         .await?;
     storage
-        .enqueue(QueueTwo(Animal::Cat, 2), Worker2Sec { id: 4, foo: 44 })
+        .enqueue(QueueTwo(Animal::Cat, 2), Job2Sec { id: 4, foo: 44 })
         .await?;
     storage
         .enqueue_in(
             QueueOne,
-            Worker1Sec {
+            Job1Sec {
                 id: 4,
                 payload: "test".to_string(),
             },
@@ -120,16 +144,16 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         )
         .await?;
     storage
-        .enqueue_in(QueueTwo(Animal::Bird, 7), Worker2Sec { id: 5, foo: 44 }, 6)
+        .enqueue_in(QueueTwo(Animal::Bird, 7), Job2Sec { id: 5, foo: 44 }, 6)
         .await?;
     storage
-        .enqueue_in(QueueTwo(Animal::Bird, 7), Worker2Sec { id: 5, foo: 44 }, 15)
+        .enqueue_in(QueueTwo(Animal::Bird, 7), Job2Sec { id: 5, foo: 44 }, 15)
         .await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant2 {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant2 {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob2 {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob2 {}).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/resumable.rs
+++ b/oxanus/examples/resumable.rs
@@ -15,12 +15,20 @@ enum WorkerError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[derive(Debug, Serialize, Deserialize)]
+struct ResumableTestJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = ResumableTestJob)]
 #[oxanus(max_retries = 10, retry_delay = 3)]
-struct ResumableTestWorker {}
+struct ResumableTestWorker;
 
 impl ResumableTestWorker {
-    async fn process(&self, ctx: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(
+        &self,
+        _job: &ResumableTestJob,
+        ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         let progress = ctx.state.get::<i32>().await?;
 
         dbg!(&progress);
@@ -46,13 +54,13 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage)
         .with_graceful_shutdown(tokio::signal::ctrl_c())
         .exit_when_processed(11);
 
-    storage.enqueue(QueueOne, ResumableTestWorker {}).await?;
+    storage.enqueue(QueueOne, ResumableTestJob {}).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/throttled.rs
+++ b/oxanus/examples/throttled.rs
@@ -10,20 +10,36 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct WorkerInstant {}
+#[derive(Debug, Serialize, Deserialize)]
+struct InstantJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = InstantJob)]
+struct WorkerInstant;
 
 impl WorkerInstant {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(
+        &self,
+        _job: &InstantJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-struct WorkerInstant2 {}
+#[derive(Debug, Serialize, Deserialize)]
+struct InstantJob2 {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(args = InstantJob2)]
+struct WorkerInstant2;
 
 impl WorkerInstant2 {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(
+        &self,
+        _job: &InstantJob2,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
@@ -40,18 +56,18 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(8);
 
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant2 {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant2 {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstant {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob2 {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob2 {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/unique.rs
+++ b/oxanus/examples/unique.rs
@@ -10,14 +10,18 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-#[oxanus(unique_id = "worker2sec:{id}", on_conflict = Skip)]
-struct Worker2Sec {
+#[derive(Debug, Serialize, Deserialize)]
+struct Job2Sec {
     id: usize,
 }
 
+#[derive(oxanus::Worker)]
+#[oxanus(args = Job2Sec)]
+#[oxanus(unique_id = "worker2sec:{id}", on_conflict = Skip)]
+struct Worker2Sec;
+
 impl Worker2Sec {
-    async fn process(&self, _: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
+    async fn process(&self, _job: &Job2Sec, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
         Ok(())
     }
@@ -34,13 +38,13 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let ctx = oxanus::Context::value(WorkerContext {});
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage);
 
-    storage.enqueue(QueueOne, Worker2Sec { id: 1 }).await?;
-    storage.enqueue(QueueOne, Worker2Sec { id: 1 }).await?;
-    storage.enqueue(QueueOne, Worker2Sec { id: 2 }).await?;
+    storage.enqueue(QueueOne, Job2Sec { id: 1 }).await?;
+    storage.enqueue(QueueOne, Job2Sec { id: 1 }).await?;
+    storage.enqueue(QueueOne, Job2Sec { id: 2 }).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/src/batch_processor.rs
+++ b/oxanus/src/batch_processor.rs
@@ -1,0 +1,32 @@
+use crate::error::OxanusError;
+use crate::worker::{BoxedWorker, Worker};
+
+pub type BatchFactory<DT, ET> =
+    fn(Vec<serde_json::Value>) -> Result<BoxedWorker<DT, ET>, OxanusError>;
+
+pub struct BatchProcessorConfig<DT, ET> {
+    pub worker_name: String,
+    pub batch_size: usize,
+    pub batch_linger_ms: u64,
+    pub factory: BatchFactory<DT, ET>,
+}
+
+pub trait BatchProcessor: Worker + Sized {
+    type Item: serde::de::DeserializeOwned + Send + Sync;
+
+    fn from_args(args: Vec<serde_json::Value>) -> Result<Self, OxanusError>;
+    fn batch_size() -> usize;
+    fn batch_linger_ms() -> u64;
+}
+
+pub fn batch_factory<B, DT, ET>(
+    args: Vec<serde_json::Value>,
+) -> Result<BoxedWorker<DT, ET>, OxanusError>
+where
+    B: BatchProcessor<Context = DT, Error = ET> + 'static,
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let processor = B::from_args(args)?;
+    Ok(Box::new(processor))
+}

--- a/oxanus/src/batch_processor.rs
+++ b/oxanus/src/batch_processor.rs
@@ -1,5 +1,6 @@
+use crate::context::JobContext;
 use crate::error::OxanusError;
-use crate::worker::{BoxedProcessable, Processable};
+use crate::worker::{BoxedProcessable, FromContext, Processable};
 
 pub type BatchFactory<DT, ET> =
     fn(Vec<serde_json::Value>, &DT) -> Result<BoxedProcessable<ET>, OxanusError>;
@@ -11,23 +12,66 @@ pub struct BatchProcessorConfig<DT, ET> {
     pub factory: BatchFactory<DT, ET>,
 }
 
-pub trait BatchProcessor: Processable + Sized {
+#[async_trait::async_trait]
+pub trait BatchProcessor: Send + Sync + Sized {
     type Item: serde::de::DeserializeOwned + Send + Sync;
+    type Error: std::error::Error + Send + Sync;
 
-    fn from_args(args: Vec<serde_json::Value>) -> Result<Self, OxanusError>;
+    async fn process_batch(&self, items: &[Self::Item], ctx: &JobContext)
+        -> Result<(), Self::Error>;
+
+    fn max_retries(&self) -> u32 {
+        2
+    }
+
+    fn retry_delay(&self, retries: u32) -> u64 {
+        u64::pow(5, retries + 2)
+    }
+
     fn batch_size() -> usize;
     fn batch_linger_ms() -> u64;
 }
 
+pub(crate) struct BoundBatch<B: BatchProcessor> {
+    pub processor: B,
+    pub items: Vec<B::Item>,
+}
+
+#[async_trait::async_trait]
+impl<B> Processable for BoundBatch<B>
+where
+    B: BatchProcessor + Send + Sync + 'static,
+    B::Item: Send + Sync + 'static,
+{
+    type Error = B::Error;
+
+    async fn process(&self, ctx: &JobContext) -> Result<(), Self::Error> {
+        self.processor.process_batch(&self.items, ctx).await
+    }
+
+    fn max_retries(&self) -> u32 {
+        self.processor.max_retries()
+    }
+
+    fn retry_delay(&self, retries: u32) -> u64 {
+        self.processor.retry_delay(retries)
+    }
+}
+
 pub fn batch_factory<B, DT, ET>(
     args: Vec<serde_json::Value>,
-    _ctx: &DT,
+    ctx: &DT,
 ) -> Result<BoxedProcessable<ET>, OxanusError>
 where
-    B: BatchProcessor<Error = ET> + 'static,
+    B: BatchProcessor<Error = ET> + FromContext<DT> + 'static,
+    B::Item: 'static,
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let processor = B::from_args(args)?;
-    Ok(Box::new(processor))
+    let items: Vec<B::Item> = args
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<Result<Vec<_>, _>>()?;
+    let processor = B::from_context(ctx);
+    Ok(Box::new(BoundBatch { processor, items }))
 }

--- a/oxanus/src/batch_processor.rs
+++ b/oxanus/src/batch_processor.rs
@@ -1,8 +1,8 @@
 use crate::error::OxanusError;
-use crate::worker::{BoxedWorker, Worker};
+use crate::worker::{BoxedProcessable, Processable};
 
 pub type BatchFactory<DT, ET> =
-    fn(Vec<serde_json::Value>) -> Result<BoxedWorker<DT, ET>, OxanusError>;
+    fn(Vec<serde_json::Value>, &DT) -> Result<BoxedProcessable<ET>, OxanusError>;
 
 pub struct BatchProcessorConfig<DT, ET> {
     pub worker_name: String,
@@ -11,7 +11,7 @@ pub struct BatchProcessorConfig<DT, ET> {
     pub factory: BatchFactory<DT, ET>,
 }
 
-pub trait BatchProcessor: Worker + Sized {
+pub trait BatchProcessor: Processable + Sized {
     type Item: serde::de::DeserializeOwned + Send + Sync;
 
     fn from_args(args: Vec<serde_json::Value>) -> Result<Self, OxanusError>;
@@ -21,9 +21,10 @@ pub trait BatchProcessor: Worker + Sized {
 
 pub fn batch_factory<B, DT, ET>(
     args: Vec<serde_json::Value>,
-) -> Result<BoxedWorker<DT, ET>, OxanusError>
+    _ctx: &DT,
+) -> Result<BoxedProcessable<ET>, OxanusError>
 where
-    B: BatchProcessor<Context = DT, Error = ET> + 'static,
+    B: BatchProcessor<Error = ET> + 'static,
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {

--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -6,8 +6,8 @@ use crate::Storage;
 use crate::batch_processor::BatchProcessorConfig;
 use crate::queue::{Queue, QueueConfig};
 use crate::storage_types::{Catalog, CronWorkerInfo, QueueInfo, QueueThrottleInfo, WorkerInfo};
-use crate::worker::Worker;
-use crate::worker_registry::{WorkerConfig, WorkerRegistry};
+use crate::worker::{FromContext, Job, Worker};
+use crate::worker_registry::{self, WorkerConfig, WorkerConfigKind, WorkerRegistry};
 
 pub struct Config<DT, ET> {
     pub(crate) registry: WorkerRegistry<DT, ET>,
@@ -55,30 +55,28 @@ impl<DT, ET> Config<DT, ET> {
         self
     }
 
-    pub fn register_worker<W>(mut self) -> Self
+    pub fn register_worker<W, A>(mut self) -> Self
     where
-        W: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
+        W: Worker<A, Error = ET> + FromContext<DT> + 'static,
+        A: Job + serde::de::DeserializeOwned + Send + Sync + 'static,
+        DT: Clone + Send + Sync + 'static,
+        ET: std::error::Error + Send + Sync + 'static,
     {
-        if let (Some(schedule), Some(queue_config)) = (W::cron_schedule(), W::cron_queue_config()) {
-            let key = queue_config
-                .static_key()
-                .expect("Statically defined cron workers can only use static queues");
-            self.register_queue_with(queue_config);
-            self.registry.register_cron::<W>(&schedule, key);
-        } else {
-            self.registry.register::<W>();
-        }
-        self
-    }
+        let name = std::any::type_name::<W>().to_string();
+        let factory = worker_registry::job_factory::<W, A, DT, ET>;
+        let kind = <W as Worker<A>>::to_config();
 
-    /// Register a cron worker with a dynamic queue
-    pub fn register_cron_worker<W>(mut self, queue: impl Queue) -> Self
-    where
-        W: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
-    {
-        self.register_queue_with(queue.config());
-        let schedule = W::cron_schedule().expect("Cron Worker must have cron_schedule defined");
-        self.registry.register_cron::<W>(&schedule, queue.key());
+        if let WorkerConfigKind::Cron { .. } = &kind
+            && let Some(queue_config) = <W as Worker<A>>::cron_queue_config()
+        {
+            self.register_queue_with(queue_config);
+        }
+
+        self.registry.register_worker_with(WorkerConfig {
+            name,
+            factory,
+            kind,
+        });
         self
     }
 
@@ -115,18 +113,21 @@ impl<DT, ET> Config<DT, ET> {
         self.queues.contains(&Q::to_config())
     }
 
-    pub fn has_registered_worker<W>(&self) -> bool
-    where
-        W: Worker<Context = DT, Error = ET>,
-    {
-        self.registry.has_registered::<W>()
+    pub fn has_registered_worker(&self, name: &str) -> bool {
+        self.registry.has_registered(name)
     }
 
-    pub fn has_registered_cron_worker<W>(&self) -> bool
-    where
-        W: Worker<Context = DT, Error = ET>,
-    {
-        self.registry.has_registered_cron::<W>()
+    pub fn has_registered_worker_type<W: 'static>(&self) -> bool {
+        self.registry.has_registered(std::any::type_name::<W>())
+    }
+
+    pub fn has_registered_cron_worker(&self, name: &str) -> bool {
+        self.registry.has_registered_cron(name)
+    }
+
+    pub fn has_registered_cron_worker_type<W: 'static>(&self) -> bool {
+        self.registry
+            .has_registered_cron(std::any::type_name::<W>())
     }
 
     /// Returns a catalog of all registered workers.

--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use tokio_util::sync::CancellationToken;
 
 use crate::Storage;
+use crate::batch_processor::BatchProcessorConfig;
 use crate::queue::{Queue, QueueConfig};
 use crate::storage_types::{Catalog, CronWorkerInfo, QueueInfo, QueueThrottleInfo, WorkerInfo};
 use crate::worker::Worker;
@@ -83,6 +84,10 @@ impl<DT, ET> Config<DT, ET> {
 
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT, ET>) {
         self.registry.register_worker_with(config);
+    }
+
+    pub fn register_batch_processor_with(&mut self, config: BatchProcessorConfig<DT, ET>) {
+        self.registry.register_batch_processor_with(config);
     }
 
     pub fn exit_when_processed(mut self, processed: u64) -> Self {

--- a/oxanus/src/context.rs
+++ b/oxanus/src/context.rs
@@ -3,20 +3,19 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::{JobId, OxanusError, Storage, job_envelope::JobMeta};
 
 #[derive(Clone)]
-pub struct Context<T: Clone + Send + Sync> {
-    pub ctx: T,
+pub struct JobContext {
     pub meta: JobMeta,
     pub state: JobState,
 }
 
-impl<T: Clone + Send + Sync> Context<T> {
-    pub fn value(v: T) -> ContextValue<T> {
-        ContextValue(v)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ContextValue<T: Clone + Send + Sync>(pub(crate) T);
+
+impl<T: Clone + Send + Sync> ContextValue<T> {
+    pub fn new(v: T) -> Self {
+        Self(v)
+    }
+}
 
 #[derive(Clone)]
 pub struct JobState {

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -43,18 +43,9 @@ where
     let concurrency = queue_config.concurrency;
     let has_batch_configs = !config.registry.batch_configs.is_empty();
 
-    let max_batch_size = config
-        .registry
-        .batch_configs
-        .values()
-        .map(|c| c.batch_size)
-        .max()
-        .unwrap_or(1);
-    let effective_concurrency = concurrency * max_batch_size;
-
-    let (result_tx, result_rx) = mpsc::channel::<JobResult>(effective_concurrency);
-    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(effective_concurrency);
-    let semaphores = Arc::new(SemaphoresMap::new(effective_concurrency));
+    let (result_tx, result_rx) = mpsc::channel::<JobResult>(concurrency);
+    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(concurrency);
+    let semaphores = Arc::new(SemaphoresMap::new(concurrency));
     let mut joinset = JoinSet::new();
     let batch_buffers: BatchBuffers = Arc::new(Mutex::new(HashMap::new()));
 

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -1,6 +1,7 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc};
+use std::time::Duration;
+use tokio::sync::{Mutex, OwnedSemaphorePermit, mpsc};
 use tokio::task::JoinSet;
 
 use crate::config::Config;
@@ -17,6 +18,18 @@ use crate::{
     result_collector::{self, Stats},
 };
 
+struct PendingBatchItem {
+    envelope: JobEnvelope,
+    permit: OwnedSemaphorePermit,
+}
+
+struct BatchBuffer {
+    items: Vec<PendingBatchItem>,
+    first_added: tokio::time::Instant,
+}
+
+type BatchBuffers = Arc<Mutex<HashMap<String, BatchBuffer>>>;
+
 pub async fn run<DT, ET>(
     config: Arc<Config<DT, ET>>,
     stats: Arc<Mutex<Stats>>,
@@ -28,10 +41,30 @@ where
     ET: std::error::Error + Send + Sync + 'static,
 {
     let concurrency = queue_config.concurrency;
-    let (result_tx, result_rx) = mpsc::channel::<JobResult>(concurrency);
-    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(concurrency);
-    let semaphores = Arc::new(SemaphoresMap::new(concurrency));
+    let has_batch_configs = !config.registry.batch_configs.is_empty();
+
+    let max_batch_size = config
+        .registry
+        .batch_configs
+        .values()
+        .map(|c| c.batch_size)
+        .max()
+        .unwrap_or(1);
+    let effective_concurrency = concurrency * max_batch_size;
+
+    let (result_tx, result_rx) = mpsc::channel::<JobResult>(effective_concurrency);
+    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(effective_concurrency);
+    let semaphores = Arc::new(SemaphoresMap::new(effective_concurrency));
     let mut joinset = JoinSet::new();
+    let batch_buffers: BatchBuffers = Arc::new(Mutex::new(HashMap::new()));
+
+    let batch_check_interval = if has_batch_configs {
+        Duration::from_millis(50)
+    } else {
+        Duration::from_secs(86400)
+    };
+    let mut batch_tick = tokio::time::interval(batch_check_interval);
+    batch_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     joinset.spawn(result_collector::run(
         result_rx,
@@ -49,13 +82,20 @@ where
         tokio::select! {
             job = job_rx.recv() => {
                 if let Some(job) = job {
-                    joinset.spawn(process_job(
+                    joinset.spawn(route_job(
                         Arc::clone(&config),
                         ctx.clone(),
                         result_tx.clone(),
                         job,
+                        Arc::clone(&batch_buffers),
                     ));
                 }
+            }
+            _ = batch_tick.tick(), if has_batch_configs => {
+                spawn_ready_batches(
+                    &config, &ctx, &result_tx,
+                    &batch_buffers, &mut joinset, false,
+                ).await;
             }
             Some(task_result) = joinset.join_next() => {
                 task_result??;
@@ -66,7 +106,281 @@ where
         }
     }
 
+    if has_batch_configs {
+        spawn_ready_batches(
+            &config,
+            &ctx,
+            &result_tx,
+            &batch_buffers,
+            &mut joinset,
+            true,
+        )
+        .await;
+    }
+
     wait_for_workers_to_finish(config, Arc::clone(&semaphores)).await;
+
+    Ok(())
+}
+
+async fn fetch_envelope<DT, ET>(config: &Config<DT, ET>, job_id: &String) -> Option<JobEnvelope> {
+    match config.storage.internal.get_job(job_id).await {
+        Ok(Some(envelope)) => Some(envelope),
+        Ok(None) => {
+            tracing::warn!("Job {} not found", job_id);
+            if let Err(e) = config.storage.internal.delete_job(job_id).await {
+                #[cfg(feature = "sentry")]
+                sentry_core::capture_error(&e);
+                tracing::error!("Failed to delete job: {}", e);
+            }
+            None
+        }
+        Err(e) => {
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_error(&e);
+            tracing::error!("Failed to get job envelope: {}", e);
+            None
+        }
+    }
+}
+
+async fn route_job<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    job_event: WorkerJob,
+    batch_buffers: BatchBuffers,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let envelope = match fetch_envelope(&config, &job_event.job_id).await {
+        Some(e) => e,
+        None => return Ok(()),
+    };
+
+    if let Some(batch_config) = config.registry.get_batch_config(&envelope.job.name) {
+        let worker_name = envelope.job.name.clone();
+        let batch_size = batch_config.batch_size;
+
+        let ready_items = {
+            let mut buffers = batch_buffers.lock().await;
+            let buffer = buffers
+                .entry(worker_name.clone())
+                .or_insert_with(|| BatchBuffer {
+                    items: Vec::new(),
+                    first_added: tokio::time::Instant::now(),
+                });
+            buffer.items.push(PendingBatchItem {
+                envelope,
+                permit: job_event.permit,
+            });
+
+            if buffer.items.len() >= batch_size {
+                buffers.remove(&worker_name)
+            } else {
+                None
+            }
+        };
+
+        if let Some(buffer) = ready_items {
+            execute_batch(config, ctx, result_tx, buffer.items).await?;
+        }
+    } else {
+        process_job(config, ctx, result_tx, envelope, job_event.permit).await?;
+    }
+
+    Ok(())
+}
+
+async fn spawn_ready_batches<DT, ET>(
+    config: &Arc<Config<DT, ET>>,
+    ctx: &ContextValue<DT>,
+    result_tx: &mpsc::Sender<JobResult>,
+    batch_buffers: &BatchBuffers,
+    joinset: &mut JoinSet<Result<(), OxanusError>>,
+    drain_all: bool,
+) where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let ready_batches = {
+        let mut buffers = batch_buffers.lock().await;
+
+        let ready_keys: Vec<String> = buffers
+            .iter()
+            .filter(|(worker_name, buffer)| {
+                if drain_all {
+                    !buffer.items.is_empty()
+                } else if let Some(cfg) = config.registry.get_batch_config(worker_name) {
+                    buffer.first_added.elapsed() >= Duration::from_millis(cfg.batch_linger_ms)
+                } else {
+                    false
+                }
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        ready_keys
+            .into_iter()
+            .filter_map(|key| buffers.remove(&key).map(|b| b.items))
+            .collect::<Vec<_>>()
+    };
+
+    for items in ready_batches {
+        joinset.spawn(execute_batch(
+            Arc::clone(config),
+            ctx.clone(),
+            result_tx.clone(),
+            items,
+        ));
+    }
+}
+
+async fn execute_batch<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    items: Vec<PendingBatchItem>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    let first_envelope = &items.first().expect("items is not empty").envelope;
+    let worker_name = first_envelope.job.name.clone();
+    let batch_config = match config.registry.get_batch_config(&worker_name) {
+        Some(cfg) => cfg,
+        None => {
+            tracing::error!("Batch config not found for {}", worker_name);
+            return Ok(());
+        }
+    };
+
+    let args: Vec<serde_json::Value> = items.iter().map(|i| i.envelope.job.args.clone()).collect();
+
+    for item in &items {
+        if let Err(e) = config
+            .storage
+            .internal
+            .set_started_at(&item.envelope.id)
+            .await
+        {
+            tracing::error!("Failed to set started_at for batch item: {}", e);
+        }
+    }
+
+    let batch_size = items.len();
+    tracing::info!(
+        worker = worker_name,
+        batch_size = batch_size,
+        "Batch started"
+    );
+
+    let batch_worker = match (batch_config.factory)(args) {
+        Ok(w) => w,
+        Err(e) => {
+            let err_msg = format!("Failed to build batch processor: {e}");
+            tracing::error!("{}", err_msg);
+            for item in items {
+                if let Err(e) = config
+                    .storage
+                    .internal
+                    .kill(&item.envelope, err_msg.clone())
+                    .await
+                {
+                    tracing::error!("Failed to kill batch item: {}", e);
+                }
+                result_tx
+                    .send(JobResult {
+                        envelope: item.envelope,
+                        kind: JobResultKind::Failed,
+                    })
+                    .await
+                    .ok();
+            }
+            return Ok(());
+        }
+    };
+
+    let full_ctx = crate::Context {
+        ctx: ctx.0,
+        meta: first_envelope.meta.clone(),
+        state: crate::context::JobState::new(
+            config.storage.clone(),
+            first_envelope.id.clone(),
+            first_envelope.meta.state.clone(),
+        ),
+    };
+
+    let start = std::time::Instant::now();
+    let result = batch_worker.process(&full_ctx).await;
+    let duration = start.elapsed();
+
+    tracing::info!(
+        worker = worker_name,
+        batch_size = batch_size,
+        success = result.is_ok(),
+        duration_ms = duration.as_millis(),
+        "Batch finished"
+    );
+
+    match result {
+        Ok(()) => {
+            for item in items {
+                if let Err(e) = config
+                    .storage
+                    .internal
+                    .finish_with_success(&item.envelope)
+                    .await
+                {
+                    tracing::error!("Failed to finish batch item: {}", e);
+                }
+                report_result(&result_tx, item.envelope, JobResultKind::Success).await;
+                drop(item.permit);
+            }
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            let max_retries = batch_worker.max_retries();
+
+            for item in items {
+                let retry_delay = batch_worker.retry_delay(item.envelope.meta.retries);
+                if item.envelope.meta.retries < max_retries {
+                    if let Err(e) = config
+                        .storage
+                        .internal
+                        .finish_with_failure(&item.envelope)
+                        .await
+                    {
+                        tracing::error!("Failed to finish batch item: {}", e);
+                    }
+                    if let Err(e) = config
+                        .storage
+                        .internal
+                        .retry_in(item.envelope.id.clone(), retry_delay, err_msg.clone())
+                        .await
+                    {
+                        tracing::error!("Failed to retry batch item: {}", e);
+                    }
+                } else if let Err(e) = config
+                    .storage
+                    .internal
+                    .kill(&item.envelope, err_msg.clone())
+                    .await
+                {
+                    tracing::error!("Failed to kill batch item: {}", e);
+                }
+                report_result(&result_tx, item.envelope, JobResultKind::Failed).await;
+                drop(item.permit);
+            }
+        }
+    }
 
     Ok(())
 }
@@ -75,33 +389,13 @@ async fn process_job<DT, ET>(
     config: Arc<Config<DT, ET>>,
     ctx: ContextValue<DT>,
     result_tx: mpsc::Sender<JobResult>,
-    job_event: WorkerJob,
+    envelope: JobEnvelope,
+    permit: OwnedSemaphorePermit,
 ) -> Result<(), OxanusError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    tracing::trace!("Processing job: {:?}", job_event);
-
-    let envelope: JobEnvelope = match config.storage.internal.get_job(&job_event.job_id).await {
-        Ok(Some(envelope)) => envelope,
-        Ok(None) => {
-            tracing::warn!("Job {} not found", job_event.job_id);
-            if let Err(e) = config.storage.internal.delete_job(&job_event.job_id).await {
-                #[cfg(feature = "sentry")]
-                sentry_core::capture_error(&e);
-                tracing::error!("Failed to delete job: {}", e);
-            }
-            return Ok(());
-        }
-        Err(e) => {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_error(&e);
-            tracing::error!("Failed to get job envelope: {}", e);
-            return Ok(());
-        }
-    };
-
     tracing::debug!(
         job_id = envelope.id,
         latency_ms = envelope.meta.latency_millis(),
@@ -114,8 +408,9 @@ where
     {
         Ok(job) => job,
         Err(e) => {
-            tracing::error!("Invalid job: {} - {}", &envelope.job.name, e);
-            if let Err(e) = config.storage.internal.kill(&envelope).await {
+            let err_msg = format!("Invalid job: {} - {}", &envelope.job.name, e);
+            tracing::error!("{}", err_msg);
+            if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
                 #[cfg(feature = "sentry")]
                 sentry_core::capture_error(&e);
                 tracing::error!("Failed to kill job: {}", e);
@@ -125,20 +420,8 @@ where
     };
 
     let result = executor::run(config, job, &envelope, ctx.clone()).await?;
-    drop(job_event.permit);
+    drop(permit);
 
-    process_result(result_tx, result, envelope).await;
-
-    Ok(())
-}
-
-async fn process_result<ET>(
-    result_tx: mpsc::Sender<JobResult>,
-    result: Result<(), ExecutionError<ET>>,
-    envelope: JobEnvelope,
-) where
-    ET: std::error::Error + Send + Sync + 'static,
-{
     let kind = match result {
         Ok(()) => JobResultKind::Success,
         Err(e) => match e {
@@ -146,7 +429,16 @@ async fn process_result<ET>(
             ExecutionError::Panic() => JobResultKind::Panicked,
         },
     };
+    report_result(&result_tx, envelope, kind).await;
 
+    Ok(())
+}
+
+async fn report_result(
+    result_tx: &mpsc::Sender<JobResult>,
+    envelope: JobEnvelope,
+    kind: JobResultKind,
+) {
     result_tx.send(JobResult { envelope, kind }).await.ok();
 }
 
@@ -230,6 +522,6 @@ async fn wait_for_workers_to_finish<DT, ET>(
             break;
         }
 
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -5,7 +5,7 @@ use tokio::sync::{Mutex, OwnedSemaphorePermit, mpsc};
 use tokio::task::JoinSet;
 
 use crate::config::Config;
-use crate::context::ContextValue;
+use crate::context::{ContextValue, JobState};
 use crate::error::OxanusError;
 use crate::executor::ExecutionError;
 use crate::job_envelope::JobEnvelope;
@@ -14,7 +14,7 @@ use crate::result_collector::{JobResult, JobResultKind};
 use crate::semaphores_map::SemaphoresMap;
 use crate::worker_event::WorkerJob;
 use crate::{
-    dispatcher, executor,
+    JobContext, dispatcher, executor,
     result_collector::{self, Stats},
 };
 
@@ -282,7 +282,7 @@ where
         "Batch started"
     );
 
-    let batch_worker = match (batch_config.factory)(args) {
+    let batch_worker = match (batch_config.factory)(args, &ctx.0) {
         Ok(w) => w,
         Err(e) => {
             let err_msg = format!("Failed to build batch processor: {e}");
@@ -308,10 +308,9 @@ where
         }
     };
 
-    let full_ctx = crate::Context {
-        ctx: ctx.0,
+    let job_ctx = JobContext {
         meta: first_envelope.meta.clone(),
-        state: crate::context::JobState::new(
+        state: JobState::new(
             config.storage.clone(),
             first_envelope.id.clone(),
             first_envelope.meta.state.clone(),
@@ -319,7 +318,7 @@ where
     };
 
     let start = std::time::Instant::now();
-    let result = batch_worker.process(&full_ctx).await;
+    let result = batch_worker.process(&job_ctx).await;
     let duration = start.elapsed();
 
     tracing::info!(
@@ -404,7 +403,7 @@ where
     );
     let job = match config
         .registry
-        .build(&envelope.job.name, envelope.job.args.clone())
+        .build(&envelope.job.name, envelope.job.args.clone(), &ctx.0)
     {
         Ok(job) => job,
         Err(e) => {
@@ -419,7 +418,7 @@ where
         }
     };
 
-    let result = executor::run(config, job, &envelope, ctx.clone()).await?;
+    let result = executor::run(config, job, &envelope).await?;
     drop(permit);
 
     let kind = match result {

--- a/oxanus/src/drainer.rs
+++ b/oxanus/src/drainer.rs
@@ -93,13 +93,14 @@ where
             Ok(ProcessJobResult::Success)
         }
         Err(e) => {
-            tracing::error!("Job failed: {}", e);
+            let err_msg = e.to_string();
+            tracing::error!("Job failed: {}", err_msg);
             config
                 .storage
                 .internal
                 .finish_with_failure(&envelope)
                 .await?;
-            config.storage.internal.kill(&envelope).await?;
+            config.storage.internal.kill(&envelope, err_msg).await?;
             Ok(ProcessJobResult::Failed)
         }
     }

--- a/oxanus/src/drainer.rs
+++ b/oxanus/src/drainer.rs
@@ -22,6 +22,16 @@ pub struct DrainStats {
 /// This function will drain a queue of jobs, processing them one by one.
 ///
 /// It is useful in development or testing to process a queue of jobs without running the full worker.
+///
+/// # Arguments
+///
+/// * `config` - The worker configuration, including queue and worker registrations
+/// * `ctx` - The context value that will be shared across all worker instances
+/// * `queue` - The queue to drain
+///
+/// # Returns
+///
+/// Returns statistics about the drain operation, or an [`OxanusError`] if the operation fails.
 pub async fn drain<DT, ET>(
     config: &Config<DT, ET>,
     ctx: ContextValue<DT>,

--- a/oxanus/src/drainer.rs
+++ b/oxanus/src/drainer.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::context::{ContextValue, JobState};
 use crate::error::OxanusError;
-use crate::{Context, JobId, Queue};
+use crate::{JobContext, JobId, Queue};
 
 enum ProcessJobResult {
     Success,
@@ -22,16 +22,6 @@ pub struct DrainStats {
 /// This function will drain a queue of jobs, processing them one by one.
 ///
 /// It is useful in development or testing to process a queue of jobs without running the full worker.
-///
-/// # Arguments
-///
-/// * `config` - The worker configuration, including queue and worker registrations
-/// * `ctx` - The context value that will be shared across all worker instances
-/// * `queue` - The queue to drain
-///
-/// # Returns
-///
-/// Returns statistics about the drain operation, or an [`OxanusError`] if the operation fails.
 pub async fn drain<DT, ET>(
     config: &Config<DT, ET>,
     ctx: ContextValue<DT>,
@@ -71,17 +61,17 @@ where
         None => return Ok(ProcessJobResult::Missing),
     };
 
-    let job = config
-        .registry
-        .build(&envelope.job.name, envelope.job.args.clone())?;
+    let processable =
+        config
+            .registry
+            .build(&envelope.job.name, envelope.job.args.clone(), &ctx.0)?;
 
-    let full_ctx = Context {
-        ctx: ctx.0,
+    let job_ctx = JobContext {
         meta: envelope.meta.clone(),
         state: JobState::new(config.storage.clone(), job_id, envelope.meta.state.clone()),
     };
 
-    let job_result = job.process(&full_ctx).await;
+    let job_result = processable.process(&job_ctx).await;
 
     match job_result {
         Ok(()) => {

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -164,7 +164,7 @@ async fn handle_err<DT, ET>(
         if let Err(e) = config
             .storage
             .internal
-            .retry_in(envelope.id.clone(), retry_delay)
+            .retry_in(envelope.id.clone(), retry_delay, err_msg.to_string())
             .await
         {
             tracing::error!("Failed to retry job: {}", e);
@@ -176,7 +176,12 @@ async fn handle_err<DT, ET>(
             max_retries,
             err_msg
         );
-        if let Err(e) = config.storage.internal.kill(envelope).await {
+        if let Err(e) = config
+            .storage
+            .internal
+            .kill(envelope, err_msg.to_string())
+            .await
+        {
             tracing::error!("Failed to kill job: {}", e);
         }
     }

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -2,10 +2,10 @@ use futures::FutureExt;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
-use crate::context::{ContextValue, JobState};
+use crate::context::JobState;
 use crate::job_envelope::JobEnvelope;
-use crate::worker::BoxedWorker;
-use crate::{Config, Context, OxanusError};
+use crate::worker::BoxedProcessable;
+use crate::{Config, JobContext, OxanusError};
 
 #[derive(Debug)]
 enum ExecutionResult<ET> {
@@ -20,9 +20,8 @@ pub(crate) enum ExecutionError<ET> {
 
 pub async fn run<DT, ET>(
     config: Arc<Config<DT, ET>>,
-    worker: BoxedWorker<DT, ET>,
+    worker: BoxedProcessable<ET>,
     envelope: &JobEnvelope,
-    ctx: ContextValue<DT>,
 ) -> Result<Result<(), ExecutionError<ET>>, OxanusError>
 where
     DT: Send + Sync + Clone + 'static,
@@ -38,8 +37,7 @@ where
         "Job started"
     );
     let start = std::time::Instant::now();
-    let full_ctx = Context {
-        ctx: ctx.0,
+    let job_ctx = JobContext {
         meta: envelope.meta.clone(),
         state: JobState::new(
             config.storage.clone(),
@@ -48,8 +46,7 @@ where
         ),
     };
 
-    // Process the job and handle panics
-    let result = match AssertUnwindSafe(process(&worker, full_ctx, &envelope))
+    let result = match AssertUnwindSafe(process(&worker, job_ctx, &envelope))
         .catch_unwind()
         .await
     {
@@ -126,20 +123,19 @@ where
     latency_ms = envelope.meta.latency_millis(),
     success,
 )))]
-async fn process<DT, ET>(
-    worker: &BoxedWorker<DT, ET>,
-    full_ctx: Context<DT>,
+async fn process<ET>(
+    worker: &BoxedProcessable<ET>,
+    job_ctx: JobContext,
     #[cfg_attr(not(feature = "tracing-instrument"), allow(unused_variables))]
     envelope: &JobEnvelope,
 ) -> Result<(), ET>
 where
-    DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
     #[cfg(feature = "tracing-instrument")]
     let span = tracing::Span::current();
 
-    let result = worker.process(&full_ctx).await;
+    let result = worker.process(&job_ctx).await;
 
     #[cfg(feature = "tracing-instrument")]
     span.record("success", result.is_ok());

--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -30,15 +30,19 @@ pub struct JobMeta {
     pub id: JobId,
     pub retries: u32,
     pub unique: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on_conflict: Option<JobConflictStrategy>,
     pub created_at: i64,
     #[serde(default)]
     pub scheduled_at: i64,
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<serde_json::Value>,
     #[serde(default = "default_resurrect")]
     pub resurrect: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
@@ -85,6 +89,7 @@ impl JobEnvelope {
                 started_at: None,
                 state: None,
                 resurrect,
+                error: None,
             },
         })
     }
@@ -113,11 +118,12 @@ impl JobEnvelope {
                 started_at: None,
                 state: None,
                 resurrect,
+                error: None,
             },
         })
     }
 
-    pub(crate) fn with_retries_incremented(self) -> Self {
+    pub(crate) fn with_retries_incremented(self, error: String) -> Self {
         Self {
             id: self.id.clone(),
             queue: self.queue,
@@ -132,8 +138,14 @@ impl JobEnvelope {
                 started_at: None,
                 state: self.meta.state,
                 resurrect: self.meta.resurrect,
+                error: Some(error),
             },
         }
+    }
+
+    pub(crate) fn with_error(mut self, error: String) -> Self {
+        self.meta.error = Some(error);
+        self
     }
 }
 
@@ -206,6 +218,7 @@ mod tests {
             started_at,
             state: None,
             resurrect: true,
+            error: None,
         }
     }
 
@@ -277,12 +290,14 @@ mod tests {
                 started_at: Some(2_000_000),
                 state: None,
                 resurrect: true,
+                error: None,
             },
         };
 
-        let retried = envelope.with_retries_incremented();
+        let retried = envelope.with_retries_incremented("something went wrong".to_string());
         assert_eq!(retried.meta.retries, 1);
         assert!(retried.meta.started_at.is_none());
+        assert_eq!(retried.meta.error.as_deref(), Some("something went wrong"));
     }
 
     #[test]
@@ -301,5 +316,6 @@ mod tests {
         let meta: JobMeta =
             serde_json::from_str(json).expect("should deserialize without started_at");
         assert!(meta.started_at.is_none());
+        assert!(meta.error.is_none());
     }
 }

--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::any::type_name;
 use uuid::Uuid;
 
-use crate::{OxanusError, Worker};
+use crate::OxanusError;
+use crate::worker::Job as JobTrait;
 
 pub type JobId = String;
 
@@ -54,13 +54,8 @@ pub enum JobConflictStrategy {
 }
 
 impl JobEnvelope {
-    pub(crate) fn new<T, DT, ET>(queue: String, job: T) -> Result<Self, OxanusError>
-    where
-        T: Worker<Context = DT, Error = ET> + serde::Serialize,
-        DT: Send + Sync + Clone + 'static,
-        ET: std::error::Error + Send + Sync + 'static,
-    {
-        let job_name = type_name::<T>().to_string();
+    pub(crate) fn new<T: JobTrait>(queue: String, job: T) -> Result<Self, OxanusError> {
+        let job_name = T::worker_name().to_string();
         let unique_id = job.unique_id();
         let unique = unique_id.is_some();
         let resurrect = T::should_resurrect();

--- a/oxanus/src/launcher.rs
+++ b/oxanus/src/launcher.rs
@@ -27,16 +27,14 @@ use crate::worker_registry::CronJob;
 ///
 /// # Examples
 ///
-/// ```rust
-/// use oxanus::{Config, Context, Storage, Queue, Worker};
+/// ```rust,ignore
+/// use oxanus::{ContextValue, Config, Storage};
 ///
 /// async fn run_worker() -> Result<(), oxanus::OxanusError> {
-///     let ctx = Context::value(MyContext {});
-///     let storage = Storage::builder().from_env()?.build()?;
+///     let ctx = ContextValue::new(MyContext {});
+///     let storage = Storage::builder().build_from_env()?;
 ///
 ///     let config = Config::new(&storage)
-///         .register_queue::<MyQueue>()
-///         .register_worker::<MyWorker>()
 ///         .with_graceful_shutdown(tokio::signal::ctrl_c());
 ///
 ///     let stats = oxanus::run(config, ctx).await?;

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -75,6 +75,7 @@
 )]
 #![allow(clippy::unused_self, clippy::single_match_else, clippy::todo)]
 
+mod batch_processor;
 mod config;
 mod context;
 mod coordinator;
@@ -107,6 +108,7 @@ pub mod prometheus;
 #[cfg(test)]
 mod test_helper;
 
+pub use crate::batch_processor::{BatchProcessor, BatchProcessorConfig, batch_factory};
 pub use crate::config::Config;
 pub use crate::context::{Context, JobState};
 pub use crate::drainer::drain;
@@ -125,4 +127,4 @@ pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_factory};
 pub use registry::*;
 
 #[cfg(feature = "macros")]
-pub use oxanus_macros::{Queue, Registry, Worker};
+pub use oxanus_macros::{BatchProcessor, Queue, Registry, Worker};

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -110,7 +110,7 @@ mod test_helper;
 
 pub use crate::batch_processor::{BatchProcessor, BatchProcessorConfig, batch_factory};
 pub use crate::config::Config;
-pub use crate::context::{Context, JobState};
+pub use crate::context::{ContextValue, JobContext, JobState};
 pub use crate::drainer::drain;
 pub use crate::error::OxanusError;
 pub use crate::job_envelope::{JobConflictStrategy, JobEnvelope, JobId, JobMeta};
@@ -120,7 +120,7 @@ pub use crate::stats::*;
 pub use crate::storage::Storage;
 pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};
 pub use crate::storage_types::*;
-pub use crate::worker::Worker;
+pub use crate::worker::{BoxedProcessable, FromContext, Job, Processable, Worker};
 pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_factory};
 
 #[cfg(feature = "registry")]

--- a/oxanus/src/registry.rs
+++ b/oxanus/src/registry.rs
@@ -1,4 +1,7 @@
-use crate::{Config, QueueConfig, Storage, worker_registry::WorkerConfig};
+use crate::{
+    Config, QueueConfig, Storage, batch_processor::BatchProcessorConfig,
+    worker_registry::WorkerConfig,
+};
 
 pub struct ComponentRegistry<DT, ET> {
     /// `module_path!()`
@@ -11,6 +14,7 @@ pub struct ComponentRegistry<DT, ET> {
 pub enum ComponentDefinition<DT, ET> {
     Queue(QueueConfig),
     Worker(WorkerConfig<DT, ET>),
+    BatchProcessor(BatchProcessorConfig<DT, ET>),
 }
 
 /// Macro to create a component registry
@@ -41,6 +45,9 @@ where
             match (component.definition)() {
                 ComponentDefinition::Queue(q) => config.register_queue_with(q),
                 ComponentDefinition::Worker(w) => config.register_worker_with(w),
+                ComponentDefinition::BatchProcessor(b) => {
+                    config.register_batch_processor_with(b);
+                }
             }
         }
         config

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -40,16 +40,66 @@ pub struct Storage {
 
 impl Storage {
     /// Creates a new [`StorageBuilder`] for configuring and building a Storage instance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use oxanus::Storage;
+    ///
+    /// let storage = Storage::builder().build_from_env()?;
+    /// ```
     pub fn builder() -> StorageBuilder {
         StorageBuilder::new()
     }
 
     /// Enqueues a job to be processed immediately.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to enqueue the job to
+    /// * `job` - The job to enqueue
+    ///
+    /// # Returns
+    ///
+    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use oxanus::Storage;
+    ///
+    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
+    ///     let job_id = storage.enqueue(MyQueue, MyJob { data: "hello".into() }).await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn enqueue(&self, queue: impl Queue, job: impl Job) -> Result<JobId, OxanusError> {
         self.enqueue_in(queue, job, 0).await
     }
 
-    /// Enqueues a job to be processed after a specified delay in seconds.
+    /// Enqueues a job to be processed after a specified delay.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to enqueue the job to
+    /// * `job` - The job to enqueue
+    /// * `delay` - The delay in seconds before the job should be processed
+    ///
+    /// # Returns
+    ///
+    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use oxanus::Storage;
+    ///
+    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
+    ///     // Schedule a job to run in 5 minutes
+    ///     let job_id = storage.enqueue_in(MyQueue, MyJob { data: "delayed".into() }, 300).await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn enqueue_in(
         &self,
         queue: impl Queue,
@@ -68,6 +118,29 @@ impl Storage {
     }
 
     /// Schedules a job to run at a specific time.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to enqueue the job to
+    /// * `job` - The job to enqueue
+    /// * `time` - The UTC timestamp when the job should become available
+    ///
+    /// # Returns
+    ///
+    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use chrono::{Duration, Utc};
+    /// use oxanus::Storage;
+    ///
+    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
+    ///     let time = Utc::now() + Duration::minutes(5);
+    ///     let job_id = storage.enqueue_at(MyQueue, MyJob { data: "scheduled".into() }, time).await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn enqueue_at(
         &self,
         queue: impl Queue,
@@ -82,11 +155,23 @@ impl Storage {
     }
 
     /// Returns the number of jobs currently enqueued in the specified queue.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to count jobs for
     pub async fn enqueued_count(&self, queue: impl Queue) -> Result<usize, OxanusError> {
         self.internal.enqueued_count(&queue.key()).await
     }
 
-    /// Returns the latency of the queue (The age of the oldest job in the queue).
+    /// Returns the latency of the queue (the age of the oldest job in the queue).
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to get the latency for
+    ///
+    /// # Returns
+    ///
+    /// The latency of the queue in milliseconds, or an [`OxanusError`] if the operation fails.
     pub async fn latency_ms(&self, queue: impl Queue) -> Result<f64, OxanusError> {
         self.internal.latency_ms(&queue.key()).await
     }
@@ -112,6 +197,12 @@ impl Storage {
     }
 
     /// Deletes a job by its ID.
+    ///
+    /// Removes the job from both the job store and the processing queue.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the job to delete
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanusError> {
         self.internal.delete_job(id).await
     }
@@ -132,6 +223,11 @@ impl Storage {
     }
 
     /// Returns a list of jobs currently enqueued in the specified queue.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to list jobs from
+    /// * `opts` - Pagination options controlling count and offset
     pub async fn list_queue_jobs(
         &self,
         queue: impl Queue,
@@ -141,11 +237,19 @@ impl Storage {
     }
 
     /// Returns a list of dead jobs.
+    ///
+    /// # Arguments
+    ///
+    /// * `opts` - Pagination options controlling count and offset
     pub async fn list_dead(&self, opts: &QueueListOpts) -> Result<Vec<JobEnvelope>, OxanusError> {
         self.internal.list_dead(opts).await
     }
 
     /// Returns a list of jobs pending retry.
+    ///
+    /// # Arguments
+    ///
+    /// * `opts` - Pagination options controlling count and offset
     pub async fn list_retries(
         &self,
         opts: &QueueListOpts,
@@ -154,6 +258,10 @@ impl Storage {
     }
 
     /// Returns a list of jobs scheduled for future execution.
+    ///
+    /// # Arguments
+    ///
+    /// * `opts` - Pagination options controlling count and offset
     pub async fn list_scheduled(
         &self,
         opts: &QueueListOpts,
@@ -162,11 +270,28 @@ impl Storage {
     }
 
     /// Removes all jobs from the specified queue.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to wipe
     pub async fn wipe_queue(&self, queue: impl Queue) -> Result<(), OxanusError> {
         self.internal.wipe_queue(&queue.key()).await
     }
 
     /// Returns Prometheus metrics based on the current stats.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use oxanus::Storage;
+    ///
+    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
+    ///     let metrics = storage.metrics().await?;
+    ///     let output = metrics.encode_to_string()?;
+    ///     println!("{}", output);
+    ///     Ok(())
+    /// }
+    /// ```
     #[cfg(feature = "prometheus")]
     pub async fn metrics(&self) -> Result<PrometheusMetrics, OxanusError> {
         let stats = self.stats().await?;

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -8,7 +8,7 @@ use crate::{
     storage_builder::StorageBuilder,
     storage_internal::StorageInternal,
     storage_types::QueueListOpts,
-    worker::Worker,
+    worker::Job,
 };
 
 #[cfg(feature = "prometheus")]
@@ -21,17 +21,14 @@ use crate::prometheus::PrometheusMetrics;
 ///
 /// # Examples
 ///
-/// ```rust
-/// use oxanus::{Storage, Queue, Worker};
+/// ```rust,ignore
+/// use oxanus::Storage;
 ///
 /// async fn example() -> Result<(), oxanus::OxanusError> {
-///     let storage = Storage::builder().from_env()?.build()?;
+///     let storage = Storage::builder().build_from_env()?;
 ///
-///     // Enqueue a job
-///     storage.enqueue(MyQueue, MyWorker { data: "hello" }).await?;
-///
-///     // Schedule a job for later
-///     storage.enqueue_in(MyQueue, MyWorker { data: "delayed" }, 300).await?;
+///     storage.enqueue(MyQueue, MyJob { data: "hello" }).await?;
+///     storage.enqueue_in(MyQueue, MyJob { data: "delayed" }, 300).await?;
 ///
 ///     Ok(())
 /// }
@@ -43,83 +40,22 @@ pub struct Storage {
 
 impl Storage {
     /// Creates a new [`StorageBuilder`] for configuring and building a Storage instance.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use oxanus::Storage;
-    ///
-    /// let builder = Storage::builder();
-    /// let storage = builder.from_env()?.build()?;
-    /// ```
     pub fn builder() -> StorageBuilder {
         StorageBuilder::new()
     }
 
     /// Enqueues a job to be processed immediately.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to enqueue the job to
-    /// * `job` - The job to enqueue
-    ///
-    /// # Returns
-    ///
-    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use oxanus::{Storage, Queue, Worker};
-    ///
-    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
-    ///     let job_id = storage.enqueue(MyQueue, MyWorker { data: "hello" }).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn enqueue<T, DT, ET>(&self, queue: impl Queue, job: T) -> Result<JobId, OxanusError>
-    where
-        T: Worker<Context = DT, Error = ET> + serde::Serialize,
-        DT: Send + Sync + Clone + 'static,
-        ET: std::error::Error + Send + Sync + 'static,
-    {
+    pub async fn enqueue(&self, queue: impl Queue, job: impl Job) -> Result<JobId, OxanusError> {
         self.enqueue_in(queue, job, 0).await
     }
 
-    /// Enqueues a job to be processed after a specified delay.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to enqueue the job to
-    /// * `job` - The job to enqueue
-    /// * `delay` - The delay in seconds before the job should be processed
-    ///
-    /// # Returns
-    ///
-    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use oxanus::{Storage, Queue, Worker};
-    ///
-    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
-    ///     // Schedule a job to run in 5 minutes
-    ///     let job_id = storage.enqueue_in(MyQueue, MyWorker { data: "delayed" }, 300).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn enqueue_in<T, DT, ET>(
+    /// Enqueues a job to be processed after a specified delay in seconds.
+    pub async fn enqueue_in(
         &self,
         queue: impl Queue,
-        job: T,
+        job: impl Job,
         delay: u64,
-    ) -> Result<JobId, OxanusError>
-    where
-        T: Worker<Context = DT, Error = ET> + serde::Serialize,
-        DT: Send + Sync + Clone + 'static,
-        ET: std::error::Error + Send + Sync + 'static,
-    {
+    ) -> Result<JobId, OxanusError> {
         let envelope = JobEnvelope::new(queue.key().clone(), job)?;
 
         tracing::trace!("Enqueuing job: {:?}", envelope);
@@ -132,40 +68,12 @@ impl Storage {
     }
 
     /// Schedules a job to run at a specific time.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to enqueue the job to
-    /// * `job` - The job to enqueue
-    /// * `time` - The UTC timestamp when the job should become available
-    ///
-    /// # Returns
-    ///
-    /// A [`JobId`] that can be used to track the job, or an [`OxanusError`] if the operation fails.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use chrono::{Duration, Utc};
-    /// use oxanus::{Storage, Queue, Worker};
-    ///
-    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
-    ///     let time = Utc::now() + Duration::minutes(5);
-    ///     let job_id = storage.enqueue_at(MyQueue, MyWorker { data: "scheduled" }, time).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn enqueue_at<T, DT, ET>(
+    pub async fn enqueue_at(
         &self,
         queue: impl Queue,
-        job: T,
+        job: impl Job,
         time: DateTime<Utc>,
-    ) -> Result<JobId, OxanusError>
-    where
-        T: Worker<Context = DT, Error = ET> + serde::Serialize,
-        DT: Send + Sync + Clone + 'static,
-        ET: std::error::Error + Send + Sync + 'static,
-    {
+    ) -> Result<JobId, OxanusError> {
         let envelope = JobEnvelope::new(queue.key().clone(), job)?;
 
         tracing::trace!("Scheduling job {:?} at {}", envelope, time);
@@ -174,119 +82,56 @@ impl Storage {
     }
 
     /// Returns the number of jobs currently enqueued in the specified queue.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to count jobs for
-    ///
-    /// # Returns
-    ///
-    /// The number of enqueued jobs, or an [`OxanusError`] if the operation fails.
     pub async fn enqueued_count(&self, queue: impl Queue) -> Result<usize, OxanusError> {
         self.internal.enqueued_count(&queue.key()).await
     }
 
     /// Returns the latency of the queue (The age of the oldest job in the queue).
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to get the latency for
-    ///
-    /// # Returns
-    ///
-    /// The latency of the queue in milliseconds, or an [`OxanusError`] if the operation fails.
     pub async fn latency_ms(&self, queue: impl Queue) -> Result<f64, OxanusError> {
         self.internal.latency_ms(&queue.key()).await
     }
 
     /// Returns the number of jobs that have failed and moved to the dead queue.
-    ///
-    /// # Returns
-    ///
-    /// The number of dead jobs, or an [`OxanusError`] if the operation fails.
     pub async fn dead_count(&self) -> Result<usize, OxanusError> {
         self.internal.dead_count().await
     }
 
     /// Returns the number of jobs that are currently being retried.
-    ///
-    /// # Returns
-    ///
-    /// The number of retrying jobs, or an [`OxanusError`] if the operation fails.
     pub async fn retries_count(&self) -> Result<usize, OxanusError> {
         self.internal.retries_count().await
     }
 
     /// Returns the number of jobs that are scheduled for future execution.
-    ///
-    /// # Returns
-    ///
-    /// The number of scheduled jobs, or an [`OxanusError`] if the operation fails.
     pub async fn scheduled_count(&self) -> Result<usize, OxanusError> {
         self.internal.scheduled_count().await
     }
 
     /// Returns the number of jobs that are currently enqueued or scheduled for future execution.
-    ///
-    /// # Returns
-    ///
-    /// The number of jobs, or an [`OxanusError`] if the operation fails.
     pub async fn jobs_count(&self) -> Result<usize, OxanusError> {
         self.internal.jobs_count().await
     }
 
     /// Deletes a job by its ID.
-    ///
-    /// Removes the job from both the job store and the processing queue.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The ID of the job to delete
-    ///
-    /// # Returns
-    ///
-    /// An [`OxanusError`] if the operation fails.
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanusError> {
         self.internal.delete_job(id).await
     }
 
     /// Returns the stats for all queues.
-    ///
-    /// # Returns
-    ///
-    /// The stats for all queues, or an [`OxanusError`] if the operation fails.
     pub async fn stats(&self) -> Result<Stats, OxanusError> {
         self.internal.stats().await
     }
 
     /// Returns the list of processes that are currently running.
-    ///
-    /// # Returns
-    ///
-    /// The list of processes, or an [`OxanusError`] if the operation fails.
     pub async fn processes(&self) -> Result<Vec<Process>, OxanusError> {
         self.internal.processes().await
     }
 
     /// Returns the namespace this storage instance is using.
-    ///
-    /// # Returns
-    ///
-    /// The namespace string.
     pub fn namespace(&self) -> &str {
         self.internal.namespace()
     }
 
     /// Returns a list of jobs currently enqueued in the specified queue.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to list jobs from
-    /// * `opts` - Pagination options controlling count and offset
-    ///
-    /// # Returns
-    ///
-    /// A vector of [`JobEnvelope`]s, or an [`OxanusError`] if the operation fails.
     pub async fn list_queue_jobs(
         &self,
         queue: impl Queue,
@@ -296,27 +141,11 @@ impl Storage {
     }
 
     /// Returns a list of dead jobs.
-    ///
-    /// # Arguments
-    ///
-    /// * `opts` - Pagination options controlling count and offset
-    ///
-    /// # Returns
-    ///
-    /// A vector of [`JobEnvelope`]s, or an [`OxanusError`] if the operation fails.
     pub async fn list_dead(&self, opts: &QueueListOpts) -> Result<Vec<JobEnvelope>, OxanusError> {
         self.internal.list_dead(opts).await
     }
 
     /// Returns a list of jobs pending retry.
-    ///
-    /// # Arguments
-    ///
-    /// * `opts` - Pagination options controlling count and offset
-    ///
-    /// # Returns
-    ///
-    /// A vector of [`JobEnvelope`]s, or an [`OxanusError`] if the operation fails.
     pub async fn list_retries(
         &self,
         opts: &QueueListOpts,
@@ -325,14 +154,6 @@ impl Storage {
     }
 
     /// Returns a list of jobs scheduled for future execution.
-    ///
-    /// # Arguments
-    ///
-    /// * `opts` - Pagination options controlling count and offset
-    ///
-    /// # Returns
-    ///
-    /// A vector of [`JobEnvelope`]s, or an [`OxanusError`] if the operation fails.
     pub async fn list_scheduled(
         &self,
         opts: &QueueListOpts,
@@ -341,37 +162,11 @@ impl Storage {
     }
 
     /// Removes all jobs from the specified queue.
-    ///
-    /// # Arguments
-    ///
-    /// * `queue` - The queue to wipe
-    ///
-    /// # Returns
-    ///
-    /// An [`OxanusError`] if the operation fails.
     pub async fn wipe_queue(&self, queue: impl Queue) -> Result<(), OxanusError> {
         self.internal.wipe_queue(&queue.key()).await
     }
 
     /// Returns Prometheus metrics based on the current stats.
-    ///
-    /// # Returns
-    ///
-    /// A [`PrometheusMetrics`] instance containing all current metrics,
-    /// or an [`OxanusError`] if fetching stats fails.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use oxanus::Storage;
-    ///
-    /// async fn example(storage: &Storage) -> Result<(), oxanus::OxanusError> {
-    ///     let metrics = storage.metrics().await?;
-    ///     let output = metrics.encode_to_string()?;
-    ///     println!("{}", output);
-    ///     Ok(())
-    /// }
-    /// ```
     #[cfg(feature = "prometheus")]
     pub async fn metrics(&self) -> Result<PrometheusMetrics, OxanusError> {
         let stats = self.stats().await?;

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -197,12 +197,17 @@ impl StorageInternal {
         Ok(envelope.id)
     }
 
-    pub async fn retry_in(&self, job_id: JobId, delay_s: u64) -> Result<(), OxanusError> {
+    pub async fn retry_in(
+        &self,
+        job_id: JobId,
+        delay_s: u64,
+        error: String,
+    ) -> Result<(), OxanusError> {
         let updated_envelope = self
             .get_job(&job_id)
             .await?
             .ok_or(OxanusError::JobNotFound)?
-            .with_retries_incremented();
+            .with_retries_incremented(error);
 
         let now = chrono::Utc::now().timestamp_micros() as u64;
 
@@ -337,12 +342,13 @@ impl StorageInternal {
         Ok(envelopes)
     }
 
-    pub async fn kill(&self, envelope: &JobEnvelope) -> Result<(), OxanusError> {
+    pub async fn kill(&self, envelope: &JobEnvelope, error: String) -> Result<(), OxanusError> {
+        let envelope = envelope.clone().with_error(error);
         let mut redis = self.connection().await?;
         let _: () = redis::pipe()
             .lrem(self.current_processing_queue(), 1, &envelope.id)
             .hdel(&self.keys.jobs, &envelope.id)
-            .lpush(&self.keys.dead, &serde_json::to_string(envelope)?)
+            .lpush(&self.keys.dead, &serde_json::to_string(&envelope)?)
             .ltrim(&self.keys.dead, 0, 999)
             .query_async(&mut redis)
             .await?;

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1138,22 +1138,20 @@ impl StorageInternal {
 
 #[cfg(test)]
 mod tests {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use testresult::TestResult;
 
     use super::*;
     use crate::test_helper::{random_string, redis_pool};
 
-    #[derive(Serialize)]
-    struct TestWorker {}
+    #[derive(Serialize, Deserialize)]
+    struct TestJob {}
 
-    #[async_trait::async_trait]
-    impl crate::Worker for TestWorker {
-        type Context = ();
-        type Error = std::io::Error;
+    struct TestJobWorker;
 
-        async fn process(&self, _: &crate::Context<Self::Context>) -> Result<(), Self::Error> {
-            Ok(())
+    impl crate::worker::Job for TestJob {
+        fn worker_name() -> &'static str {
+            std::any::type_name::<TestJobWorker>()
         }
     }
 
@@ -1181,7 +1179,7 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let mut envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
         let now = chrono::Utc::now();
         let actual_latency = 7777;
         envelope.meta.created_at = now.timestamp_micros() - actual_latency * 1_000;
@@ -1205,7 +1203,7 @@ mod tests {
         let latency_micros = storage.latency_micros(&queue).await?;
         assert_eq!(latency_micros, 0.0);
 
-        let mut envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
         let now = chrono::Utc::now();
         let actual_latency_ms = 7777;
         let actual_latency_micros = actual_latency_ms * 1_000;
@@ -1222,7 +1220,7 @@ mod tests {
         let latency_s = latency_micros / 1_000_000.0;
         assert!((latency_s - actual_latency_s).abs() < 0.05);
 
-        let mut envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
         let actual_latency_ms2 = 5000;
         let actual_latency_micros2 = actual_latency_ms2 * 1_000;
         envelope2.meta.created_at = now.timestamp_micros() - actual_latency_micros2;
@@ -1241,14 +1239,14 @@ mod tests {
     async fn test_cleanup() -> TestResult {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
-        let mut expired_envelope1 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut expired_envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
         expired_envelope1.meta.created_at =
             (chrono::Utc::now().timestamp() - JOB_EXPIRE_TIME - 1) * 1000000;
-        let mut expired_envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut expired_envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
         expired_envelope2.meta.created_at =
             (chrono::Utc::now().timestamp() - JOB_EXPIRE_TIME - 1) * 1000000;
 
-        let active_envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let active_envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(expired_envelope1.clone()).await?;
         storage.enqueue(expired_envelope2.clone()).await?;
@@ -1280,7 +1278,7 @@ mod tests {
     async fn test_resurrect() -> TestResult {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
-        let envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(envelope.clone()).await?;
 
@@ -1373,7 +1371,7 @@ mod tests {
     async fn test_resurrect_when_process_is_missing() -> TestResult {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
-        let envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(envelope.clone()).await?;
 
@@ -1403,9 +1401,9 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let envelope1 = JobEnvelope::new(queue.clone(), TestWorker {})?;
-        let envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
-        let envelope3 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope3 = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(envelope1.clone()).await?;
         storage.enqueue(envelope2.clone()).await?;
@@ -1435,9 +1433,9 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let envelope1 = JobEnvelope::new(queue.clone(), TestWorker {})?;
-        let envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
-        let envelope3 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope3 = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(envelope1.clone()).await?;
         storage.enqueue(envelope2.clone()).await?;
@@ -1479,8 +1477,8 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let envelope1 = JobEnvelope::new(queue.clone(), TestWorker {})?;
-        let envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
 
         storage.enqueue(envelope1.clone()).await?;
         storage.enqueue(envelope2.clone()).await?;
@@ -1503,7 +1501,7 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
         assert!(envelope.meta.started_at.is_none());
 
         storage.enqueue(envelope.clone()).await?;

--- a/oxanus/src/test_helper.rs
+++ b/oxanus/src/test_helper.rs
@@ -1,9 +1,4 @@
-use crate::{
-    Context, Storage, Worker, context::JobState, job_envelope::JobEnvelope,
-    storage_internal::StorageInternal,
-};
 use rand::distr::{Alphanumeric, SampleString};
-use serde::Serialize;
 
 pub fn random_string() -> String {
     Alphanumeric.sample_string(&mut rand::rng(), 16)
@@ -15,26 +10,7 @@ pub async fn redis_pool() -> Result<deadpool_redis::Pool, deadpool_redis::PoolEr
     let cfg = deadpool_redis::Config::from_url(redis_url);
     let pool = cfg
         .create_pool(Some(deadpool_redis::Runtime::Tokio1))
-        .unwrap();
+        .expect("Failed to create pool");
 
     Ok(pool)
-}
-
-pub async fn create_worker_context<W>(ctx: W::Context, worker: W) -> Context<W::Context>
-where
-    W: Worker + Serialize + 'static,
-{
-    let internal = StorageInternal::new(redis_pool().await.unwrap(), Some(random_string()));
-    let queue = random_string();
-    let envelope = JobEnvelope::new(queue.clone(), worker).unwrap();
-    let state = JobState::new(
-        Storage { internal },
-        envelope.id,
-        envelope.meta.state.clone(),
-    );
-    Context {
-        ctx: ctx.clone(),
-        meta: envelope.meta,
-        state,
-    }
 }

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -1,14 +1,33 @@
-use crate::{QueueConfig, WorkerConfigKind, context::Context, job_envelope::JobConflictStrategy};
-use std::panic::UnwindSafe;
+use crate::{
+    QueueConfig, WorkerConfigKind, context::JobContext, job_envelope::JobConflictStrategy,
+};
 
-pub type BoxedWorker<DT, ET> = Box<dyn Worker<Context = DT, Error = ET>>;
+pub trait Job: Send + Sync + serde::Serialize {
+    fn worker_name() -> &'static str
+    where
+        Self: Sized;
+
+    fn unique_id(&self) -> Option<String> {
+        None
+    }
+
+    fn on_conflict(&self) -> JobConflictStrategy {
+        JobConflictStrategy::Skip
+    }
+
+    fn should_resurrect() -> bool
+    where
+        Self: Sized,
+    {
+        true
+    }
+}
 
 #[async_trait::async_trait]
-pub trait Worker: Send + Sync + UnwindSafe {
-    type Context: Clone + Send + Sync;
+pub trait Worker<Args: Send + Sync>: Send + Sync {
     type Error: std::error::Error + Send + Sync;
 
-    async fn process(&self, data: &Context<Self::Context>) -> Result<(), Self::Error>;
+    async fn process(&self, job: &Args, ctx: &JobContext) -> Result<(), Self::Error>;
 
     fn max_retries(&self) -> u32 {
         2
@@ -24,14 +43,6 @@ pub trait Worker: Send + Sync + UnwindSafe {
         // 6 -> 390625 seconds
         // 7 -> 1953125 seconds
         u64::pow(5, retries + 2)
-    }
-
-    fn unique_id(&self) -> Option<String> {
-        None
-    }
-
-    fn on_conflict(&self) -> JobConflictStrategy {
-        JobConflictStrategy::Skip
     }
 
     /// 6 part cron schedule: "* * * * * *"
@@ -76,21 +87,57 @@ pub trait Worker: Send + Sync + UnwindSafe {
     }
 }
 
+pub trait FromContext<T> {
+    fn from_context(ctx: &T) -> Self;
+}
+
+#[async_trait::async_trait]
+pub trait Processable: Send + Sync {
+    type Error: std::error::Error + Send + Sync;
+
+    async fn process(&self, ctx: &JobContext) -> Result<(), Self::Error>;
+    fn max_retries(&self) -> u32;
+    fn retry_delay(&self, retries: u32) -> u64;
+}
+
+pub type BoxedProcessable<ET> = Box<dyn Processable<Error = ET>>;
+
+pub(crate) struct BoundJob<W, A> {
+    pub worker: W,
+    pub args: A,
+}
+
+#[async_trait::async_trait]
+impl<W, A> Processable for BoundJob<W, A>
+where
+    W: Worker<A> + Send + Sync + 'static,
+    A: Send + Sync + 'static,
+{
+    type Error = W::Error;
+
+    async fn process(&self, ctx: &JobContext) -> Result<(), Self::Error> {
+        self.worker.process(&self.args, ctx).await
+    }
+
+    fn max_retries(&self) -> u32 {
+        self.worker.max_retries()
+    }
+
+    fn retry_delay(&self, retries: u32) -> u64 {
+        self.worker.retry_delay(retries)
+    }
+}
+
 #[cfg(feature = "macros")]
 #[cfg(test)]
 mod tests {
-    use super::{JobConflictStrategy, Worker};
+    use super::{Job, JobConflictStrategy};
     use crate as oxanus;
-    use crate::Context;
-    use crate::test_helper::create_worker_context;
     use serde::{Deserialize, Serialize};
     use std::io::Error as WorkerError;
-    use std::sync::{Arc, Mutex}; // needed for unit test
 
     #[derive(Clone, Default)]
-    struct WorkerContext {
-        count: Arc<Mutex<usize>>,
-    }
+    struct WorkerContext {}
 
     #[derive(oxanus::Registry)]
     #[allow(dead_code)]
@@ -102,144 +149,162 @@ mod tests {
 
     #[tokio::test]
     async fn test_define_worker_with_macro() {
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
-        struct TestWorker {}
+        #[derive(Debug, Serialize, Deserialize)]
+        struct TestJobArgs {}
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = TestJobArgs)]
+        struct TestWorker;
 
         impl TestWorker {
-            async fn process(&self, ctx: &Context<WorkerContext>) -> Result<(), WorkerError> {
-                *ctx.ctx
-                    .count
-                    .lock()
-                    .map_err(|e| std::io::Error::other(e.to_string()))? += 1;
+            async fn process(
+                &self,
+                _job: &TestJobArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
             }
         }
 
-        assert_eq!(TestWorker {}.max_retries(), 2);
-        assert_eq!(TestWorker {}.on_conflict(), JobConflictStrategy::Skip);
+        assert_eq!(oxanus::Worker::<TestJobArgs>::max_retries(&TestWorker), 2);
 
-        let ctx = WorkerContext::default();
-        let context = create_worker_context(ctx.clone(), TestWorker {}).await;
+        #[derive(Debug, Serialize, Deserialize)]
+        struct TestJobArgs2 {}
 
-        Worker::process(&TestWorker {}, &context).await.unwrap();
-
-        assert_eq!(*ctx.count.lock().unwrap(), 1);
-
-        Worker::process(&TestWorker {}, &context).await.unwrap();
-
-        assert_eq!(*ctx.count.lock().unwrap(), 2);
-
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = TestJobArgs2)]
         #[oxanus(error = std::fmt::Error, registry = ComponentRegistryFmt)]
         #[oxanus(max_retries = 3, retry_delay = 10)]
         #[oxanus(on_conflict = Replace)]
-        struct TestWorkerCustomError {}
+        struct TestWorkerCustomError;
 
         impl TestWorkerCustomError {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), std::fmt::Error> {
+            async fn process(
+                &self,
+                _job: &TestJobArgs2,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), std::fmt::Error> {
                 use std::fmt::Write;
-
                 let mut s = String::new();
                 write!(&mut s, "hi")
             }
         }
 
-        assert_eq!(TestWorkerCustomError {}.unique_id(), None);
-        assert_eq!(TestWorkerCustomError {}.max_retries(), 3);
-        assert_eq!(TestWorkerCustomError {}.retry_delay(1), 10);
         assert_eq!(
-            TestWorkerCustomError {}.on_conflict(),
-            JobConflictStrategy::Replace
+            oxanus::Worker::<TestJobArgs2>::max_retries(&TestWorkerCustomError),
+            3
         );
+        assert_eq!(
+            oxanus::Worker::<TestJobArgs2>::retry_delay(&TestWorkerCustomError, 1),
+            10
+        );
+        assert_eq!(TestJobArgs2 {}.on_conflict(), JobConflictStrategy::Replace);
 
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
-        #[oxanus(unique_id = "test_worker_{id}")]
-        struct TestWorkerUniqueId {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct UniqueJobArgs {
             id: i32,
             _1: i32,
         }
 
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = UniqueJobArgs)]
+        #[oxanus(unique_id = "test_worker_{id}")]
+        struct TestWorkerUniqueId;
+
         impl TestWorkerUniqueId {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
-                Ok(())
-            }
-        }
-
-        assert_eq!(TestWorkerUniqueId { id: 1, _1: 0 }.max_retries(), 2);
-        assert_eq!(
-            TestWorkerUniqueId { id: 1, _1: 0 }.unique_id().unwrap(),
-            "test_worker_1"
-        );
-        assert_eq!(
-            TestWorkerUniqueId { id: 12, _1: 0 }.unique_id().unwrap(),
-            "test_worker_12"
-        );
-
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
-        #[oxanus(unique_id(fmt = "test_worker_{id}_{task}", id = self.id, task = self.task.name))]
-        struct TestWorkerNestedUniqueId {
-            id: i32,
-            task: TestWorkerNestedTask,
-        }
-
-        #[derive(Serialize, Deserialize, Default)]
-        struct TestWorkerNestedTask {
-            name: String,
-        }
-
-        impl TestWorkerNestedUniqueId {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+            async fn process(
+                &self,
+                _job: &UniqueJobArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
             }
         }
 
         assert_eq!(
-            TestWorkerNestedUniqueId {
-                id: 1,
-                task: Default::default()
-            }
-            .max_retries(),
+            oxanus::Worker::<UniqueJobArgs>::max_retries(&TestWorkerUniqueId),
             2
         );
         assert_eq!(
-            TestWorkerNestedUniqueId {
-                id: 1,
-                task: TestWorkerNestedTask {
-                    name: "task1".to_owned(),
-                }
-            }
-            .unique_id()
-            .unwrap(),
-            "test_worker_1_task1"
+            oxanus::Job::unique_id(&UniqueJobArgs { id: 1, _1: 0 }),
+            Some("test_worker_1".to_string())
         );
         assert_eq!(
-            TestWorkerNestedUniqueId {
-                id: 2,
-                task: TestWorkerNestedTask {
-                    name: "task2".to_owned(),
-                }
-            }
-            .unique_id()
-            .unwrap(),
-            "test_worker_2_task2"
+            oxanus::Job::unique_id(&UniqueJobArgs { id: 12, _1: 0 }),
+            Some("test_worker_12".to_string())
         );
 
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
+        #[derive(Debug, Serialize, Deserialize, Default)]
+        struct NestedTask {
+            name: String,
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct NestedUniqueJobArgs {
+            id: i32,
+            task: NestedTask,
+        }
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = NestedUniqueJobArgs)]
+        #[oxanus(unique_id(fmt = "test_worker_{id}_{task}", id = self.id, task = self.task.name))]
+        struct TestWorkerNestedUniqueId;
+
+        impl TestWorkerNestedUniqueId {
+            async fn process(
+                &self,
+                _job: &NestedUniqueJobArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        assert_eq!(
+            oxanus::Job::unique_id(&NestedUniqueJobArgs {
+                id: 1,
+                task: NestedTask {
+                    name: "task1".to_owned(),
+                }
+            }),
+            Some("test_worker_1_task1".to_string())
+        );
+        assert_eq!(
+            oxanus::Job::unique_id(&NestedUniqueJobArgs {
+                id: 2,
+                task: NestedTask {
+                    name: "task2".to_owned(),
+                }
+            }),
+            Some("test_worker_2_task2".to_string())
+        );
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct CustomUniqueJobArgs {
+            id: i32,
+            task: NestedTask,
+        }
+
+        impl CustomUniqueJobArgs {
+            fn unique_id(&self) -> Option<String> {
+                Some(format!("worker_id_{}_task_{}", self.id, self.task.name))
+            }
+        }
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = CustomUniqueJobArgs)]
         #[oxanus(unique_id = Self::unique_id)]
         #[oxanus(retry_delay = Self::retry_delay)]
         #[oxanus(max_retries = Self::max_retries)]
-        struct TestWorkerCustomUniqueId {
-            id: i32,
-            task: TestWorkerNestedTask,
-        }
+        struct TestWorkerCustomUniqueId;
 
         impl TestWorkerCustomUniqueId {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+            async fn process(
+                &self,
+                _job: &CustomUniqueJobArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
-            }
-
-            fn unique_id(&self) -> Option<String> {
-                Some(format!("worker_id_{}_task_{}", self.id, self.task.name))
             }
 
             fn retry_delay(&self, retries: u32) -> u64 {
@@ -252,53 +317,75 @@ mod tests {
         }
 
         assert_eq!(
-            Worker::unique_id(&TestWorkerCustomUniqueId {
+            oxanus::Job::unique_id(&CustomUniqueJobArgs {
                 id: 1,
-                task: TestWorkerNestedTask {
+                task: NestedTask {
                     name: "11".to_owned(),
                 }
-            })
-            .unwrap(),
-            "worker_id_1_task_11"
+            }),
+            Some("worker_id_1_task_11".to_string())
         );
-        let worker2 = TestWorkerCustomUniqueId {
+        let job2 = CustomUniqueJobArgs {
             id: 2,
-            task: TestWorkerNestedTask {
+            task: NestedTask {
                 name: "22".to_owned(),
             },
         };
-        assert_eq!(Worker::unique_id(&worker2).unwrap(), "worker_id_2_task_22");
-        assert_eq!(worker2.retry_delay(1), 2);
-        assert_eq!(worker2.retry_delay(2), 4);
-        assert_eq!(worker2.max_retries(), 9);
+        assert_eq!(
+            oxanus::Job::unique_id(&job2),
+            Some("worker_id_2_task_22".to_string())
+        );
+        let worker = TestWorkerCustomUniqueId;
+        assert_eq!(
+            oxanus::Worker::<CustomUniqueJobArgs>::retry_delay(&worker, 1),
+            2
+        );
+        assert_eq!(
+            oxanus::Worker::<CustomUniqueJobArgs>::retry_delay(&worker, 2),
+            4
+        );
+        assert_eq!(
+            oxanus::Worker::<CustomUniqueJobArgs>::max_retries(&worker),
+            9
+        );
     }
 
     #[tokio::test]
     async fn test_define_cron_worker_with_macro() {
-        use crate as oxanus; // needed for unit test
+        use crate as oxanus;
         use crate::Queue;
         use std::io::Error as WorkerError;
 
         #[derive(Serialize, oxanus::Queue)]
         struct DefaultQueue;
 
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
+        #[derive(Debug, Serialize, Deserialize)]
+        struct CronArgs {}
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = CronArgs)]
         #[oxanus(cron(schedule = "*/1 * * * * *", queue = DefaultQueue))]
-        struct TestCronWorker {}
+        struct TestCronWorker;
 
         impl TestCronWorker {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+            async fn process(
+                &self,
+                _job: &CronArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
             }
         }
 
-        assert_eq!(TestCronWorker {}.unique_id(), None);
-        assert_eq!(TestCronWorker::cron_schedule().unwrap(), "*/1 * * * * *");
         assert_eq!(
-            TestCronWorker::cron_queue_config().unwrap(),
-            DefaultQueue::to_config(),
+            <TestCronWorker as oxanus::Worker<CronArgs>>::cron_schedule(),
+            Some("*/1 * * * * *".to_string())
         );
-        assert!(TestCronWorker::should_resurrect());
+        assert_eq!(
+            <TestCronWorker as oxanus::Worker<CronArgs>>::cron_queue_config(),
+            Some(DefaultQueue::to_config()),
+        );
+        assert!(<TestCronWorker as oxanus::Worker<CronArgs>>::should_resurrect());
     }
 
     #[tokio::test]
@@ -306,27 +393,45 @@ mod tests {
         use crate as oxanus;
         use std::io::Error as WorkerError;
 
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
+        #[derive(Debug, Serialize, Deserialize)]
+        struct NoResurrectArgs {}
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = NoResurrectArgs)]
         #[oxanus(resurrect = false)]
-        struct NoResurrectWorker {}
+        struct NoResurrectWorker;
 
         impl NoResurrectWorker {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+            async fn process(
+                &self,
+                _job: &NoResurrectArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
             }
         }
 
-        assert!(!NoResurrectWorker::should_resurrect());
+        assert!(!<NoResurrectWorker as oxanus::Worker<NoResurrectArgs>>::should_resurrect());
 
-        #[derive(Serialize, Deserialize, oxanus::Worker)]
-        struct DefaultResurrectWorker {}
+        #[derive(Debug, Serialize, Deserialize)]
+        struct DefaultResurrectArgs {}
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(args = DefaultResurrectArgs)]
+        struct DefaultResurrectWorker;
 
         impl DefaultResurrectWorker {
-            async fn process(&self, _: &Context<WorkerContext>) -> Result<(), WorkerError> {
+            async fn process(
+                &self,
+                _job: &DefaultResurrectArgs,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
                 Ok(())
             }
         }
 
-        assert!(DefaultResurrectWorker::should_resurrect());
+        assert!(<DefaultResurrectWorker as oxanus::Worker<
+            DefaultResurrectArgs,
+        >>::should_resurrect());
     }
 }

--- a/oxanus/src/worker_registry.rs
+++ b/oxanus/src/worker_registry.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use std::{any::type_name, collections::HashMap};
 
+use crate::batch_processor::BatchProcessorConfig;
 use crate::error::OxanusError;
 use crate::worker::Worker;
 
@@ -10,6 +11,7 @@ type JobFactory<DT, ET> = fn(serde_json::Value) -> Result<BoxedJob<DT, ET>, Oxan
 pub struct WorkerRegistry<DT, ET> {
     jobs: HashMap<String, JobFactory<DT, ET>>,
     pub schedules: HashMap<String, CronJob>,
+    pub batch_configs: HashMap<String, BatchProcessorConfig<DT, ET>>,
 }
 
 pub struct WorkerConfig<DT, ET> {
@@ -50,6 +52,7 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
         Self {
             jobs: HashMap::new(),
             schedules: HashMap::new(),
+            batch_configs: HashMap::new(),
         }
     }
 
@@ -114,6 +117,15 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
                 );
             }
         }
+    }
+
+    pub fn register_batch_processor_with(&mut self, config: BatchProcessorConfig<DT, ET>) {
+        self.batch_configs
+            .insert(config.worker_name.clone(), config);
+    }
+
+    pub fn get_batch_config(&self, worker_name: &str) -> Option<&BatchProcessorConfig<DT, ET>> {
+        self.batch_configs.get(worker_name)
     }
 
     pub fn worker_names(&self) -> Vec<&str> {

--- a/oxanus/src/worker_registry.rs
+++ b/oxanus/src/worker_registry.rs
@@ -1,12 +1,12 @@
+use std::collections::HashMap;
 use std::str::FromStr;
-use std::{any::type_name, collections::HashMap};
 
 use crate::batch_processor::BatchProcessorConfig;
 use crate::error::OxanusError;
-use crate::worker::Worker;
+use crate::worker::{BoundJob, BoxedProcessable, FromContext, Worker};
 
-type BoxedJob<DT, ET> = Box<dyn Worker<Context = DT, Error = ET>>;
-type JobFactory<DT, ET> = fn(serde_json::Value) -> Result<BoxedJob<DT, ET>, OxanusError>;
+pub(crate) type JobFactory<DT, ET> =
+    fn(serde_json::Value, &DT) -> Result<BoxedProcessable<ET>, OxanusError>;
 
 pub struct WorkerRegistry<DT, ET> {
     jobs: HashMap<String, JobFactory<DT, ET>>,
@@ -36,15 +36,19 @@ pub struct CronJob {
     pub resurrect: bool,
 }
 
-pub fn job_factory<
-    T: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
-    DT,
-    ET,
->(
+pub fn job_factory<W, A, DT, ET>(
     value: serde_json::Value,
-) -> Result<BoxedJob<DT, ET>, OxanusError> {
-    let job: T = serde_json::from_value(value)?;
-    Ok(Box::new(job))
+    ctx: &DT,
+) -> Result<BoxedProcessable<ET>, OxanusError>
+where
+    W: Worker<A, Error = ET> + FromContext<DT> + 'static,
+    A: serde::de::DeserializeOwned + Send + Sync + 'static,
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let args: A = serde_json::from_value(value)?;
+    let worker = W::from_context(ctx);
+    Ok(Box::new(BoundJob { worker, args }))
 }
 
 impl<DT, ET> WorkerRegistry<DT, ET> {
@@ -54,39 +58,6 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
             schedules: HashMap::new(),
             batch_configs: HashMap::new(),
         }
-    }
-
-    pub fn register<T>(&mut self) -> &mut Self
-    where
-        T: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
-    {
-        let name = type_name::<T>();
-
-        self.jobs.insert(name.to_string(), job_factory::<T, DT, ET>);
-        self
-    }
-
-    pub fn register_cron<T>(&mut self, schedule: &str, queue_key: String) -> &mut Self
-    where
-        T: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
-    {
-        self.validate_cron_worker::<T>();
-
-        let name = type_name::<T>();
-        let schedule = cron::Schedule::from_str(schedule)
-            .unwrap_or_else(|_| panic!("{name}: Invalid cron schedule: {schedule}"));
-
-        self.register::<T>();
-        self.schedules.insert(
-            name.to_string(),
-            CronJob {
-                schedule,
-                queue_key,
-                resurrect: T::should_resurrect(),
-            },
-        );
-
-        self
     }
 
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT, ET>) {
@@ -99,8 +70,6 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
                 queue_key,
                 resurrect,
             } => {
-                // we can enforce cron worker being `struct Worker {}` in macro
-
                 self.jobs.insert(config.name.clone(), config.factory);
 
                 let schedule = cron::Schedule::from_str(&schedule).unwrap_or_else(|_| {
@@ -132,46 +101,29 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
         self.jobs.keys().map(|s| s.as_str()).collect()
     }
 
-    pub fn has_registered<T>(&self) -> bool
-    where
-        T: Worker<Context = DT, Error = ET>,
-    {
-        self.jobs.contains_key(type_name::<T>())
+    pub fn has_registered(&self, name: &str) -> bool {
+        self.jobs.contains_key(name)
     }
 
-    pub fn has_registered_cron<T>(&self) -> bool
-    where
-        T: Worker<Context = DT, Error = ET>,
-    {
-        self.schedules.contains_key(type_name::<T>())
+    pub fn has_registered_cron(&self, name: &str) -> bool {
+        self.schedules.contains_key(name)
     }
 
     pub fn build(
         &self,
         name: &str,
         json: serde_json::Value,
-    ) -> Result<BoxedJob<DT, ET>, OxanusError> {
+        ctx: &DT,
+    ) -> Result<BoxedProcessable<ET>, OxanusError> {
         let factory = self
             .jobs
             .get(name)
             .ok_or_else(|| OxanusError::GenericError(format!("Job type {name} not registered")))?;
-        match factory(json) {
+        match factory(json, ctx) {
             Ok(job) => Ok(job),
             Err(e) => Err(OxanusError::JobFactoryError(format!(
                 "Failed to build job {name}: {e}"
             ))),
-        }
-    }
-
-    fn validate_cron_worker<T>(&self)
-    where
-        T: Worker<Context = DT, Error = ET> + serde::de::DeserializeOwned + 'static,
-    {
-        let name = type_name::<T>();
-        if serde_json::from_value::<T>(serde_json::json!({})).is_err() {
-            panic!(
-                "{name}: Cron worker must be deserializable from empty JSON (Don't define worker as `struct {name};`, use `struct {name} {{}}` instead)"
-            );
         }
     }
 }

--- a/oxanus/tests/integration/batch.rs
+++ b/oxanus/tests/integration/batch.rs
@@ -10,13 +10,31 @@ struct BatchComponentRegistry(oxanus::ComponentRegistry<WorkerState, WorkerError
 #[oxanus(key = "batch_test", concurrency = 1, registry = BatchComponentRegistry)]
 struct BatchQueue;
 
-#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
-#[oxanus(context = WorkerState, error = WorkerError, registry = BatchComponentRegistry)]
-struct BatchItem {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BatchItemJob {
     value: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[derive(oxanus::Worker)]
+#[oxanus(
+    args = BatchItemJob,
+    context = WorkerState,
+    error = WorkerError,
+    registry = BatchComponentRegistry
+)]
+struct BatchItemWorker;
+
+impl BatchItemWorker {
+    async fn process(
+        &self,
+        _job: &BatchItemJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+#[derive(oxanus::BatchProcessor)]
 #[oxanus(
     batch_size = 3,
     batch_linger_ms = 500,
@@ -25,16 +43,27 @@ struct BatchItem {
     registry = BatchComponentRegistry
 )]
 struct TestBatchProcessor {
-    items: Vec<BatchItem>,
+    items: Vec<BatchItemJob>,
 }
 
 impl TestBatchProcessor {
-    async fn process_batch(&self, ctx: &oxanus::Context<WorkerState>) -> Result<(), WorkerError> {
-        let mut redis = ctx.ctx.redis.get().await?;
+    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL is not set");
+        let cfg = deadpool_redis::Config::from_url(redis_url);
+        let pool = cfg
+            .create_pool(Some(deadpool_redis::Runtime::Tokio1))
+            .expect("Failed to create pool");
+        let mut redis = pool.get().await.expect("Failed to get redis conn");
         let batch_size = self.items.len() as i64;
-        let _: () = redis.rpush("batch_test:sizes", batch_size).await?;
+        let _: () = redis
+            .rpush("batch_test:sizes", batch_size)
+            .await
+            .expect("rpush failed");
         for item in &self.items {
-            let _: () = redis.rpush("batch_test:values", item.value).await?;
+            let _: () = redis
+                .rpush("batch_test:values", item.value)
+                .await
+                .expect("rpush failed");
         }
         Ok(())
     }
@@ -47,7 +76,7 @@ pub async fn test_batch() -> TestResult {
     let _: () = redis_conn.del("batch_test:sizes").await?;
     let _: () = redis_conn.del("batch_test:values").await?;
 
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
 
@@ -61,7 +90,9 @@ pub async fn test_batch() -> TestResult {
         BatchComponentRegistry::build_config(&storage).exit_when_processed(jobs_count as u64);
 
     for i in 1..=jobs_count {
-        storage.enqueue(BatchQueue, BatchItem { value: i }).await?;
+        storage
+            .enqueue(BatchQueue, BatchItemJob { value: i })
+            .await?;
     }
 
     assert_eq!(storage.enqueued_count(BatchQueue).await?, jobs_count);

--- a/oxanus/tests/integration/batch.rs
+++ b/oxanus/tests/integration/batch.rs
@@ -1,0 +1,86 @@
+use crate::shared::{WorkerError, WorkerState, random_string, setup};
+use deadpool_redis::redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use testresult::TestResult;
+
+#[derive(oxanus::Registry)]
+struct BatchComponentRegistry(oxanus::ComponentRegistry<WorkerState, WorkerError>);
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "batch_test", concurrency = 1, registry = BatchComponentRegistry)]
+struct BatchQueue;
+
+#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError, registry = BatchComponentRegistry)]
+struct BatchItem {
+    value: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::BatchProcessor)]
+#[oxanus(
+    batch_size = 3,
+    batch_linger_ms = 500,
+    context = WorkerState,
+    error = WorkerError,
+    registry = BatchComponentRegistry
+)]
+struct TestBatchProcessor {
+    items: Vec<BatchItem>,
+}
+
+impl TestBatchProcessor {
+    async fn process_batch(&self, ctx: &oxanus::Context<WorkerState>) -> Result<(), WorkerError> {
+        let mut redis = ctx.ctx.redis.get().await?;
+        let batch_size = self.items.len() as i64;
+        let _: () = redis.rpush("batch_test:sizes", batch_size).await?;
+        for item in &self.items {
+            let _: () = redis.rpush("batch_test:values", item.value).await?;
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+pub async fn test_batch() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let _: () = redis_conn.del("batch_test:sizes").await?;
+    let _: () = redis_conn.del("batch_test:values").await?;
+
+    let ctx = oxanus::Context::value(WorkerState {
+        redis: redis_pool.clone(),
+    });
+
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+
+    let jobs_count = 7;
+
+    let config =
+        BatchComponentRegistry::build_config(&storage).exit_when_processed(jobs_count as u64);
+
+    for i in 1..=jobs_count {
+        storage.enqueue(BatchQueue, BatchItem { value: i }).await?;
+    }
+
+    assert_eq!(storage.enqueued_count(BatchQueue).await?, jobs_count);
+
+    oxanus::run(config, ctx).await?;
+
+    let sizes: Vec<i64> = redis_conn.lrange("batch_test:sizes", 0, -1).await?;
+    let total: i64 = sizes.iter().sum();
+    assert_eq!(total, jobs_count as i64);
+
+    let mut sorted_sizes = sizes;
+    sorted_sizes.sort();
+    assert_eq!(sorted_sizes, vec![1, 3, 3]);
+
+    let values: Vec<String> = redis_conn.lrange("batch_test:values", 0, -1).await?;
+    assert_eq!(values.len(), jobs_count);
+
+    assert_eq!(storage.enqueued_count(BatchQueue).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}

--- a/oxanus/tests/integration/batch.rs
+++ b/oxanus/tests/integration/batch.rs
@@ -7,7 +7,7 @@ use testresult::TestResult;
 struct BatchComponentRegistry(oxanus::ComponentRegistry<WorkerState, WorkerError>);
 
 #[derive(Serialize, oxanus::Queue)]
-#[oxanus(key = "batch_test", concurrency = 1, registry = BatchComponentRegistry)]
+#[oxanus(key = "batch_test", concurrency = 3, registry = BatchComponentRegistry)]
 struct BatchQueue;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +36,7 @@ impl BatchItemWorker {
 
 #[derive(oxanus::BatchProcessor)]
 #[oxanus(
+    args = BatchItemJob,
     batch_size = 3,
     batch_linger_ms = 500,
     context = WorkerState,
@@ -43,23 +44,22 @@ impl BatchItemWorker {
     registry = BatchComponentRegistry
 )]
 struct TestBatchProcessor {
-    items: Vec<BatchItemJob>,
+    state: WorkerState,
 }
 
 impl TestBatchProcessor {
-    async fn process_batch(&self, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
-        let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL is not set");
-        let cfg = deadpool_redis::Config::from_url(redis_url);
-        let pool = cfg
-            .create_pool(Some(deadpool_redis::Runtime::Tokio1))
-            .expect("Failed to create pool");
-        let mut redis = pool.get().await.expect("Failed to get redis conn");
-        let batch_size = self.items.len() as i64;
+    async fn process_batch(
+        &self,
+        items: &[BatchItemJob],
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        let mut redis = self.state.redis.get().await.expect("Failed to get redis conn");
+        let batch_size = items.len() as i64;
         let _: () = redis
             .rpush("batch_test:sizes", batch_size)
             .await
             .expect("rpush failed");
-        for item in &self.items {
+        for item in items {
             let _: () = redis
                 .rpush("batch_test:values", item.value)
                 .await

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -5,18 +5,28 @@ use serde::{Deserialize, Serialize};
 use testresult::TestResult;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CronWorkerRedisCounter {}
+pub struct CronCounterJob {}
+
+pub struct CronCounterWorker {
+    pub state: WorkerState,
+}
+
+impl oxanus::Job for CronCounterJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<CronCounterWorker>()
+    }
+}
 
 #[async_trait::async_trait]
-impl oxanus::Worker for CronWorkerRedisCounter {
-    type Context = WorkerState;
+impl oxanus::Worker<CronCounterJob> for CronCounterWorker {
     type Error = WorkerError;
 
     async fn process(
         &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
+        _job: &CronCounterJob,
+        _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
+        let mut redis = self.state.redis.get().await?;
         let _: () = redis.incr("cron:counter", 1).await?;
         Ok(())
     }
@@ -30,13 +40,19 @@ impl oxanus::Worker for CronWorkerRedisCounter {
     }
 }
 
+impl oxanus::FromContext<WorkerState> for CronCounterWorker {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
 #[tokio::test]
 pub async fn test_cron() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
     let _: i64 = redis_conn.del("cron:counter").await?;
 
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
 
@@ -44,7 +60,7 @@ pub async fn test_cron() -> TestResult {
         .namespace(random_string())
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
-        .register_worker::<CronWorkerRedisCounter>()
+        .register_worker::<CronCounterWorker, CronCounterJob>()
         .exit_when_processed(2);
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/tests/integration/dead.rs
+++ b/oxanus/tests/integration/dead.rs
@@ -4,17 +4,21 @@ use testresult::TestResult;
 use crate::shared::*;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerFail {}
+pub struct FailJob {}
+
+pub struct FailWorker;
+
+impl oxanus::Job for FailJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<FailWorker>()
+    }
+}
 
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerFail {
-    type Context = ();
+impl oxanus::Worker<FailJob> for FailWorker {
     type Error = WorkerError;
 
-    async fn process(
-        &self,
-        oxanus::Context { .. }: &oxanus::Context<()>,
-    ) -> Result<(), WorkerError> {
+    async fn process(&self, _: &FailJob, _: &oxanus::JobContext) -> Result<(), WorkerError> {
         Err(WorkerError::Generic(
             "I have nothing to live for...".to_string(),
         ))
@@ -29,19 +33,25 @@ impl oxanus::Worker for WorkerFail {
     }
 }
 
+impl oxanus::FromContext<()> for FailWorker {
+    fn from_context(_: &()) -> Self {
+        Self
+    }
+}
+
 #[tokio::test]
 pub async fn test_dead() -> TestResult {
     let redis_pool = setup();
-    let ctx = oxanus::Context::value(());
+    let ctx = oxanus::ContextValue::new(());
     let storage = oxanus::Storage::builder()
         .namespace(random_string())
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerFail>()
+        .register_worker::<FailWorker, FailJob>()
         .exit_when_processed(1);
 
-    storage.enqueue(QueueOne, WorkerFail {}).await?;
+    storage.enqueue(QueueOne, FailJob {}).await?;
 
     assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
 

--- a/oxanus/tests/integration/drain.rs
+++ b/oxanus/tests/integration/drain.rs
@@ -23,19 +23,19 @@ impl oxanus::Queue for QueueStatic {
 #[tokio::test]
 pub async fn test_drain() -> TestResult {
     let redis_pool = setup();
-    let ctx = oxanus::Context::value(());
+    let ctx = oxanus::ContextValue::new(());
     let storage = oxanus::Storage::builder()
         .namespace(random_string())
         .build_from_pool(redis_pool)?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueDynamic>()
-        .register_worker::<WorkerNoop>()
+        .register_worker::<NoopWorker, NoopJob>()
         .exit_when_processed(2);
 
-    storage.enqueue(QueueDynamic(1), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(2), WorkerNoop {}).await?;
-    storage.enqueue(QueueStatic, WorkerNoop {}).await?;
-    storage.enqueue(QueueStatic, WorkerNoop {}).await?;
+    storage.enqueue(QueueDynamic(1), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(2), NoopJob {}).await?;
+    storage.enqueue(QueueStatic, NoopJob {}).await?;
+    storage.enqueue(QueueStatic, NoopJob {}).await?;
 
     assert_eq!(storage.jobs_count().await?, 4);
     assert_eq!(storage.enqueued_count(QueueDynamic(1)).await?, 1);

--- a/oxanus/tests/integration/dynamic.rs
+++ b/oxanus/tests/integration/dynamic.rs
@@ -14,17 +14,17 @@ impl oxanus::Queue for QueueDynamic {
 #[tokio::test]
 pub async fn test_dynamic() -> TestResult {
     let redis_pool = setup();
-    let ctx = oxanus::Context::value(());
+    let ctx = oxanus::ContextValue::new(());
     let storage = oxanus::Storage::builder()
         .namespace(random_string())
         .build_from_pool(redis_pool)?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueDynamic>()
-        .register_worker::<WorkerNoop>()
+        .register_worker::<NoopWorker, NoopJob>()
         .exit_when_processed(2);
 
-    storage.enqueue(QueueDynamic(1), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(2), WorkerNoop {}).await?;
+    storage.enqueue(QueueDynamic(1), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(2), NoopJob {}).await?;
 
     assert_eq!(storage.enqueued_count(QueueDynamic(1)).await?, 1);
     assert_eq!(storage.enqueued_count(QueueDynamic(2)).await?, 1);

--- a/oxanus/tests/integration/main.rs
+++ b/oxanus/tests/integration/main.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "macros")]
+mod batch;
 mod cron;
 mod dead;
 mod drain;

--- a/oxanus/tests/integration/panic.rs
+++ b/oxanus/tests/integration/panic.rs
@@ -3,14 +3,21 @@ use serde::{Deserialize, Serialize};
 use testresult::TestResult;
 
 #[derive(Serialize, Deserialize)]
-struct WorkerPanic {}
+struct PanicJob {}
+
+struct PanicWorker;
+
+impl oxanus::Job for PanicJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<PanicWorker>()
+    }
+}
 
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerPanic {
-    type Context = ();
+impl oxanus::Worker<PanicJob> for PanicWorker {
     type Error = std::io::Error;
 
-    async fn process(&self, _: &oxanus::Context<()>) -> Result<(), std::io::Error> {
+    async fn process(&self, _: &PanicJob, _: &oxanus::JobContext) -> Result<(), std::io::Error> {
         panic!("test panic");
     }
 
@@ -19,19 +26,25 @@ impl oxanus::Worker for WorkerPanic {
     }
 }
 
+impl oxanus::FromContext<()> for PanicWorker {
+    fn from_context(_: &()) -> Self {
+        Self
+    }
+}
+
 #[tokio::test]
 pub async fn test_panic() -> TestResult {
     let redis_pool = setup();
-    let ctx = oxanus::Context::value(());
+    let ctx = oxanus::ContextValue::new(());
     let storage = oxanus::Storage::builder()
         .namespace(random_string())
         .build_from_pool(redis_pool)?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerPanic>()
+        .register_worker::<PanicWorker, PanicJob>()
         .exit_when_processed(1);
 
-    storage.enqueue(QueueOne, WorkerPanic {}).await?;
+    storage.enqueue(QueueOne, PanicJob {}).await?;
 
     assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
 

--- a/oxanus/tests/integration/registry.rs
+++ b/oxanus/tests/integration/registry.rs
@@ -10,26 +10,46 @@ struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
 #[oxanus(key = "two")]
 struct QueueTwo;
 
-#[derive(Debug, Clone, Serialize, Deserialize, oxanus::Worker)]
-pub struct WorkerCounter {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CounterJob {
     pub key: String,
 }
 
-impl WorkerCounter {
-    async fn process(&self, ctx: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
-        let mut redis = ctx.ctx.redis.get().await?;
-        let _: () = redis.incr(&self.key, 1).await?;
+#[derive(oxanus::Worker)]
+#[oxanus(args = CounterJob)]
+pub struct CounterWorker {
+    ctx: WorkerContext,
+}
+
+impl CounterWorker {
+    async fn process(
+        &self,
+        job: &CounterJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        let mut redis = self.ctx.redis.get().await?;
+        let _: () = redis.incr(&job.key, 1).await?;
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
-#[oxanus(cron(schedule = "* * * * * *", queue = QueueTwo))]
-pub struct CronWorkerCounter {}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CronCounterJob {}
 
-impl CronWorkerCounter {
-    async fn process(&self, ctx: &oxanus::Context<WorkerContext>) -> Result<(), WorkerError> {
-        let mut redis = ctx.ctx.redis.get().await?;
+#[derive(oxanus::Worker)]
+#[oxanus(args = CronCounterJob)]
+#[oxanus(cron(schedule = "* * * * * *", queue = QueueTwo))]
+pub struct CronCounterWorker {
+    ctx: WorkerContext,
+}
+
+impl CronCounterWorker {
+    async fn process(
+        &self,
+        _job: &CronCounterJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        let mut redis = self.ctx.redis.get().await?;
         let _: () = redis.incr("test_worker:counter", 1).await?;
         Ok(())
     }
@@ -41,7 +61,7 @@ pub async fn test_registry() -> TestResult {
     let mut redis_conn = redis_pool.get().await?;
     let _: i64 = redis_conn.del("test_worker:counter").await?;
 
-    let ctx = oxanus::Context::value(WorkerContext {
+    let ctx = oxanus::ContextValue::new(WorkerContext {
         redis: redis_pool.clone(),
     });
 
@@ -51,15 +71,14 @@ pub async fn test_registry() -> TestResult {
 
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(2);
 
-    // no need to manually register, here we verify they were registered
     assert!(config.has_registered_queue::<QueueTwo>());
-    assert!(config.has_registered_worker::<WorkerCounter>());
-    assert!(config.has_registered_cron_worker::<CronWorkerCounter>());
+    assert!(config.has_registered_worker_type::<CounterWorker>());
+    assert!(config.has_registered_cron_worker_type::<CronCounterWorker>());
 
     storage
         .enqueue(
             QueueTwo,
-            WorkerCounter {
+            CounterJob {
                 key: "test_worker:counter".to_owned(),
             },
         )

--- a/oxanus/tests/integration/retry.rs
+++ b/oxanus/tests/integration/retry.rs
@@ -5,30 +5,34 @@ use testresult::TestResult;
 use crate::shared::*;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerRedisSetWithRetry {
+pub struct RetryJob {
     pub key: String,
     pub value_first: String,
     pub value_second: String,
 }
 
+pub struct RetryWorker {
+    pub state: WorkerState,
+}
+
+impl oxanus::Job for RetryJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<RetryWorker>()
+    }
+}
+
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerRedisSetWithRetry {
-    type Context = WorkerState;
+impl oxanus::Worker<RetryJob> for RetryWorker {
     type Error = WorkerError;
 
-    async fn process(
-        &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
-        let value: Option<String> = redis.get(&self.key).await?;
+    async fn process(&self, job: &RetryJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        let mut redis = self.state.redis.get().await?;
+        let value: Option<String> = redis.get(&job.key).await?;
         if value.is_some() {
-            let _: () = redis
-                .set_ex(&self.key, self.value_second.clone(), 3)
-                .await?;
+            let _: () = redis.set_ex(&job.key, job.value_second.clone(), 3).await?;
             return Ok(());
         }
-        let _: () = redis.set_ex(&self.key, self.value_first.clone(), 3).await?;
+        let _: () = redis.set_ex(&job.key, job.value_first.clone(), 3).await?;
         Err(WorkerError::Generic("Key not set".to_string()))
     }
 
@@ -41,12 +45,18 @@ impl oxanus::Worker for WorkerRedisSetWithRetry {
     }
 }
 
+impl oxanus::FromContext<WorkerState> for RetryWorker {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
 #[tokio::test]
 pub async fn test_retry() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
 
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
 
@@ -55,7 +65,7 @@ pub async fn test_retry() -> TestResult {
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerRedisSetWithRetry>()
+        .register_worker::<RetryWorker, RetryJob>()
         .exit_when_processed(2);
 
     let random_key = uuid::Uuid::new_v4().to_string();
@@ -65,7 +75,7 @@ pub async fn test_retry() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerRedisSetWithRetry {
+            RetryJob {
                 key: random_key.clone(),
                 value_first: random_value_first.clone(),
                 value_second: random_value_second.clone(),

--- a/oxanus/tests/integration/shared.rs
+++ b/oxanus/tests/integration/shared.rs
@@ -18,39 +18,74 @@ pub struct WorkerState {
     pub redis: deadpool_redis::Pool,
 }
 
+// --- NoopJob + NoopWorker ---
+
 #[derive(Serialize, Deserialize)]
-pub struct WorkerNoop {}
+pub struct NoopJob {}
+
+pub struct NoopWorker;
+
+impl oxanus::Job for NoopJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<NoopWorker>()
+    }
+}
 
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerNoop {
-    type Context = ();
+impl oxanus::Worker<NoopJob> for NoopWorker {
     type Error = WorkerError;
 
-    async fn process(&self, _: &oxanus::Context<()>) -> Result<(), WorkerError> {
+    async fn process(&self, _: &NoopJob, _: &oxanus::JobContext) -> Result<(), WorkerError> {
         Ok(())
     }
 }
 
+impl oxanus::FromContext<()> for NoopWorker {
+    fn from_context(_: &()) -> Self {
+        Self
+    }
+}
+
+// --- RedisSetJob + RedisSetWorker ---
+
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerRedisSet {
+pub struct RedisSetJob {
     pub key: String,
     pub value: String,
 }
 
+pub struct RedisSetWorker {
+    pub state: WorkerState,
+}
+
+impl oxanus::Job for RedisSetJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<RedisSetWorker>()
+    }
+}
+
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerRedisSet {
-    type Context = WorkerState;
+impl oxanus::Worker<RedisSetJob> for RedisSetWorker {
     type Error = WorkerError;
 
     async fn process(
         &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
+        job: &RedisSetJob,
+        _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
-        let _: () = redis.set_ex(&self.key, self.value.clone(), 3).await?;
+        let mut redis = self.state.redis.get().await?;
+        let _: () = redis.set_ex(&job.key, job.value.clone(), 3).await?;
         Ok(())
     }
 }
+
+impl oxanus::FromContext<WorkerState> for RedisSetWorker {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+// --- Queue ---
 
 #[derive(Serialize)]
 pub struct QueueOne;
@@ -60,6 +95,8 @@ impl oxanus::Queue for QueueOne {
         oxanus::QueueConfig::as_static("one")
     }
 }
+
+// --- Setup ---
 
 pub fn setup() -> deadpool_redis::Pool {
     dotenvy::from_filename(".env.test").ok();

--- a/oxanus/tests/integration/standard.rs
+++ b/oxanus/tests/integration/standard.rs
@@ -7,7 +7,7 @@ pub async fn test_standard() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
 
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
 
@@ -16,7 +16,7 @@ pub async fn test_standard() -> TestResult {
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerRedisSet>()
+        .register_worker::<RedisSetWorker, RedisSetJob>()
         .exit_when_processed(1);
 
     let random_key = uuid::Uuid::new_v4().to_string();
@@ -25,7 +25,7 @@ pub async fn test_standard() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerRedisSet {
+            RedisSetJob {
                 key: random_key.clone(),
                 value: random_value.clone(),
             },

--- a/oxanus/tests/integration/stats.rs
+++ b/oxanus/tests/integration/stats.rs
@@ -23,24 +23,24 @@ impl oxanus::Queue for QueueStatic {
 #[tokio::test]
 pub async fn test_stats() -> TestResult {
     let redis_pool = setup();
-    let ctx = oxanus::Context::value(());
+    let ctx = oxanus::ContextValue::new(());
     let storage = oxanus::Storage::builder()
         .namespace(random_string())
         .build_from_pool(redis_pool)?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueDynamic>()
         .register_queue::<QueueStatic>()
-        .register_worker::<WorkerNoop>()
+        .register_worker::<NoopWorker, NoopJob>()
         .exit_when_processed(8);
 
-    storage.enqueue(QueueDynamic(1), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(2), WorkerNoop {}).await?;
-    storage.enqueue(QueueStatic, WorkerNoop {}).await?;
-    storage.enqueue(QueueStatic, WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(1), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(2), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(3), WorkerNoop {}).await?;
-    storage.enqueue(QueueDynamic(4), WorkerNoop {}).await?;
+    storage.enqueue(QueueDynamic(1), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(2), NoopJob {}).await?;
+    storage.enqueue(QueueStatic, NoopJob {}).await?;
+    storage.enqueue(QueueStatic, NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(1), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(2), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(3), NoopJob {}).await?;
+    storage.enqueue(QueueDynamic(4), NoopJob {}).await?;
 
     let stats = storage.stats().await?;
 

--- a/oxanus/tests/integration/unique.rs
+++ b/oxanus/tests/integration/unique.rs
@@ -4,37 +4,26 @@ use testresult::TestResult;
 
 use crate::shared::*;
 
+// --- Unique Skip ---
+
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerUniqueSkip {
+pub struct UniqueSkipJob {
     pub id: i32,
     pub key: String,
     pub value: i32,
 }
 
-#[async_trait::async_trait]
-impl oxanus::Worker for WorkerUniqueSkip {
-    type Context = WorkerState;
-    type Error = WorkerError;
+pub struct UniqueSkipWorker {
+    pub state: WorkerState,
+}
 
-    async fn process(
-        &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
-    ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
-        let _: () = redis.set_ex(&self.key, self.value.to_string(), 3).await?;
-        Ok(())
+impl oxanus::Job for UniqueSkipJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<UniqueSkipWorker>()
     }
 
     fn unique_id(&self) -> Option<String> {
         Some(format!("unique:{}", self.id))
-    }
-
-    fn retry_delay(&self, _retries: u32) -> u64 {
-        0
-    }
-
-    fn max_retries(&self) -> u32 {
-        0
     }
 
     fn on_conflict(&self) -> oxanus::JobConflictStrategy {
@@ -42,29 +31,18 @@ impl oxanus::Worker for WorkerUniqueSkip {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerUniqueReplace {
-    pub id: i32,
-    pub key: String,
-    pub value: i32,
-}
-
 #[async_trait::async_trait]
-impl oxanus::Worker for WorkerUniqueReplace {
-    type Context = WorkerState;
+impl oxanus::Worker<UniqueSkipJob> for UniqueSkipWorker {
     type Error = WorkerError;
 
     async fn process(
         &self,
-        oxanus::Context { ctx, .. }: &oxanus::Context<WorkerState>,
+        job: &UniqueSkipJob,
+        _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
-        let mut redis = ctx.redis.get().await?;
-        let _: () = redis.set_ex(&self.key, self.value.to_string(), 3).await?;
+        let mut redis = self.state.redis.get().await?;
+        let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
         Ok(())
-    }
-
-    fn unique_id(&self) -> Option<String> {
-        Some(format!("unique:{}", self.id))
     }
 
     fn retry_delay(&self, _retries: u32) -> u64 {
@@ -74,17 +52,77 @@ impl oxanus::Worker for WorkerUniqueReplace {
     fn max_retries(&self) -> u32 {
         0
     }
+}
+
+impl oxanus::FromContext<WorkerState> for UniqueSkipWorker {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+// --- Unique Replace ---
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UniqueReplaceJob {
+    pub id: i32,
+    pub key: String,
+    pub value: i32,
+}
+
+pub struct UniqueReplaceWorker {
+    pub state: WorkerState,
+}
+
+impl oxanus::Job for UniqueReplaceJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<UniqueReplaceWorker>()
+    }
+
+    fn unique_id(&self) -> Option<String> {
+        Some(format!("unique:{}", self.id))
+    }
 
     fn on_conflict(&self) -> oxanus::JobConflictStrategy {
         oxanus::JobConflictStrategy::Replace
     }
 }
 
+#[async_trait::async_trait]
+impl oxanus::Worker<UniqueReplaceJob> for UniqueReplaceWorker {
+    type Error = WorkerError;
+
+    async fn process(
+        &self,
+        job: &UniqueReplaceJob,
+        _ctx: &oxanus::JobContext,
+    ) -> Result<(), WorkerError> {
+        let mut redis = self.state.redis.get().await?;
+        let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
+        Ok(())
+    }
+
+    fn retry_delay(&self, _retries: u32) -> u64 {
+        0
+    }
+
+    fn max_retries(&self) -> u32 {
+        0
+    }
+}
+
+impl oxanus::FromContext<WorkerState> for UniqueReplaceWorker {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+// --- Tests ---
+
 #[tokio::test]
 pub async fn test_unique_skip() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
     let storage = oxanus::Storage::builder()
@@ -92,7 +130,7 @@ pub async fn test_unique_skip() -> TestResult {
         .build_from_pool(redis_pool.clone())?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerUniqueSkip>()
+        .register_worker::<UniqueSkipWorker, UniqueSkipJob>()
         .exit_when_processed(2);
     let key1 = random_string();
     let key2 = random_string();
@@ -100,7 +138,7 @@ pub async fn test_unique_skip() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueSkip {
+            UniqueSkipJob {
                 id: 1,
                 key: key1.clone(),
                 value: 1,
@@ -110,7 +148,7 @@ pub async fn test_unique_skip() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueSkip {
+            UniqueSkipJob {
                 id: 1,
                 key: key1.clone(),
                 value: 2,
@@ -120,7 +158,7 @@ pub async fn test_unique_skip() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueSkip {
+            UniqueSkipJob {
                 id: 2,
                 key: key2.clone(),
                 value: 3,
@@ -130,7 +168,7 @@ pub async fn test_unique_skip() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueSkip {
+            UniqueSkipJob {
                 id: 2,
                 key: key2.clone(),
                 value: 4,
@@ -158,7 +196,7 @@ pub async fn test_unique_skip() -> TestResult {
 pub async fn test_unique_replace() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
-    let ctx = oxanus::Context::value(WorkerState {
+    let ctx = oxanus::ContextValue::new(WorkerState {
         redis: redis_pool.clone(),
     });
     let storage = oxanus::Storage::builder()
@@ -166,7 +204,7 @@ pub async fn test_unique_replace() -> TestResult {
         .build_from_pool(redis_pool)?;
     let config = oxanus::Config::new(&storage)
         .register_queue::<QueueOne>()
-        .register_worker::<WorkerUniqueReplace>()
+        .register_worker::<UniqueReplaceWorker, UniqueReplaceJob>()
         .exit_when_processed(2);
 
     let key1 = random_string();
@@ -175,7 +213,7 @@ pub async fn test_unique_replace() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueReplace {
+            UniqueReplaceJob {
                 id: 1,
                 key: key1.clone(),
                 value: 1,
@@ -185,7 +223,7 @@ pub async fn test_unique_replace() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueReplace {
+            UniqueReplaceJob {
                 id: 1,
                 key: key1.clone(),
                 value: 2,
@@ -195,7 +233,7 @@ pub async fn test_unique_replace() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueReplace {
+            UniqueReplaceJob {
                 id: 2,
                 key: key2.clone(),
                 value: 3,
@@ -205,7 +243,7 @@ pub async fn test_unique_replace() -> TestResult {
     storage
         .enqueue(
             QueueOne,
-            WorkerUniqueReplace {
+            UniqueReplaceJob {
                 id: 2,
                 key: key2.clone(),
                 value: 4,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large refactor of core execution/enqueue/registry pipeline (new `Job`/`Worker<Args>` model, new contexts, new Redis envelope fields, and batching), which could affect job serialization, retries/dead-lettering, and runtime scheduling behavior.
> 
> **Overview**
> This PR **reworks the public API to separate job data from worker logic**. Jobs now implement `Job` (data/unique id/conflict policy) and workers implement `Worker<Args>` with `process(&self, job: &Args, ctx: &JobContext)`, while application context is passed via `ContextValue::new(...)` and injected into workers via `FromContext` (auto-derived by macros).
> 
> It also **adds first-class batch processing**: a new `BatchProcessor` trait + derive macro, registry/config plumbing for batch processors, and coordinator logic to buffer items per worker and execute batches based on `batch_size`/`batch_linger_ms`.
> 
> Execution and storage flows are updated accordingly: the worker registry now builds `Processable` instances using the shared context, `JobEnvelope`/Redis metadata gains an `error` field (and retry/kill paths now record error messages), and all examples/benches/integration tests plus new `README.v2.md` and `MIGRATION.md` are updated to the new API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 369a1a05190fbc4809850d69b2bd198920dcdf7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->