### PR TITLE
Fix queue latency for scheduled jobs

### DIFF
--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -171,11 +171,19 @@ impl JobMeta {
         self.scheduled_at / 1000000
     }
 
+    pub fn effective_scheduled_at_micros(&self) -> i64 {
+        if self.scheduled_at > 0 {
+            self.scheduled_at
+        } else {
+            self.created_at
+        }
+    }
+
     pub fn latency_micros(&self) -> i64 {
         let reference = self
             .started_at
             .unwrap_or_else(|| chrono::Utc::now().timestamp_micros());
-        (reference - self.scheduled_at).max(0)
+        (reference - self.effective_scheduled_at_micros()).max(0)
     }
 
     pub fn latency_secs(&self) -> i64 {

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -538,7 +538,7 @@ impl StorageInternal {
                 let envelope = self.get_job_w_conn(redis, job_id).await?;
                 Ok(envelope.map_or(0.0, |envelope| {
                     let now = chrono::Utc::now().timestamp_micros();
-                    (now - envelope.meta.created_at) as f64
+                    (now - envelope.meta.scheduled_at) as f64
                 }))
             }
             None => Ok(0.0),
@@ -1184,7 +1184,9 @@ mod tests {
         let mut envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
         let now = chrono::Utc::now();
         let actual_latency = 7777;
-        envelope.meta.created_at = now.timestamp_micros() - actual_latency * 1_000;
+        let past = now.timestamp_micros() - actual_latency * 1_000;
+        envelope.meta.created_at = past;
+        envelope.meta.scheduled_at = past;
         storage.enqueue(envelope).await?;
 
         let latency = storage.latency_ms(&queue).await?;
@@ -1210,7 +1212,9 @@ mod tests {
         let actual_latency_ms = 7777;
         let actual_latency_micros = actual_latency_ms * 1_000;
         let actual_latency_s = actual_latency_ms as f64 / 1_000.0;
-        envelope.meta.created_at = now.timestamp_micros() - actual_latency_micros;
+        let past = now.timestamp_micros() - actual_latency_micros;
+        envelope.meta.created_at = past;
+        envelope.meta.scheduled_at = past;
         storage.enqueue(envelope).await?;
 
         let latency_ms = storage.latency_ms(&queue).await?;
@@ -1225,7 +1229,9 @@ mod tests {
         let mut envelope2 = JobEnvelope::new(queue.clone(), TestWorker {})?;
         let actual_latency_ms2 = 5000;
         let actual_latency_micros2 = actual_latency_ms2 * 1_000;
-        envelope2.meta.created_at = now.timestamp_micros() - actual_latency_micros2;
+        let past2 = now.timestamp_micros() - actual_latency_micros2;
+        envelope2.meta.created_at = past2;
+        envelope2.meta.scheduled_at = past2;
         storage.enqueue(envelope2).await?;
 
         let latency_ms = storage.latency_ms(&queue).await?;

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -538,7 +538,7 @@ impl StorageInternal {
                 let envelope = self.get_job_w_conn(redis, job_id).await?;
                 Ok(envelope.map_or(0.0, |envelope| {
                     let now = chrono::Utc::now().timestamp_micros();
-                    (now - envelope.meta.scheduled_at) as f64
+                    (now - envelope.meta.effective_scheduled_at_micros()) as f64
                 }))
             }
             None => Ok(0.0),


### PR DESCRIPTION
## Summary

- Queue latency calculation in `latency_micros_w_conn` used `created_at` instead of `scheduled_at`, causing jobs scheduled via `enqueue_in` to report inflated latency that included the intentional delay period
- Changed to use `scheduled_at`, which correctly measures time since the job was meant to start processing
- Updated latency tests to set both `created_at` and `scheduled_at` so they remain accurate under the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metric fix: adjusts latency calculations to use `scheduled_at` (with fallback) so scheduled jobs don’t report inflated queue latency; core enqueue/dequeue behavior is unchanged.
> 
> **Overview**
> Fixes queue latency reporting for scheduled jobs by basing latency on the time a job was *meant* to run (`scheduled_at`) rather than when it was created.
> 
> Adds `JobMeta::effective_scheduled_at_micros()` as a backward-compatible fallback (uses `created_at` if `scheduled_at` is unset/zero), wires this into both `JobMeta::latency_micros()` and `StorageInternal::latency_micros_w_conn`, and updates latency tests to set `scheduled_at` alongside `created_at`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff5f792cfcec34591ea97eb79f7fff99adffcc24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->