### PR TITLE
Deduplicate relative time filters, add oxanus-web README docs

### DIFF
--- a/oxanus-web/src/filters.rs
+++ b/oxanus-web/src/filters.rs
@@ -18,13 +18,9 @@ pub fn relative_time(ts: &i64, _env: &dyn askama::Values) -> askama::Result<Stri
     Ok(result)
 }
 
-#[askama::filter_fn]
-pub fn relative_time_micros(ts: &i64, _env: &dyn askama::Values) -> askama::Result<String> {
-    let now_micros = chrono::Utc::now().timestamp_micros();
-    let diff_secs = (now_micros - ts) / 1_000_000;
-
+fn format_relative_micros(diff_secs: i64) -> String {
     if diff_secs.abs() < 15 {
-        return Ok("now".to_string());
+        return "now".to_string();
     }
 
     let abs = diff_secs.abs();
@@ -34,7 +30,7 @@ pub fn relative_time_micros(ts: &i64, _env: &dyn askama::Values) -> askama::Resu
         ("in ", "")
     };
 
-    let result = if abs < 60 {
+    if abs < 60 {
         format!("{prefix}{abs}s{suffix}")
     } else if abs < 3600 {
         format!("{prefix}{}m{suffix}", abs / 60)
@@ -46,9 +42,14 @@ pub fn relative_time_micros(ts: &i64, _env: &dyn askama::Values) -> askama::Resu
         } else {
             format!("{prefix}{h}h{m}m{suffix}")
         }
-    };
+    }
+}
 
-    Ok(result)
+#[askama::filter_fn]
+pub fn relative_time_micros(ts: &i64, _env: &dyn askama::Values) -> askama::Result<String> {
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let diff_secs = (now_micros - ts) / 1_000_000;
+    Ok(format_relative_micros(diff_secs))
 }
 
 #[askama::filter_fn]
@@ -78,33 +79,7 @@ pub fn relative_time_micros_opt(
 
     let now_micros = chrono::Utc::now().timestamp_micros();
     let diff_secs = (now_micros - ts) / 1_000_000;
-
-    if diff_secs.abs() < 15 {
-        return Ok("now".to_string());
-    }
-
-    let abs = diff_secs.abs();
-    let (prefix, suffix) = if diff_secs > 0 {
-        ("", " ago")
-    } else {
-        ("in ", "")
-    };
-
-    let result = if abs < 60 {
-        format!("{prefix}{abs}s{suffix}")
-    } else if abs < 3600 {
-        format!("{prefix}{}m{suffix}", abs / 60)
-    } else {
-        let h = abs / 3600;
-        let m = (abs % 3600) / 60;
-        if m == 0 {
-            format!("{prefix}{h}h{suffix}")
-        } else {
-            format!("{prefix}{h}h{m}m{suffix}")
-        }
-    };
-
-    Ok(result)
+    Ok(format_relative_micros(diff_secs))
 }
 
 fn format_with_commas(mut n: u64) -> String {

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -83,6 +83,40 @@ async fn main() -> Result<(), oxanus::OxanusError> {
 
 For more detailed usage examples, check out the [examples directory](https://github.com/pragmaplatform/oxanus/tree/main/oxanus/examples).
 
+## Web Dashboard
+
+The `oxanus-web` crate provides a web UI dashboard for monitoring jobs, queues, and cron schedules. It integrates as a nested axum router.
+
+```rust
+use oxanus_web::OxanusWebState;
+
+// Build your oxanus config as usual
+let config = ComponentRegistry::build_config(&storage)
+    .with_graceful_shutdown(tokio::signal::ctrl_c());
+
+// Create the oxanus-web router
+let oxanus_router = oxanus_web::router(OxanusWebState {
+    catalog: config.catalog(),
+    storage: config.storage.clone(),
+    base_path: "/oxanus".to_string(),
+});
+
+// Nest it into your existing axum app
+let app = your_app_router().nest("/oxanus", oxanus_router);
+```
+
+The dashboard exposes these pages:
+
+- `/` - Overview with job stats
+- `/busy` - Currently processing jobs
+- `/queues` - All queues with stats
+- `/queues/{queue_key}` - Jobs in a specific queue
+- `/cron` - Cron job schedules
+- `/scheduled` - Scheduled jobs
+- `/retries` - Jobs pending retry
+- `/dead` - Dead letter queue
+
+It also provides management actions for wiping queues and deleting individual jobs.
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary
- Extract shared microsecond-to-relative-time formatting into a `format_relative_micros` helper, eliminating duplication between `relative_time_micros` and `relative_time_micros_opt` filters (addresses PR #18 review comment)
- Add Web Dashboard section to README documenting how to integrate `oxanus-web` into an axum app

## Test plan
- [x] `cargo check --all` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of template time-formatting helpers plus README documentation additions; behavior should remain the same aside from any subtle formatting edge cases.
> 
> **Overview**
> Refactors `oxanus-web`’s Askama relative-time filters by extracting shared microsecond relative-time formatting into a `format_relative_micros` helper and reusing it in both `relative_time_micros` and `relative_time_micros_opt`, removing duplicated logic.
> 
> Adds a new **Web Dashboard** section to `oxanus`’s README documenting how to mount the `oxanus-web` router in an axum app, listing available pages and basic management actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a631d4b7cee03ec199bb89bd78749079034c7d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->