### PR TITLE
Add Conductor workspace setup and archive scripts

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "./scripts/workspace-setup.sh",
+        "archive": "./scripts/workspace-archive.sh"
+    }
+}

--- a/scripts/workspace-archive.sh
+++ b/scripts/workspace-archive.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+WORKSPACE_DIR=$(basename "$(pwd)")
+REDIS_DB=$(( ($(echo "$WORKSPACE_DIR" | cksum | cut -d' ' -f1) % 255) + 1 ))
+REDIS_CONTAINER="redis"
+
+echo "Archiving workspace: $WORKSPACE_DIR"
+
+# Flush Redis database
+if docker ps --format '{{.Names}}' | grep -q "$REDIS_CONTAINER"; then
+  echo "Flushing Redis database $REDIS_DB..."
+  docker exec "$REDIS_CONTAINER" redis-cli -n "$REDIS_DB" FLUSHDB
+else
+  echo "Redis container not running, skipping Redis cleanup"
+fi
+
+echo "Workspace archive complete!"

--- a/scripts/workspace-setup.sh
+++ b/scripts/workspace-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+WORKSPACE_DIR=$(basename "$(pwd)")
+REDIS_DB=$(( ($(echo "$WORKSPACE_DIR" | cksum | cut -d' ' -f1) % 255) + 1 ))
+
+echo "Setting up workspace: $WORKSPACE_DIR"
+echo "Redis database: $REDIS_DB"
+
+ENV_FILE=".env.test"
+
+if [ -f "$ENV_FILE" ]; then
+  echo "$ENV_FILE already exists, skipping"
+else
+  echo "Creating $ENV_FILE..."
+  echo "REDIS_URL=redis://localhost:6379/${REDIS_DB}" > "$ENV_FILE"
+fi
+
+echo ""
+echo "Workspace setup complete!"
+echo "  Redis DB: $REDIS_DB"


### PR DESCRIPTION
## Summary
- Adds `scripts/workspace-setup.sh` to generate `.env.test` with a deterministic Redis DB number derived from the workspace directory name
- Adds `scripts/workspace-archive.sh` to flush the Redis DB when archiving a workspace
- Adds `conductor.json` to wire up the setup and archive scripts

## Test plan
- [ ] Run `./scripts/workspace-setup.sh` and verify `.env.test` is created with correct Redis DB
- [ ] Run `./scripts/workspace-archive.sh` and verify Redis DB is flushed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-workflow change, but `workspace-archive.sh` runs a destructive `FLUSHDB` against a computed Redis DB, so misuse or unexpected container naming could cause data loss in local Redis.
> 
> **Overview**
> Adds `conductor.json` wiring for workspace lifecycle scripts.
> 
> Introduces `scripts/workspace-setup.sh` to generate `.env.test` with a deterministic per-workspace `REDIS_URL`, and `scripts/workspace-archive.sh` to `FLUSHDB` the corresponding Redis database (when a `redis` Docker container is running) during workspace archival.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d06d8222b50878088d4e338d04c985a675ef7c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->