### PR TITLE
Throttling - Support custom cost

### DIFF
--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -18,6 +18,7 @@ struct OxanusArgs {
     on_conflict: Option<Ident>,
     cron: Option<Cron>,
     resurrect: Option<bool>,
+    throttle_cost: Option<ThrottleCost>,
 }
 
 #[derive(Debug)]
@@ -48,6 +49,14 @@ enum RetryDelay {
     /// #[retry_delay = 3]
     Value(u64),
     /// #[retry_delay = mymod::func]
+    CustomFunc(Path),
+}
+
+#[derive(Debug)]
+enum ThrottleCost {
+    /// #[throttle_cost = 2]
+    Value(u64),
+    /// #[throttle_cost = Self::throttle_cost]
     CustomFunc(Path),
 }
 
@@ -88,6 +97,7 @@ macro_rules! impl_from_meta_for_num_or_path {
 
 impl_from_meta_for_num_or_path!(MaxRetries, u32, "max_retries");
 impl_from_meta_for_num_or_path!(RetryDelay, u64, "retry_delay");
+impl_from_meta_for_num_or_path!(ThrottleCost, u64, "throttle_cost");
 
 impl FromMeta for UniqueIdSpec {
     fn from_meta(meta: &Meta) -> darling::Result<Self> {
@@ -200,6 +210,11 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
         None => quote!(),
     };
 
+    let throttle_cost = match args.throttle_cost {
+        Some(throttle_cost) => expand_throttle_cost(throttle_cost),
+        None => quote!(),
+    };
+
     let resurrect = match args.resurrect {
         Some(value) => quote! {
             fn should_resurrect() -> bool
@@ -259,6 +274,8 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
             #cron
 
             #resurrect
+
+            #throttle_cost
         }
 
         #registry
@@ -341,6 +358,25 @@ fn expand_unique_id(spec: UniqueIdSpec, fields: &Fields) -> TokenStream {
     quote! {
         fn unique_id(&self) -> Option<String> {
             #formatter
+        }
+    }
+}
+
+fn expand_throttle_cost(throttle_cost: ThrottleCost) -> TokenStream {
+    match throttle_cost {
+        ThrottleCost::Value(value) => {
+            quote! {
+                fn throttle_cost(&self) -> Option<u64> {
+                    Some(#value)
+                }
+            }
+        }
+        ThrottleCost::CustomFunc(func) => {
+            quote! {
+                fn throttle_cost(&self) -> Option<u64> {
+                    #func(self)
+                }
+            }
         }
     }
 }

--- a/oxanus/examples/throttled.rs
+++ b/oxanus/examples/throttled.rs
@@ -20,6 +20,7 @@ impl WorkerInstant {
 }
 
 #[derive(Debug, Serialize, Deserialize, oxanus::Worker)]
+#[oxanus(throttle_cost = 2)]
 struct WorkerInstant2 {}
 
 impl WorkerInstant2 {

--- a/oxanus/src/dispatcher.rs
+++ b/oxanus/src/dispatcher.rs
@@ -80,7 +80,11 @@ async fn pop_queue_message_w_throttle(
         if state.is_allowed
             && let Some(job_id) = storage.dequeue(queue_key).await?
         {
-            throttler.consume().await?;
+            let cost = storage
+                .get_job(&job_id)
+                .await?
+                .and_then(|envelope| envelope.meta.throttle_cost);
+            throttler.consume(cost).await?;
             return Ok(job_id);
         }
 

--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -43,6 +43,8 @@ pub struct JobMeta {
     pub resurrect: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub throttle_cost: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
@@ -90,6 +92,7 @@ impl JobEnvelope {
                 state: None,
                 resurrect,
                 error: None,
+                throttle_cost: job.throttle_cost(),
             },
         })
     }
@@ -119,6 +122,7 @@ impl JobEnvelope {
                 state: None,
                 resurrect,
                 error: None,
+                throttle_cost: None,
             },
         })
     }
@@ -144,6 +148,7 @@ impl JobEnvelope {
                 state: self.meta.state,
                 resurrect: self.meta.resurrect,
                 error: Some(error),
+                throttle_cost: self.meta.throttle_cost,
             },
         }
     }
@@ -219,6 +224,7 @@ mod tests {
             state: None,
             resurrect: true,
             error: None,
+            throttle_cost: None,
         }
     }
 
@@ -291,6 +297,7 @@ mod tests {
                 state: None,
                 resurrect: true,
                 error: None,
+                throttle_cost: None,
             },
         };
 

--- a/oxanus/src/throttler.rs
+++ b/oxanus/src/throttler.rs
@@ -1,5 +1,6 @@
 use crate::OxanusError;
 use deadpool_redis::redis;
+use uuid::Uuid;
 
 pub struct Throttler {
     redis_pool: deadpool_redis::Pool,
@@ -25,17 +26,21 @@ impl Throttler {
         }
     }
 
-    pub async fn consume(&self) -> Result<ThrottlerState, OxanusError> {
+    pub async fn consume(&self, cost: Option<u64>) -> Result<ThrottlerState, OxanusError> {
         let mut redis = self.redis_pool.get().await?;
         let current_time = u64::try_from(chrono::Utc::now().timestamp_micros())?;
         let state = self.state_w_conn(&mut redis).await?;
 
         if state.is_allowed {
-            let (updated, _): (u64, ()) = redis::pipe()
-                .zadd(&self.key, current_time, current_time)
-                .expire(&self.key, self.window_s())
-                .query_async(&mut redis)
-                .await?;
+            let effective_cost = cost.unwrap_or(1);
+            let members: Vec<(u64, String)> = (0..effective_cost)
+                .map(|_| (current_time, Uuid::new_v4().to_string()))
+                .collect();
+
+            let mut pipe = redis::pipe();
+            pipe.zadd_multiple(&self.key, &members)
+                .expire(&self.key, self.window_s());
+            let (updated, _): (u64, ()) = pipe.query_async(&mut redis).await?;
 
             Ok(ThrottlerState {
                 requests: state.requests + updated,
@@ -112,16 +117,29 @@ mod tests {
         let pool = redis_pool().await?;
         let key = random_string();
         let rate_limiter = Throttler::new(pool, &key, 2, 60000);
-        assert!(rate_limiter.consume().await?.is_allowed);
-        assert!(rate_limiter.consume().await?.is_allowed);
-        let state = rate_limiter.consume().await?;
+        assert!(rate_limiter.consume(None).await?.is_allowed);
+        assert!(rate_limiter.consume(None).await?.is_allowed);
+        let state = rate_limiter.consume(None).await?;
         assert!(!state.is_allowed);
         assert!(state.throttled_for.is_some());
-        assert!(state.throttled_for.unwrap() >= 60000);
-        let state = rate_limiter.consume().await?;
+        assert!(state.throttled_for.unwrap_or(0) >= 60000);
+        let state = rate_limiter.consume(None).await?;
         assert!(!state.is_allowed);
         assert!(state.throttled_for.is_some());
-        assert!(state.throttled_for.unwrap() >= 60000);
+        assert!(state.throttled_for.unwrap_or(0) >= 60000);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_consume_with_cost() -> TestResult {
+        let pool = redis_pool().await?;
+        let key = random_string();
+        let rate_limiter = Throttler::new(pool, &key, 4, 60000);
+        assert!(rate_limiter.consume(Some(2)).await?.is_allowed);
+        assert!(rate_limiter.consume(Some(2)).await?.is_allowed);
+        let state = rate_limiter.consume(Some(1)).await?;
+        assert!(!state.is_allowed);
 
         Ok(())
     }

--- a/oxanus/src/throttler.rs
+++ b/oxanus/src/throttler.rs
@@ -33,6 +33,11 @@ impl Throttler {
 
         if state.is_allowed {
             let effective_cost = cost.unwrap_or(1);
+
+            if effective_cost == 0 {
+                return Ok(state);
+            }
+
             let members: Vec<(u64, String)> = (0..effective_cost)
                 .map(|_| (current_time, Uuid::new_v4().to_string()))
                 .collect();

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -56,6 +56,10 @@ pub trait Worker: Send + Sync + UnwindSafe {
         true
     }
 
+    fn throttle_cost(&self) -> Option<u64> {
+        None
+    }
+
     fn to_config() -> WorkerConfigKind
     where
         Self: Sized,


### PR DESCRIPTION
Implementation is optimistic so limit might temporarily overflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes queue throttling behavior by charging variable “cost” per dequeued job and persists that cost in job metadata; mistakes could cause unintended throughput limits or Redis load spikes under high costs.
> 
> **Overview**
> Adds **per-job throttle cost** support so throttled queues can charge more than 1 token for specific jobs.
> 
> This introduces a new worker attribute `#[oxanus(throttle_cost = ...)]` (literal or function) that flows into `JobMeta.throttle_cost`, and updates the dispatcher/throttler to read that value when dequeuing and consume `cost` tokens (implemented as multiple Redis ZSET members, with `0` as a no-op). Includes updated tests and an example (`examples/throttled.rs`) demonstrating costed jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36219fb9d28d4f2c22f0652d022412ff4776997d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->