### PR TITLE
Deduplicate filter logic and pre-compute concurrency map

### DIFF
--- a/oxanus-web/src/filters.rs
+++ b/oxanus-web/src/filters.rs
@@ -1,24 +1,11 @@
 #[askama::filter_fn]
 pub fn relative_time(ts: &i64, _env: &dyn askama::Values) -> askama::Result<String> {
     let now = chrono::Utc::now().timestamp();
-    let diff = now - ts;
-
-    if diff < 15 {
-        return Ok("now".to_string());
-    }
-
-    let result = if diff < 60 {
-        format!("{diff}s ago")
-    } else if diff < 3600 {
-        format!("{}m ago", diff / 60)
-    } else {
-        format!("{}h ago", diff / 3600)
-    };
-
-    Ok(result)
+    let diff_secs = now - ts;
+    Ok(format_relative(diff_secs))
 }
 
-fn format_relative_micros(diff_secs: i64) -> String {
+fn format_relative(diff_secs: i64) -> String {
     if diff_secs.abs() < 15 {
         return "now".to_string();
     }
@@ -49,7 +36,7 @@ fn format_relative_micros(diff_secs: i64) -> String {
 pub fn relative_time_micros(ts: &i64, _env: &dyn askama::Values) -> askama::Result<String> {
     let now_micros = chrono::Utc::now().timestamp_micros();
     let diff_secs = (now_micros - ts) / 1_000_000;
-    Ok(format_relative_micros(diff_secs))
+    Ok(format_relative(diff_secs))
 }
 
 #[askama::filter_fn]
@@ -79,7 +66,7 @@ pub fn relative_time_micros_opt(
 
     let now_micros = chrono::Utc::now().timestamp_micros();
     let diff_secs = (now_micros - ts) / 1_000_000;
-    Ok(format_relative_micros(diff_secs))
+    Ok(format_relative(diff_secs))
 }
 
 fn format_with_commas(mut n: u64) -> String {

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -17,13 +17,12 @@ pub(crate) async fn dashboard(
     Extension(state): Extension<OxanusWebState>,
 ) -> Result<DashboardTemplate, OxanusWebError> {
     let stats = state.storage.stats().await?;
-    let concurrency_map = build_concurrency_map(&state);
 
     Ok(DashboardTemplate {
         base_path: state.base_path,
         active_tab: "",
         stats,
-        concurrency_map,
+        concurrency_map: state.concurrency_map,
     })
 }
 
@@ -31,13 +30,12 @@ pub(crate) async fn busy(
     Extension(state): Extension<OxanusWebState>,
 ) -> Result<BusyTemplate, OxanusWebError> {
     let stats = state.storage.stats().await?;
-    let concurrency_map = build_concurrency_map(&state);
 
     Ok(BusyTemplate {
         base_path: state.base_path,
         active_tab: "/busy",
         stats,
-        concurrency_map,
+        concurrency_map: state.concurrency_map,
     })
 }
 
@@ -46,19 +44,18 @@ pub(crate) async fn queues_list(
     Query(params): Query<QueuesParams>,
 ) -> Result<QueuesTemplate, OxanusWebError> {
     let mut stats = state.storage.stats().await?;
-    let concurrency_map = build_concurrency_map(&state);
 
     let sort = params.sort.as_deref().unwrap_or("key");
     let dir = params.dir.as_deref().unwrap_or("asc");
     let desc = dir == "desc";
 
-    sort_queues(&mut stats.queues, &concurrency_map, sort, desc);
+    sort_queues(&mut stats.queues, &state.concurrency_map, sort, desc);
 
     Ok(QueuesTemplate {
         base_path: state.base_path,
         active_tab: "/queues",
         queues: stats.queues,
-        concurrency_map,
+        concurrency_map: state.concurrency_map,
         sort: sort.to_string(),
         dir: dir.to_string(),
     })
@@ -85,7 +82,6 @@ pub(crate) async fn scheduled_jobs(
     let opts = list_opts(page);
 
     let total = state.storage.scheduled_count().await?;
-
     let mut jobs = state.storage.list_scheduled(&opts).await?;
 
     let has_next = jobs.len() > JOBS_PER_PAGE;
@@ -110,7 +106,6 @@ pub(crate) async fn dead_jobs(
     let opts = list_opts(page);
 
     let total = state.storage.dead_count().await?;
-
     let mut jobs = state.storage.list_dead(&opts).await?;
 
     let has_next = jobs.len() > JOBS_PER_PAGE;
@@ -135,7 +130,6 @@ pub(crate) async fn retry_jobs(
     let opts = list_opts(page);
 
     let total = state.storage.retries_count().await?;
-
     let mut jobs = state.storage.list_retries(&opts).await?;
 
     let has_next = jobs.len() > JOBS_PER_PAGE;
@@ -164,7 +158,6 @@ pub(crate) async fn queue_detail(
         .storage
         .enqueued_count(RawQueue(queue_key.clone()))
         .await?;
-
     let mut jobs = state
         .storage
         .list_queue_jobs(RawQueue(queue_key.clone()), &opts)
@@ -214,15 +207,6 @@ pub(crate) async fn delete_job(
 }
 
 // --- Helpers ---
-
-fn build_concurrency_map(state: &OxanusWebState) -> HashMap<String, usize> {
-    state
-        .catalog
-        .queues
-        .iter()
-        .map(|q| (q.key.clone(), q.concurrency))
-        .collect()
-}
 
 #[derive(Serialize)]
 struct RawQueue(String);

--- a/oxanus-web/src/lib.rs
+++ b/oxanus-web/src/lib.rs
@@ -3,6 +3,8 @@ mod filters;
 mod handlers;
 mod templates;
 
+use std::collections::HashMap;
+
 use axum::{
     Router,
     extract::Extension,
@@ -16,6 +18,23 @@ pub struct OxanusWebState {
     pub storage: oxanus::Storage,
     pub catalog: oxanus::Catalog,
     pub base_path: String,
+    pub concurrency_map: HashMap<String, usize>,
+}
+
+impl OxanusWebState {
+    pub fn new(storage: oxanus::Storage, catalog: oxanus::Catalog, base_path: String) -> Self {
+        let concurrency_map = catalog
+            .queues
+            .iter()
+            .map(|q| (q.key.clone(), q.concurrency))
+            .collect();
+        Self {
+            storage,
+            catalog,
+            base_path,
+            concurrency_map,
+        }
+    }
 }
 
 pub fn router(state: OxanusWebState) -> Router {

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -95,11 +95,11 @@ let config = ComponentRegistry::build_config(&storage)
     .with_graceful_shutdown(tokio::signal::ctrl_c());
 
 // Create the oxanus-web router
-let oxanus_router = oxanus_web::router(OxanusWebState {
-    catalog: config.catalog(),
-    storage: config.storage.clone(),
-    base_path: "/oxanus".to_string(),
-});
+let oxanus_router = oxanus_web::router(OxanusWebState::new(
+    config.storage.clone(),
+    config.catalog(),
+    "/oxanus".to_string(),
+));
 
 // Nest it into your existing axum app
 let app = your_app_router().nest("/oxanus", oxanus_router);


### PR DESCRIPTION
## Summary
- Consolidate `relative_time` filter to reuse the shared `format_relative` helper instead of maintaining duplicate inline formatting logic
- Pre-compute `concurrency_map` once at `OxanusWebState` construction via a new `::new()` constructor, instead of rebuilding the HashMap on every request
- Update README example to use the new constructor

## Test plan
- [x] `cargo check --all` passes
- [x] `cargo clippy --all-features --workspace` clean
- [x] `cargo fmt --all --check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor with small behavior change potential in time formatting (e.g., future timestamps) and a state construction API change (`OxanusWebState::new`).
> 
> **Overview**
> Deduplicates the Askama relative-time filters by routing `relative_time`, `relative_time_micros`, and `relative_time_micros_opt` through a shared `format_relative` helper (including support for future timestamps via `"in …"`).
> 
> Precomputes and stores a `concurrency_map` on `OxanusWebState` via a new `OxanusWebState::new()` constructor, removes per-request map rebuilding in handlers, and updates the README example to use the new constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 688f071a2ff0d8d6664835e1275865c1884fa67e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->