### PR TITLE
Add queue links in job cards and show dynamic child queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.5]
+
+### Added
+- Make queue name clickable in job cards linking to queue detail page
+- Show dynamic child queues in Active Queues sections on dashboard and busy pages
+
 ## [0.9.4]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus-web/templates/busy.html
+++ b/oxanus-web/templates/busy.html
@@ -78,6 +78,17 @@
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                             <td class="py-3 text-right text-purple-400">{{ queue.latency_s|format_latency }}</td>
                         </tr>
+                        {% for dq in &queue.queues %}
+                        {% if dq.enqueued > 0 %}
+                        <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
+                            <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
+                            <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>
+                            <td class="py-2 text-right text-xs text-purple-400">{{ dq.latency_s|format_latency }}</td>
+                        </tr>
+                        {% endif %}
+                        {% endfor %}
                         {% endif %}
                         {% endfor %}
                     </tbody>
@@ -106,7 +117,7 @@
                     <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
                         <div>
                             <span class="text-gray-500">Queue:</span>
-                            <span class="ml-1 text-gray-300">{{ item.job_envelope.queue }}</span>
+                            <a href="{{ base_path }}/queues/{{ item.job_envelope.queue|urlencode }}" class="ml-1 text-blue-400 hover:text-blue-300 hover:underline">{{ item.job_envelope.queue }}</a>
                         </div>
                         <div>
                             <span class="text-gray-500">Started:</span>

--- a/oxanus-web/templates/dashboard.html
+++ b/oxanus-web/templates/dashboard.html
@@ -111,6 +111,17 @@
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                             <td class="py-3 text-right text-purple-400">{{ queue.latency_s|format_latency }}</td>
                         </tr>
+                        {% for dq in &queue.queues %}
+                        {% if dq.enqueued > 0 %}
+                        <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
+                            <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
+                            <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>
+                            <td class="py-2 text-right text-xs text-purple-400">{{ dq.latency_s|format_latency }}</td>
+                        </tr>
+                        {% endif %}
+                        {% endfor %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -51,7 +51,7 @@
                 <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
                     <div>
                         <span class="text-gray-500">Queue:</span>
-                        <span class="ml-1 text-gray-300">{{ job.queue }}</span>
+                        <a href="{{ base_path }}/queues/{{ job.queue|urlencode }}" class="ml-1 text-blue-400 hover:text-blue-300 hover:underline">{{ job.queue }}</a>
                     </div>
                     <div>
                         <span class="text-gray-500">Retries:</span>

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Make queue name clickable in job cards (busy, retries, scheduled, dead pages) linking to queue detail page
- Show dynamic child queues with enqueued jobs in Active Queues sections on dashboard and busy pages
- Bump oxanus and oxanus-web to 0.9.5

## Test plan
- [ ] Verify queue name links work in job cards on busy, retries, scheduled, and dead pages
- [ ] Verify dynamic child queues appear under parent queues on dashboard and busy pages
- [ ] Verify child queue links navigate to correct queue detail page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI template changes (new links and additional queue rows) plus version/dependency bumps; no core queueing or data-handling logic is modified.
> 
> **Overview**
> Adds navigation improvements to the web UI by making queue names in job cards link to their queue detail pages.
> 
> Extends the dashboard and busy pages’ *Active/Queues* tables to render dynamic child queues (with enqueued jobs) under their parent queue, including links to the child queue detail view.
> 
> Bumps `oxanus`/`oxanus-web` to `0.9.5` (and updates `Cargo.lock` accordingly) and records the changes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98dd070d9e38c1f66188976ccaf266fc52a982a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->