### PR TITLE
Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.2]
+
+### Added
+- Web UI dashboard (`oxanus-web` crate) for monitoring jobs, queues, and cron
+- Revive button to dead jobs dashboard
+- Link enqueued stat box to queues tab in web dashboard
+
+### Changed
+- Eliminate redundant Redis fetch in job execution hot path
+- Deduplicate relative time filter and pre-compute concurrency map
+
 ## [0.9.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> This PR is a release/version bump only (no functional code changes shown), updating crate versions and documenting the 0.9.2 release notes. Risk is low aside from potential downstream packaging/publishing expectations tied to the new version number.
> 
> **Overview**
> Updates the project to **v0.9.2** by bumping the `oxanus` and `oxanus-web` crate versions (including `Cargo.lock`).
> 
> Adds the `0.9.2` section to `CHANGELOG.md`, documenting the new web dashboard additions and a couple of performance/cleanup changes for this release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10953721bc237a081d7fa9c3f2b02756399fbde7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->