### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1]
+
+### Fixed
+- Fix queue latency calculation by falling back to `created_at` when `scheduled_at` is zero
+
 ## [0.9.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxanus version from 0.9.0 to 0.9.1
- Add changelog entry for queue latency fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump and changelog update only, with no functional code changes in the PR itself.
> 
> **Overview**
> Bumps the `oxanus` crate version from `0.9.0` to `0.9.1` (including `Cargo.lock`).
> 
> Adds a `0.9.1` changelog entry documenting a fix to queue latency calculation (fallback to `created_at` when `scheduled_at` is zero).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af3b5783241945b81a323d5dfa8f408a024bc84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->