### PR TITLE
Web: truncate long errors and add Copy Error Info button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -155,9 +155,8 @@
             'Error: ' + btn.dataset.error
         ].join('\n');
         navigator.clipboard.writeText(info).then(function() {
-            var orig = btn.textContent;
             btn.textContent = 'Copied!';
-            setTimeout(function() { btn.textContent = orig; }, 1500);
+            setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);
         }, function() {
             btn.textContent = 'Copy failed';
             setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -76,7 +76,13 @@
                 {% when Some with (error) %}
                 <details class="mt-3" open>
                     <summary class="text-xs text-red-400 cursor-pointer hover:text-red-300">Error</summary>
+                    {% if error.lines().count() > 10 %}
+                    <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50 error-truncated">{{ error.lines().take(10).collect::<Vec<_>>().join("\n") }}</pre>
+                    <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50 error-full" style="display:none">{{ error }}</pre>
+                    <button onclick="toggleFullError(this)" class="mt-1 text-xs text-red-400 hover:text-red-300 cursor-pointer underline">View full error</button>
+                    {% else %}
                     <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50">{{ error }}</pre>
+                    {% endif %}
                 </details>
                 {% when None %}
                 {% endmatch %}
@@ -91,7 +97,14 @@
                 {% when None %}
                 {% endmatch %}
                 {% if kind.is_dead() %}
-                <div class="mt-3 flex justify-end">
+                <div class="mt-3 flex justify-end gap-2">
+                    <button onclick="copyErrorInfo(this)" class="px-2.5 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300 text-xs transition-colors"
+                        data-job-name="{{ job.job.name }}"
+                        data-queue="{{ job.queue }}"
+                        data-created="{{ job.meta.created_at|relative_time_micros }}"
+                        data-args="{{ job.job.args }}"
+                        data-error="{% match job.meta.error %}{% when Some with (e) %}{{ e }}{% when None %}{% endmatch %}"
+                    >Copy Error Info</button>
                     <form method="POST" action="{{ base_path }}/enqueue" onsubmit="return confirm('Revive job {{ job.job.name }}?')">
                         <input type="hidden" name="queue" value="{{ job.queue }}">
                         <input type="hidden" name="name" value="{{ job.job.name }}">
@@ -118,5 +131,38 @@
         </div>
         {% endif %}
     </div>
+    <script>
+    function toggleFullError(btn) {
+        var container = btn.parentElement;
+        var truncated = container.querySelector('.error-truncated');
+        var full = container.querySelector('.error-full');
+        if (full.style.display === 'none') {
+            truncated.style.display = 'none';
+            full.style.display = '';
+            btn.textContent = 'Show less';
+        } else {
+            truncated.style.display = '';
+            full.style.display = 'none';
+            btn.textContent = 'View full error';
+        }
+    }
+    function copyErrorInfo(btn) {
+        var info = [
+            'Job: ' + btn.dataset.jobName,
+            'Queue: ' + btn.dataset.queue,
+            'Created: ' + btn.dataset.created,
+            'Arguments: ' + btn.dataset.args,
+            'Error: ' + btn.dataset.error
+        ].join('\n');
+        navigator.clipboard.writeText(info).then(function() {
+            var orig = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(function() { btn.textContent = orig; }, 1500);
+        }, function() {
+            btn.textContent = 'Copy failed';
+            setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);
+        });
+    }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Errors with 10+ lines are truncated to first 10 lines with a "View full error" / "Show less" toggle
- Added "Copy Error Info" button on dead jobs (next to Revive) that copies job name, queue, created time, arguments, and full error to clipboard
- Clipboard copy includes error feedback ("Copied!" / "Copy failed")

## Test plan
- [ ] View a dead job with an error longer than 10 lines, verify truncation and toggle
- [ ] View a dead job with a short error, verify it displays normally (no toggle)
- [ ] Click "Copy Error Info", paste elsewhere, verify all fields are present
- [ ] Verify "Copied!" feedback appears briefly after clicking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only template changes plus a lockfile version bump; main risk is minor UX/browser-compatibility issues with `navigator.clipboard` and rendering long error strings in HTML attributes.
> 
> **Overview**
> Improves the dead-jobs view by truncating multi-line errors (over 10 lines) and adding a **View full error / Show less** toggle to expand the full stack trace on demand.
> 
> Adds a **Copy Error Info** button next to *Revive* for dead jobs, copying job name/queue/timestamps/args/full error to the clipboard with basic success/failure feedback.
> 
> Also bumps the `oxanus` crate in `Cargo.lock` from `0.9.2` to `0.9.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e4413a070b24de8aeedc512724a28164cb420c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->