### PR TITLE
Add Revive button to dead jobs dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "serde",
  "serde_json",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -23,3 +23,4 @@ chrono = { version = "^0.4", features = ["serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 urlencoding = "2"
+uuid = { version = "^1.17", features = ["v4"] }

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -1,4 +1,5 @@
 use axum::{
+    Form,
     extract::{Extension, Path, Query},
     response::Redirect,
 };
@@ -206,6 +207,43 @@ pub(crate) async fn delete_job(
     )))
 }
 
+pub(crate) async fn enqueue_job(
+    Extension(state): Extension<OxanusWebState>,
+    Form(form): Form<EnqueueJobForm>,
+) -> Result<Redirect, OxanusWebError> {
+    let now = chrono::Utc::now().timestamp_micros();
+    let id = uuid::Uuid::new_v4().to_string();
+    let args: serde_json::Value =
+        serde_json::from_str(&form.args).map_err(oxanus::OxanusError::from)?;
+
+    let envelope = oxanus::JobEnvelope {
+        id: id.clone(),
+        queue: form.queue.clone(),
+        job: oxanus::Job {
+            name: form.name,
+            args,
+        },
+        meta: oxanus::JobMeta {
+            id,
+            retries: 0,
+            unique: false,
+            on_conflict: None,
+            created_at: now,
+            scheduled_at: now,
+            started_at: None,
+            state: None,
+            resurrect: true,
+            error: None,
+            throttle_cost: None,
+        },
+    };
+
+    state.storage.enqueue_envelope(envelope).await?;
+
+    let redirect = form.redirect.as_deref().unwrap_or("/dead");
+    Ok(Redirect::to(&format!("{}{}", state.base_path, redirect)))
+}
+
 // --- Helpers ---
 
 #[derive(Serialize)]
@@ -237,6 +275,15 @@ pub(crate) struct QueuesParams {
     sort: Option<String>,
     #[serde(default)]
     dir: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct EnqueueJobForm {
+    queue: String,
+    name: String,
+    args: String,
+    #[serde(default)]
+    redirect: Option<String>,
 }
 
 fn list_opts(page: usize) -> oxanus::QueueListOpts {

--- a/oxanus-web/src/lib.rs
+++ b/oxanus-web/src/lib.rs
@@ -47,6 +47,7 @@ pub fn router(state: OxanusWebState) -> Router {
         .route("/dead", get(handlers::dead_jobs))
         .route("/retries", get(handlers::retry_jobs))
         .route("/queues/{queue_key}", get(handlers::queue_detail))
+        .route("/enqueue", post(handlers::enqueue_job))
         .route("/queues/{queue_key}/wipe", post(handlers::wipe_queue))
         .route(
             "/queues/{queue_key}/jobs/{job_id}/delete",

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -206,6 +206,10 @@ impl JobListKind {
         }
     }
 
+    pub fn is_dead(&self) -> bool {
+        matches!(self, Self::Dead)
+    }
+
     pub fn dot_class(&self) -> &'static str {
         match self {
             Self::Dead => "bg-red-400",

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -90,6 +90,17 @@
                 {% endif %}
                 {% when None %}
                 {% endmatch %}
+                {% if kind.is_dead() %}
+                <div class="mt-3 flex justify-end">
+                    <form method="POST" action="{{ base_path }}/enqueue" onsubmit="return confirm('Revive job {{ job.job.name }}?')">
+                        <input type="hidden" name="queue" value="{{ job.queue }}">
+                        <input type="hidden" name="name" value="{{ job.job.name }}">
+                        <input type="hidden" name="args" value="{{ job.job.args }}">
+                        <input type="hidden" name="redirect" value="/dead">
+                        <button type="submit" class="px-2.5 py-1 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-xs transition-colors">Revive</button>
+                    </form>
+                </div>
+                {% endif %}
             </div>
             {% endfor %}
         </div>

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -111,7 +111,7 @@ pub use crate::config::Config;
 pub use crate::context::{Context, JobState};
 pub use crate::drainer::drain;
 pub use crate::error::OxanusError;
-pub use crate::job_envelope::{JobConflictStrategy, JobEnvelope, JobId, JobMeta};
+pub use crate::job_envelope::{Job, JobConflictStrategy, JobEnvelope, JobId, JobMeta};
 pub use crate::launcher::run;
 pub use crate::queue::{Queue, QueueConfig, QueueKind, QueueThrottle};
 pub use crate::stats::*;

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -340,6 +340,23 @@ impl Storage {
         self.internal.list_scheduled(opts).await
     }
 
+    /// Enqueues a pre-built job envelope for immediate processing.
+    ///
+    /// Unlike [`enqueue`](Self::enqueue), this accepts a raw [`JobEnvelope`] directly,
+    /// which is useful for re-enqueueing jobs from the dead queue or other sources
+    /// where the original worker type is not available.
+    ///
+    /// # Arguments
+    ///
+    /// * `envelope` - The job envelope to enqueue
+    ///
+    /// # Returns
+    ///
+    /// The [`JobId`] of the enqueued job, or an [`OxanusError`] if the operation fails.
+    pub async fn enqueue_envelope(&self, envelope: JobEnvelope) -> Result<JobId, OxanusError> {
+        self.internal.enqueue(envelope).await
+    }
+
     /// Removes all jobs from the specified queue.
     ///
     /// # Arguments

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1526,4 +1526,47 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_enqueue_envelope() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        let now = chrono::Utc::now().timestamp_micros();
+        let id = uuid::Uuid::new_v4().to_string();
+        let envelope = JobEnvelope {
+            id: id.clone(),
+            queue: queue.clone(),
+            job: crate::job_envelope::Job {
+                name: "MyWorker".to_string(),
+                args: serde_json::json!({"key": "value"}),
+            },
+            meta: crate::job_envelope::JobMeta {
+                id: id.clone(),
+                retries: 0,
+                unique: false,
+                on_conflict: None,
+                created_at: now,
+                scheduled_at: now,
+                started_at: None,
+                state: None,
+                resurrect: true,
+                error: None,
+                throttle_cost: None,
+            },
+        };
+
+        let returned_id = storage.enqueue(envelope).await?;
+        assert_eq!(returned_id, id);
+        assert_eq!(storage.enqueued_count(&queue).await?, 1);
+
+        let job = storage.get_job(&id).await?.expect("job should exist");
+        assert_eq!(job.queue, queue);
+        assert_eq!(job.job.name, "MyWorker");
+        assert_eq!(job.job.args, serde_json::json!({"key": "value"}));
+        assert_eq!(job.meta.retries, 0);
+        assert!(job.meta.error.is_none());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a generic `POST /enqueue` endpoint that accepts job name, args, and queue via form data and enqueues a fresh copy for immediate processing
- Dead jobs page now shows a "Revive" button that re-enqueues the job on its original queue
- Exposes `Storage::enqueue_envelope` for enqueueing pre-built `JobEnvelope`s without a `Worker` type
- Re-exports `Job` from the public API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated `POST /enqueue` path in the web UI that can create and enqueue arbitrary jobs/envelopes, which could be sensitive if the UI is exposed beyond trusted operators. Also expands the public storage API surface by allowing raw `JobEnvelope` enqueueing, so misuse could bypass worker-typed validation.
> 
> **Overview**
> Adds a generic `POST /enqueue` handler in `oxanus-web` that accepts form fields (`queue`, `name`, `args`, optional `redirect`) and enqueues a freshly generated `JobEnvelope` (new UUID + current timestamps) for immediate processing.
> 
> Updates the Dead Jobs UI to show a **Revive** button that posts the original job’s queue/name/args to `/enqueue`, effectively re-enqueueing a copy of the dead job.
> 
> Exposes new core API surface by re-exporting `Job` and adding `Storage::enqueue_envelope` (with a new test) to allow enqueuing pre-built envelopes without requiring a concrete `Worker` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3792826f486887f0a0900d26994535cf89e2fc64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->