### PR TITLE
Fix missing tiles on dynamic sub-queue detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.6]
+
+### Fixed
+- Show stats tiles on dynamic sub-queue detail pages
+
 ## [0.9.5]
 
 ### Added

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -156,7 +156,27 @@ pub(crate) async fn queue_detail(
     let opts = list_opts(page);
 
     let stats = state.storage.stats().await?;
-    let queue_stats = stats.queues.iter().find(|q| q.key == queue_key).cloned();
+    let queue_stats = stats
+        .queues
+        .iter()
+        .find(|q| q.key == queue_key)
+        .cloned()
+        .or_else(|| {
+            // For dynamic sub-queues (prefix#suffix), look inside parent's sub-queues
+            let (prefix, suffix) = queue_key.split_once('#')?;
+            let parent = stats.queues.iter().find(|q| q.key == prefix)?;
+            let dq = parent.queues.iter().find(|dq| dq.suffix == suffix)?;
+            Some(oxanus::QueueStats {
+                key: queue_key.clone(),
+                enqueued: dq.enqueued,
+                processed: dq.processed,
+                succeeded: dq.succeeded,
+                panicked: dq.panicked,
+                failed: dq.failed,
+                latency_s: dq.latency_s,
+                queues: Vec::new(),
+            })
+        });
     let total = queue_stats.as_ref().map_or(0, |q| q.enqueued);
     let busy = stats
         .processing


### PR DESCRIPTION
## Summary
- Dynamic sub-queue detail pages (e.g., `prefix#suffix`) were missing stats tiles because the handler only searched top-level `QueueStats` entries
- Added fallback lookup that splits the key by `#` and finds the matching `DynamicQueueStats` from the parent queue
- Bumps oxanus-web to 0.9.6

## Test plan
- [ ] Navigate to a dynamic sub-queue detail page and verify stats tiles (Enqueued, Busy, Processed, Succeeded, Failed, Panicked, Latency) are displayed
- [ ] Verify static queue detail pages still show tiles correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `queue_detail` stats lookup plus a version/changelog bump; primary risk is incorrect parsing of `prefix#suffix` keys leading to missing/incorrect stats display.
> 
> **Overview**
> Fixes missing stats tiles on dynamic sub-queue detail pages by extending `queue_detail` to *fallback* from top-level `QueueStats` lookup to parsing `prefix#suffix` and constructing a `QueueStats` from the parent queue’s `DynamicQueueStats`.
> 
> Bumps `oxanus-web` version to `0.9.6` and records the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ffa785540bbd7147f95631ffdc83ce06ca6860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->