### PR TITLE
Fix panic instrumentation

### DIFF
--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -124,7 +124,7 @@ where
     args = %envelope.job.args,
     retries = envelope.meta.retries,
     latency_ms = envelope.meta.latency_millis(),
-    success,
+    success = false,
 )))]
 async fn process<DT, ET>(
     worker: &BoxedWorker<DT, ET>,


### PR DESCRIPTION
In case of panic, trace would be missing success value completely instead of being it set to false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts tracing instrumentation metadata and does not change job execution or retry behavior.
> 
> **Overview**
> Fixes job span instrumentation so the `success` field is always present by initializing it to `false` in `process`’s `tracing::instrument` fields, preventing missing `success` values when a panic occurs before `span.record()` runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ff9d98b9f4ece25c7892bbb3486f5d62cfbe5fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->