### PR TITLE
Add queue stats tiles and dashboard latency tile

### DIFF
--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -155,10 +155,15 @@ pub(crate) async fn queue_detail(
     let page = params.page.max(1);
     let opts = list_opts(page);
 
-    let total = state
-        .storage
-        .enqueued_count(RawQueue(queue_key.clone()))
-        .await?;
+    let stats = state.storage.stats().await?;
+    let queue_stats = stats.queues.iter().find(|q| q.key == queue_key).cloned();
+    let total = queue_stats.as_ref().map_or(0, |q| q.enqueued);
+    let busy = stats
+        .processing
+        .iter()
+        .filter(|p| p.job_envelope.queue == queue_key)
+        .count();
+
     let mut jobs = state
         .storage
         .list_queue_jobs(RawQueue(queue_key.clone()), &opts)
@@ -171,6 +176,8 @@ pub(crate) async fn queue_detail(
         base_path: state.base_path,
         active_tab: "/queues",
         queue_key,
+        queue_stats,
+        busy,
         jobs,
         page,
         total,

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -151,6 +151,8 @@ pub(crate) struct QueueDetailTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub queue_key: String,
+    pub queue_stats: Option<oxanus::QueueStats>,
+    pub busy: usize,
     pub jobs: Vec<oxanus::JobEnvelope>,
     pub page: usize,
     pub total: usize,

--- a/oxanus-web/templates/dashboard.html
+++ b/oxanus-web/templates/dashboard.html
@@ -15,7 +15,7 @@
 
         {% include "_tabs.html" %}
 
-        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4 mb-10">
+        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4 mb-10">
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
                 <div class="text-2xl font-semibold text-green-400">{{ stats.global.processed|format_number_i64 }}</div>
@@ -44,6 +44,10 @@
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Dead</div>
                 <div class="text-2xl font-semibold text-red-400">{{ stats.global.dead|format_number }}</div>
             </a>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Latency</div>
+                <div class="text-2xl font-semibold text-yellow-400">{{ stats.global.latency_s_max|format_latency }}</div>
+            </div>
         </div>
 
         <section class="mb-10">

--- a/oxanus-web/templates/queue_detail.html
+++ b/oxanus-web/templates/queue_detail.html
@@ -23,6 +23,41 @@
             </form>
         </div>
 
+        {% match queue_stats %}
+        {% when Some with (qs) %}
+        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4 mb-8">
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Enqueued</div>
+                <div class="text-2xl font-semibold text-blue-400">{{ qs.enqueued|format_number }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Busy</div>
+                <div class="text-2xl font-semibold text-purple-400">{{ busy|format_number }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
+                <div class="text-2xl font-semibold text-green-400">{{ qs.processed|format_number_i64 }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded</div>
+                <div class="text-2xl font-semibold text-emerald-400">{{ qs.succeeded|format_number_i64 }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
+                <div class="text-2xl font-semibold text-red-400">{{ qs.failed|format_number_i64 }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Panicked</div>
+                <div class="text-2xl font-semibold text-orange-400">{{ qs.panicked|format_number_i64 }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Latency</div>
+                <div class="text-2xl font-semibold text-yellow-400">{{ qs.latency_s|format_latency }}</div>
+            </div>
+        </div>
+        {% when None %}
+        {% endmatch %}
+
         <div class="flex items-center justify-between mb-4">
             <h2 class="text-lg font-semibold">
                 {% if total > 0 %}


### PR DESCRIPTION
## Summary
- Add 7 stat tiles (enqueued, busy, processed, succeeded, failed, panicked, latency) to the queue detail page (`/queues/:key`)
- Add a max latency tile to the dashboard overview

## Test plan
- [ ] Verify queue detail page shows stat tiles with correct values
- [ ] Verify dashboard shows latency tile
- [ ] Verify tiles display correctly on different screen sizes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/handler changes that only read existing `stats()` data, but they do alter how queue totals are computed (now derived from stats rather than a dedicated count call).
> 
> **Overview**
> Adds a new **max latency** tile to the dashboard overview and expands the top stats grid to accommodate it.
> 
> Enhances the `/queues/:key` detail page with a 7-tile stats header (enqueued, busy, processed, succeeded, failed, panicked, latency). The `queue_detail` handler now pulls queue totals and the per-queue busy count from `storage.stats()` and passes `queue_stats`/`busy` into `QueueDetailTemplate` for conditional rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740624bbc1a1caf2f0619ea7ce269b383d4d01a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->