### PR TITLE
Release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.3]
+
+### Fixed
+- Fix panic instrumentation: trace was missing `success` value instead of recording `false`
+
 ## [0.9.2]
 
 ### Added

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Fix panic instrumentation: trace was missing `success` value instead of recording `false`
- Bump oxanus version to 0.9.3
- Update changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata updates (changelog + crate version bump) with no functional code changes in this diff, so runtime risk is low.
> 
> **Overview**
> Prepares the `0.9.3` release by bumping the `oxanus` crate version from `0.9.2` to `0.9.3` and adding a `CHANGELOG.md` entry noting a fix for missing `success` in panic instrumentation traces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cc500a46d68b1d186e7b017f82d51bacd7253c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->