### PR TITLE
Bump oxanus and oxanus-web to 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.4]
+
+### Added
+- Queue stats tiles to queue detail page
+- Add latency tile to overview dashboard
+
 ## [0.9.3]
+
+### Added
+- Truncate long errors and add Copy Error Info button in web dashboard
 
 ### Fixed
 - Fix panic instrumentation: trace was missing `success` value instead of recording `false`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump `oxanus` and `oxanus-web` versions from 0.9.3 to 0.9.4
- Add 0.9.4 changelog entry (queue stats tiles, latency tile)
- Backfill missing 0.9.3 changelog entry (Copy Error Info button)

## Test plan
- [ ] Verify `cargo check --all` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates crate versions and changelog/Cargo.lock metadata with no functional code changes.
> 
> **Overview**
> Bumps `oxanus` and `oxanus-web` from `0.9.3` to `0.9.4` (including `Cargo.lock`).
> 
> Updates `CHANGELOG.md` with a new `0.9.4` entry (queue stats tiles, overview latency tile) and backfills the missing `0.9.3` added item for the Copy Error Info UI improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ccd0ea9c29c761364a3026a32c4012bcaf49aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->