### PR TITLE
Eliminate redundant Redis fetch in hot path + bench script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env.test
+.bench-results/

--- a/oxanus/benches/concurrency.rs
+++ b/oxanus/benches/concurrency.rs
@@ -51,61 +51,27 @@ impl oxanus::Worker for WorkerNoop {
     }
 }
 
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_0_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
-    let sleep_ms = 0;
-    let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
+macro_rules! bench_jobs {
+    ($name:ident, $sleep_ms:expr) => {
+        #[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+        fn $name(bencher: divan::Bencher, n: usize) {
+            let rt = &tokio::runtime::Runtime::new().unwrap();
+            let config = build_config(n);
+            rt.block_on(async { setup(config, JOBS_COUNT, $sleep_ms).await.unwrap() });
 
-    bencher.bench(|| {
-        rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
-        })
-    });
+            bencher.bench(|| {
+                rt.block_on(async {
+                    execute(n, JOBS_COUNT).await.unwrap();
+                })
+            });
+        }
+    };
 }
 
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_1_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
-    let sleep_ms = 1;
-    let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
-
-    bencher.bench(|| {
-        rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
-        })
-    });
-}
-
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_2_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
-    let sleep_ms = 2;
-    let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
-
-    bencher.bench(|| {
-        rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
-        })
-    });
-}
-
-#[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
-fn run_1000_jobs_taking_10_ms(bencher: divan::Bencher, n: usize) {
-    let rt = &tokio::runtime::Runtime::new().unwrap();
-    let sleep_ms = 10;
-    let config = build_config(n);
-    rt.block_on(async { setup(config, JOBS_COUNT, sleep_ms).await.unwrap() });
-
-    bencher.bench(|| {
-        rt.block_on(async {
-            execute(n, JOBS_COUNT).await.unwrap();
-        })
-    });
-}
+bench_jobs!(run_1000_jobs_taking_0_ms, 0);
+bench_jobs!(run_1000_jobs_taking_1_ms, 1);
+bench_jobs!(run_1000_jobs_taking_2_ms, 2);
+bench_jobs!(run_1000_jobs_taking_10_ms, 10);
 
 async fn setup(
     config: oxanus::Config<WorkerState, ServiceError>,

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -83,7 +83,7 @@ where
 {
     tracing::trace!("Processing job: {:?}", job_event);
 
-    let envelope: JobEnvelope = match config.storage.internal.get_job(&job_event.job_id).await {
+    let mut envelope: JobEnvelope = match config.storage.internal.get_job(&job_event.job_id).await {
         Ok(Some(envelope)) => envelope,
         Ok(None) => {
             tracing::warn!("Job {} not found", job_event.job_id);
@@ -125,7 +125,7 @@ where
         }
     };
 
-    let result = executor::run(config, job, &envelope, ctx.clone()).await?;
+    let result = executor::run(config, job, &mut envelope, ctx.clone()).await?;
     drop(job_event.permit);
 
     process_result(result_tx, result, envelope).await;

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -49,7 +49,7 @@ where
     };
 
     // Process the job and handle panics
-    let result = match AssertUnwindSafe(process(&worker, full_ctx, &envelope))
+    let result = match AssertUnwindSafe(process(&worker, full_ctx, envelope))
         .catch_unwind()
         .await
     {
@@ -85,7 +85,7 @@ where
         ExecutionResult::NotPanic(result) => {
             match &result {
                 Ok(()) => {
-                    if let Err(e) = config.storage.internal.finish_with_success(&envelope).await {
+                    if let Err(e) = config.storage.internal.finish_with_success(envelope).await {
                         tracing::error!("Failed to finish job: {}", e);
                     }
                 }
@@ -100,7 +100,7 @@ where
                         "Job failed"
                     );
 
-                    handle_err(config, &e.to_string(), &envelope, retry_delay, max_retries).await;
+                    handle_err(config, &e.to_string(), envelope, retry_delay, max_retries).await;
                 }
             }
 
@@ -110,7 +110,7 @@ where
             #[cfg(feature = "sentry")]
             sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
 
-            handle_err(config, &panic_msg, &envelope, retry_delay, max_retries).await;
+            handle_err(config, &panic_msg, envelope, retry_delay, max_retries).await;
 
             Ok(Err(ExecutionError::Panic()))
         }

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -21,14 +21,14 @@ pub(crate) enum ExecutionError<ET> {
 pub async fn run<DT, ET>(
     config: Arc<Config<DT, ET>>,
     worker: BoxedWorker<DT, ET>,
-    envelope: &JobEnvelope,
+    envelope: &mut JobEnvelope,
     ctx: ContextValue<DT>,
 ) -> Result<Result<(), ExecutionError<ET>>, OxanusError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let envelope = config.storage.internal.set_started_at(&envelope.id).await?;
+    config.storage.internal.set_started_at(envelope).await?;
 
     tracing::info!(
         job_id = envelope.id,

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -309,14 +309,10 @@ impl StorageInternal {
         Ok(envelope)
     }
 
-    pub async fn set_started_at(&self, id: &JobId) -> Result<JobEnvelope, OxanusError> {
-        let mut envelope = match self.get_job(id).await? {
-            Some(envelope) => envelope,
-            None => return Err(OxanusError::JobNotFound),
-        };
+    pub async fn set_started_at(&self, envelope: &mut JobEnvelope) -> Result<(), OxanusError> {
         envelope.meta.started_at = Some(chrono::Utc::now().timestamp_micros());
-        self.update_job(&envelope).await?;
-        Ok(envelope)
+        self.update_job(envelope).await?;
+        Ok(())
     }
 
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanusError> {
@@ -1509,16 +1505,16 @@ mod tests {
         let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
         let queue = random_string();
 
-        let envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
+        let mut envelope = JobEnvelope::new(queue.clone(), TestWorker {})?;
         assert!(envelope.meta.started_at.is_none());
 
         storage.enqueue(envelope.clone()).await?;
 
         let before = chrono::Utc::now().timestamp_micros();
-        let updated = storage.set_started_at(&envelope.id).await?;
+        storage.set_started_at(&mut envelope).await?;
         let after = chrono::Utc::now().timestamp_micros();
 
-        let started_at = updated.meta.started_at.expect("started_at should be set");
+        let started_at = envelope.meta.started_at.expect("started_at should be set");
         assert!(started_at >= before);
         assert!(started_at <= after);
 
@@ -1527,16 +1523,6 @@ mod tests {
             .await?
             .expect("job should exist");
         assert_eq!(persisted.meta.started_at, Some(started_at));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_set_started_at_job_not_found() -> TestResult {
-        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
-
-        let result = storage.set_started_at(&"nonexistent".to_string()).await;
-        assert!(result.is_err());
 
         Ok(())
     }

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+BENCH_DIR=".bench-results"
+
+usage() {
+    echo "Usage:"
+    echo "  $0 run <label>         Run benchmarks and save results with a label"
+    echo "  $0 compare <a> <b>     Compare two labeled benchmark runs"
+    echo "  $0 list                List saved benchmark results"
+    echo "  $0 latest              Show the most recent result"
+    echo ""
+    echo "Examples:"
+    echo "  $0 run before          # baseline run"
+    echo "  # ... make changes ..."
+    echo "  $0 run after           # run after changes"
+    echo "  $0 compare before after"
+}
+
+cmd_run() {
+    local label="$1"
+    if [ -z "$label" ]; then
+        echo "Error: label is required"
+        usage
+        exit 1
+    fi
+
+    mkdir -p "$BENCH_DIR"
+
+    local outfile="$BENCH_DIR/$label.txt"
+    echo "Running benchmarks (label: $label)..."
+    echo ""
+
+    cargo bench -p oxanus 2>&1 | tee "$outfile"
+
+    echo ""
+    echo "Results saved to $outfile"
+}
+
+cmd_compare() {
+    local a="$1"
+    local b="$2"
+
+    if [ -z "$a" ] || [ -z "$b" ]; then
+        echo "Error: two labels are required"
+        usage
+        exit 1
+    fi
+
+    local file_a="$BENCH_DIR/$a.txt"
+    local file_b="$BENCH_DIR/$b.txt"
+
+    if [ ! -f "$file_a" ]; then
+        echo "Error: no results found for '$a' ($file_a)"
+        exit 1
+    fi
+    if [ ! -f "$file_b" ]; then
+        echo "Error: no results found for '$b' ($file_b)"
+        exit 1
+    fi
+
+    # Extract timing lines: bench name and time
+    extract_timings() {
+        grep -E '^\s+│' "$1" | sed 's/│/|/g' || true
+    }
+
+    echo "=== Benchmark Comparison: $a vs $b ==="
+    echo ""
+
+    # Show them side by side using diff
+    paste <(
+        echo "--- $a ---"
+        grep -E '(╰─|│|├─)' "$file_a" || grep -E '^\s' "$file_a"
+    ) <(
+        echo "--- $b ---"
+        grep -E '(╰─|│|├─)' "$file_b" || grep -E '^\s' "$file_b"
+    ) | column -t -s $'\t' 2>/dev/null || {
+        # Fallback: show sequentially
+        echo "--- $a ---"
+        cat "$file_a"
+        echo ""
+        echo "--- $b ---"
+        cat "$file_b"
+    }
+
+    echo ""
+    echo "Full results:"
+    echo "  $file_a"
+    echo "  $file_b"
+}
+
+cmd_list() {
+    if [ ! -d "$BENCH_DIR" ]; then
+        echo "No benchmark results found. Run '$0 run <label>' first."
+        exit 0
+    fi
+
+    echo "Saved benchmark results:"
+    for f in "$BENCH_DIR"/*.txt; do
+        [ -f "$f" ] || continue
+        local label=$(basename "$f" .txt)
+        local date=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$f" 2>/dev/null || stat -c "%y" "$f" 2>/dev/null | cut -d. -f1)
+        printf "  %-20s %s\n" "$label" "$date"
+    done
+}
+
+cmd_latest() {
+    if [ ! -d "$BENCH_DIR" ]; then
+        echo "No benchmark results found."
+        exit 1
+    fi
+
+    local latest=$(ls -t "$BENCH_DIR"/*.txt 2>/dev/null | head -1)
+    if [ -z "$latest" ]; then
+        echo "No benchmark results found."
+        exit 1
+    fi
+
+    echo "Latest: $(basename "$latest" .txt)"
+    echo ""
+    cat "$latest"
+}
+
+# Main
+case "${1:-}" in
+    run)     cmd_run "$2" ;;
+    compare) cmd_compare "$2" "$3" ;;
+    list)    cmd_list ;;
+    latest)  cmd_latest ;;
+    *)       usage ;;
+esac


### PR DESCRIPTION
## Summary
- **Performance**: `set_started_at` was re-fetching the job envelope from Redis (`HGET`) even though `process_job` already loaded it. Now passes the envelope by `&mut` reference, eliminating 1 Redis round trip per job.
- **Bench script**: Adds `scripts/bench.sh` for labeled benchmark runs and side-by-side comparison (`run <label>`, `compare <a> <b>`, `list`, `latest`).
- **Bench cleanup**: Deduplicates the four benchmark functions into a `bench_jobs!` macro.

## Benchmark results (concurrency=1, 1000 jobs)

| Scenario | Before | After | Delta |
|---|---|---|---|
| 0ms jobs | 3.555s | 3.156s | **-11.2%** |
| 1ms jobs | 5.798s | 5.315s | **-8.3%** |
| 2ms jobs | 7.503s | 6.416s | **-14.5%** |
| 10ms jobs | 16.89s | 16.16s | **-4.3%** |

## Test plan
- [x] `cargo check --all-features --workspace` passes
- [x] `cargo test -p oxanus` passes (including updated `test_set_started_at`)
- [x] `cargo bench` runs successfully
- [x] Compared before/after benchmarks via `scripts/bench.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the job execution hot path by changing how `started_at` is persisted, which could affect job bookkeeping if the in-memory envelope diverges from Redis. Scope is small and covered by an updated unit test, but it impacts core runtime behavior.
> 
> **Overview**
> Removes an extra Redis round-trip in the job processing hot path by changing `StorageInternal::set_started_at` to mutate an already-loaded `JobEnvelope` (passed by `&mut`) instead of re-fetching it from Redis, and updates coordinator/executor call sites accordingly.
> 
> Adds a small benchmarking workflow: `.bench-results/` is gitignored, `scripts/bench.sh` supports labeled `cargo bench` runs and comparisons, and the concurrency benchmark is deduplicated via a `bench_jobs!` macro.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4063a2b8f53cc68c078b75ae4d0b3fe8d95d8b6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->