### PR TITLE
Link enqueued stat box to queues tab

### DIFF
--- a/oxanus-web/templates/dashboard.html
+++ b/oxanus-web/templates/dashboard.html
@@ -28,10 +28,10 @@
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Busy</div>
                 <div class="text-2xl font-semibold text-purple-400">{{ stats.processing.len() }}</div>
             </a>
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+            <a href="{{ base_path }}/queues" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Enqueued</div>
                 <div class="text-2xl font-semibold text-blue-400">{{ stats.global.enqueued|format_number }}</div>
-            </div>
+            </a>
             <a href="{{ base_path }}/retries" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Retries</div>
                 <div class="text-2xl font-semibold text-orange-400">{{ stats.global.retries|format_number }}</div>


### PR DESCRIPTION
## Summary
- Make the Enqueued stat box on the dashboard clickable, linking to the Queues tab
- Matches the existing pattern used by Busy, Retries, Scheduled, and Dead boxes

## Test plan
- [ ] Open the web dashboard and verify the Enqueued box is clickable
- [ ] Verify it navigates to the Queues tab
- [ ] Verify hover styling matches other stat boxes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/template change that only adjusts navigation and styling; no backend logic or data handling is modified.
> 
> **Overview**
> Makes the dashboard **Enqueued** stat tile clickable by converting it from a static `<div>` to an `<a>` linking to `{{ base_path }}/queues`, matching the hover styling/interaction used by the other stat tiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8818b928ace8a69cb2cb17e1835d86d0456e735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->