### PR TITLE
Store error message on dead and retried jobs

### DIFF
--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -114,8 +114,9 @@ where
     {
         Ok(job) => job,
         Err(e) => {
-            tracing::error!("Invalid job: {} - {}", &envelope.job.name, e);
-            if let Err(e) = config.storage.internal.kill(&envelope).await {
+            let err_msg = format!("Invalid job: {} - {}", &envelope.job.name, e);
+            tracing::error!("{}", err_msg);
+            if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
                 #[cfg(feature = "sentry")]
                 sentry_core::capture_error(&e);
                 tracing::error!("Failed to kill job: {}", e);

--- a/oxanus/src/drainer.rs
+++ b/oxanus/src/drainer.rs
@@ -99,7 +99,11 @@ where
                 .internal
                 .finish_with_failure(&envelope)
                 .await?;
-            config.storage.internal.kill(&envelope).await?;
+            config
+                .storage
+                .internal
+                .kill(&envelope, e.to_string())
+                .await?;
             Ok(ProcessJobResult::Failed)
         }
     }

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -164,7 +164,7 @@ async fn handle_err<DT, ET>(
         if let Err(e) = config
             .storage
             .internal
-            .retry_in(envelope.id.clone(), retry_delay)
+            .retry_in(envelope.id.clone(), retry_delay, err_msg.to_string())
             .await
         {
             tracing::error!("Failed to retry job: {}", e);
@@ -176,7 +176,12 @@ async fn handle_err<DT, ET>(
             max_retries,
             err_msg
         );
-        if let Err(e) = config.storage.internal.kill(envelope).await {
+        if let Err(e) = config
+            .storage
+            .internal
+            .kill(envelope, err_msg.to_string())
+            .await
+        {
             tracing::error!("Failed to kill job: {}", e);
         }
     }

--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -39,6 +39,8 @@ pub struct JobMeta {
     pub state: Option<serde_json::Value>,
     #[serde(default = "default_resurrect")]
     pub resurrect: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
@@ -85,6 +87,7 @@ impl JobEnvelope {
                 started_at: None,
                 state: None,
                 resurrect,
+                error: None,
             },
         })
     }
@@ -113,11 +116,17 @@ impl JobEnvelope {
                 started_at: None,
                 state: None,
                 resurrect,
+                error: None,
             },
         })
     }
 
-    pub(crate) fn with_retries_incremented(self) -> Self {
+    pub(crate) fn with_error(mut self, error: String) -> Self {
+        self.meta.error = Some(error);
+        self
+    }
+
+    pub(crate) fn with_retries_incremented(self, error: String) -> Self {
         Self {
             id: self.id.clone(),
             queue: self.queue,
@@ -132,6 +141,7 @@ impl JobEnvelope {
                 started_at: None,
                 state: self.meta.state,
                 resurrect: self.meta.resurrect,
+                error: Some(error),
             },
         }
     }
@@ -206,6 +216,7 @@ mod tests {
             started_at,
             state: None,
             resurrect: true,
+            error: None,
         }
     }
 
@@ -277,12 +288,14 @@ mod tests {
                 started_at: Some(2_000_000),
                 state: None,
                 resurrect: true,
+                error: None,
             },
         };
 
-        let retried = envelope.with_retries_incremented();
+        let retried = envelope.with_retries_incremented("something went wrong".to_string());
         assert_eq!(retried.meta.retries, 1);
         assert!(retried.meta.started_at.is_none());
+        assert_eq!(retried.meta.error.as_deref(), Some("something went wrong"));
     }
 
     #[test]
@@ -301,5 +314,6 @@ mod tests {
         let meta: JobMeta =
             serde_json::from_str(json).expect("should deserialize without started_at");
         assert!(meta.started_at.is_none());
+        assert!(meta.error.is_none());
     }
 }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -197,12 +197,17 @@ impl StorageInternal {
         Ok(envelope.id)
     }
 
-    pub async fn retry_in(&self, job_id: JobId, delay_s: u64) -> Result<(), OxanusError> {
+    pub async fn retry_in(
+        &self,
+        job_id: JobId,
+        delay_s: u64,
+        error: String,
+    ) -> Result<(), OxanusError> {
         let updated_envelope = self
             .get_job(&job_id)
             .await?
             .ok_or(OxanusError::JobNotFound)?
-            .with_retries_incremented();
+            .with_retries_incremented(error);
 
         let now = chrono::Utc::now().timestamp_micros() as u64;
 
@@ -337,12 +342,13 @@ impl StorageInternal {
         Ok(envelopes)
     }
 
-    pub async fn kill(&self, envelope: &JobEnvelope) -> Result<(), OxanusError> {
+    pub async fn kill(&self, envelope: &JobEnvelope, error: String) -> Result<(), OxanusError> {
+        let envelope = envelope.clone().with_error(error);
         let mut redis = self.connection().await?;
         let _: () = redis::pipe()
             .lrem(self.current_processing_queue(), 1, &envelope.id)
             .hdel(&self.keys.jobs, &envelope.id)
-            .lpush(&self.keys.dead, &serde_json::to_string(envelope)?)
+            .lpush(&self.keys.dead, &serde_json::to_string(&envelope)?)
             .ltrim(&self.keys.dead, 0, 999)
             .query_async(&mut redis)
             .await?;


### PR DESCRIPTION
## Summary
- Adds `error: Option<String>` field to `JobMeta` to capture the error message when jobs fail
- Updates `kill()` and `retry_in()` to accept and store the error string
- Error is preserved in the dead letter queue and on retried job envelopes for easier debugging

## Test plan
- [x] All 26 unit tests pass
- [x] All 11 integration tests pass
- [x] Backward-compatible deserialization verified (existing jobs without `error` field still parse)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the persisted job envelope schema and Redis write paths for `retry_in`/`kill`, which could affect compatibility with existing consumers and job lifecycle behavior if any callers weren’t updated.
> 
> **Overview**
> Failed jobs now retain an error message in their persisted metadata: `JobMeta` gains an optional `error` field (omitted when `None`) and retry/killed envelopes are updated to include it.
> 
> Job lifecycle paths are updated to thread an error string through storage operations: `StorageInternal::retry_in` and `StorageInternal::kill` take an `error` parameter, and callers in `executor`, `drainer`, and `coordinator` pass through worker/validation failure messages so dead-letter and retried jobs are easier to debug.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1133e8bcf1bb9e7f8cf064231eb98b57496bc29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->