### PR TITLE
Handle transient Redis errors without full shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -166,13 +166,17 @@ where
     loop {
         let all_queues: HashSet<String> = match &queue_config.kind {
             QueueKind::Static { key } => HashSet::from([key.clone()]),
-            QueueKind::Dynamic { prefix, .. } => {
-                config
-                    .storage
-                    .internal
-                    .queue_keys(&format!("{prefix}*"))
-                    .await?
-            }
+            QueueKind::Dynamic { prefix, .. } => config
+                .storage
+                .internal
+                .track_redis_result(
+                    config
+                        .storage
+                        .internal
+                        .queue_keys(&format!("{prefix}*"))
+                        .await,
+                )?
+                .unwrap_or_default(),
         };
         let new_queues: HashSet<String> = all_queues.difference(&tracked_queues).cloned().collect();
 
@@ -183,13 +187,24 @@ where
                 "Tracking queue"
             );
 
-            tokio::spawn(dispatcher::run(
-                Arc::clone(&config),
-                queue_config.clone(),
-                queue.clone(),
-                job_tx.clone(),
-                Arc::clone(&semaphores),
-            ));
+            let dispatcher_config = Arc::clone(&config);
+            let dispatcher_queue_config = queue_config.clone();
+            let dispatcher_job_tx = job_tx.clone();
+            let dispatcher_semaphores = Arc::clone(&semaphores);
+            let dispatcher_queue = queue.clone();
+            tokio::spawn(async move {
+                if let Err(e) = dispatcher::run(
+                    dispatcher_config,
+                    dispatcher_queue_config,
+                    dispatcher_queue,
+                    dispatcher_job_tx,
+                    dispatcher_semaphores,
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "Dispatcher exited with error");
+                }
+            });
 
             tracked_queues.insert(queue);
         }

--- a/oxanus/src/dispatcher.rs
+++ b/oxanus/src/dispatcher.rs
@@ -17,7 +17,8 @@ pub async fn run<DT, ET>(
     queue_key: String,
     job_tx: mpsc::Sender<WorkerJob>,
     semaphores: Arc<SemaphoresMap>,
-) where
+) -> Result<(), OxanusError>
+where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
@@ -27,12 +28,19 @@ pub async fn run<DT, ET>(
 
         tokio::select! {
             result = pop_queue_message(&config.storage.internal, &queue_config, &queue_key) => {
-                let job_id = result.expect("Failed to pop queue message");
-                let job = WorkerJob { job_id, permit };
-                job_tx
-                    .send(job)
-                    .await
-                    .expect("Failed to send job to worker");
+                match config.storage.internal.track_redis_result(result)? {
+                    Some(job_id) => {
+                        let job = WorkerJob { job_id, permit };
+                        job_tx
+                            .send(job)
+                            .await
+                            .expect("Failed to send job to worker");
+                    }
+                    None => {
+                        drop(permit);
+                        sleep(Duration::from_secs(1)).await;
+                    }
+                }
             }
             _ = config.cancel_token.cancelled() => {
                 tracing::debug!("Stopping dispatcher for queue {}", queue_key);
@@ -41,6 +49,8 @@ pub async fn run<DT, ET>(
             }
         }
     }
+
+    Ok(())
 }
 
 async fn pop_queue_message(

--- a/oxanus/src/result_collector.rs
+++ b/oxanus/src/result_collector.rs
@@ -39,7 +39,11 @@ where
         tokio::select! {
             result = rx.recv() => {
                 match result {
-                    Some(result) => update_stats(Arc::clone(&config), Arc::clone(&stats), result).await?,
+                    Some(result) => {
+                        config.storage.internal.track_redis_result(
+                            update_stats(Arc::clone(&config), Arc::clone(&stats), result).await
+                        )?;
+                    }
                     None => return Ok(()),
                 }
             }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1008,19 +1008,22 @@ impl StorageInternal {
 
             let scheduled_at = next.timestamp_micros();
             let job_id = format!("{job_name}-{scheduled_at}");
-            let envelope = JobEnvelope::new_cron(
-                cron_job.queue_key.clone(),
-                job_id,
-                job_name.clone(),
-                scheduled_at,
-                cron_job.resurrect,
-            )?;
 
-            if self
-                .track_redis_result(self.enqueue_at(envelope, next).await)?
-                .is_none()
-            {
-                continue;
+            loop {
+                let envelope = JobEnvelope::new_cron(
+                    cron_job.queue_key.clone(),
+                    job_id.clone(),
+                    job_name.clone(),
+                    scheduled_at,
+                    cron_job.resurrect,
+                )?;
+
+                match self.track_redis_result(self.enqueue_at(envelope, next).await)? {
+                    Some(_) => break,
+                    None => {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                }
             }
 
             previous = Some(next);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -3,6 +3,8 @@ use deadpool_redis::redis::{self, AsyncCommands};
 use std::{
     collections::{HashMap, HashSet},
     num::NonZero,
+    sync::Arc,
+    sync::atomic::{AtomicU32, Ordering},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -18,12 +20,14 @@ use crate::{
 
 const JOB_EXPIRE_TIME: i64 = 7 * 24 * 3600; // 7 days
 const RESURRECT_THRESHOLD_SECS: i64 = 5;
+const MAX_CONSECUTIVE_REDIS_FAILURES: u32 = 10;
 
 #[derive(Clone)]
 pub(crate) struct StorageInternal {
     pool: deadpool_redis::Pool,
     keys: StorageKeys,
     started_at: i64,
+    consecutive_redis_failures: Arc<AtomicU32>,
 }
 
 enum JobEnqueueAction {
@@ -39,6 +43,44 @@ impl StorageInternal {
             pool,
             keys,
             started_at: chrono::Utc::now().timestamp(),
+            consecutive_redis_failures: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    fn record_redis_success(&self) {
+        if self.consecutive_redis_failures.load(Ordering::Relaxed) != 0 {
+            self.consecutive_redis_failures.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn record_redis_failure(&self, err: &OxanusError) -> bool {
+        let count = self
+            .consecutive_redis_failures
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        tracing::warn!(error = %err, consecutive_failures = count, "Transient Redis error");
+        count >= MAX_CONSECUTIVE_REDIS_FAILURES
+    }
+
+    /// Wraps a Redis operation result with resilience tracking.
+    /// Returns `Ok(Some(value))` on success, `Ok(None)` on transient failure,
+    /// or `Err(e)` if the consecutive failure threshold has been exceeded.
+    pub(crate) fn track_redis_result<T>(
+        &self,
+        result: Result<T, OxanusError>,
+    ) -> Result<Option<T>, OxanusError> {
+        match result {
+            Ok(val) => {
+                self.record_redis_success();
+                Ok(Some(val))
+            }
+            Err(e) => {
+                if self.record_redis_failure(&e) {
+                    Err(e)
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 
@@ -766,7 +808,7 @@ impl StorageInternal {
                     return Ok(());
                 }
                 _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {
-                    self.enqueue_scheduled(&self.keys.retry).await?;
+                    self.track_redis_result(self.enqueue_scheduled(&self.keys.retry).await)?;
                 }
             }
         }
@@ -781,8 +823,7 @@ impl StorageInternal {
                     return Ok(());
                 }
                 _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {
-                    self.enqueue_scheduled(&self.keys.schedule)
-                        .await?;
+                    self.track_redis_result(self.enqueue_scheduled(&self.keys.schedule).await)?;
                 }
             }
         }
@@ -797,7 +838,7 @@ impl StorageInternal {
                     return Ok(());
                 }
                 _ = tokio::time::sleep(tokio::time::Duration::from_secs(600)) => {
-                    self.cleanup().await?;
+                    self.track_redis_result(self.cleanup().await)?;
                 }
             }
         }
@@ -810,7 +851,7 @@ impl StorageInternal {
                     return Ok(());
                 }
                 _ = tokio::time::sleep(tokio::time::Duration::from_millis(500)) => {
-                    self.ping().await?;
+                    self.track_redis_result(self.ping().await)?;
                 }
             }
         }
@@ -923,7 +964,7 @@ impl StorageInternal {
                     return Ok(());
                 }
                 _ = tokio::time::sleep(tokio::time::Duration::from_secs(2)) => {
-                    self.resurrect().await?;
+                    self.track_redis_result(self.resurrect().await)?;
                 }
             }
         }
@@ -975,7 +1016,12 @@ impl StorageInternal {
                 cron_job.resurrect,
             )?;
 
-            self.enqueue_at(envelope, next).await?;
+            if self
+                .track_redis_result(self.enqueue_at(envelope, next).await)?
+                .is_none()
+            {
+                continue;
+            }
 
             previous = Some(next);
         }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -20,7 +20,7 @@ use crate::{
 
 const JOB_EXPIRE_TIME: i64 = 7 * 24 * 3600; // 7 days
 const RESURRECT_THRESHOLD_SECS: i64 = 5;
-const MAX_CONSECUTIVE_REDIS_FAILURES: u32 = 10;
+const MAX_CONSECUTIVE_REDIS_FAILURES: u32 = 30;
 
 #[derive(Clone)]
 pub(crate) struct StorageInternal {
@@ -1010,6 +1010,10 @@ impl StorageInternal {
             let job_id = format!("{job_name}-{scheduled_at}");
 
             loop {
+                if cancel_token.is_cancelled() {
+                    return Ok(());
+                }
+
                 let envelope = JobEnvelope::new_cron(
                     cron_job.queue_key.clone(),
                     job_id.clone(),


### PR DESCRIPTION
## Summary

- Add a centralized consecutive failure counter (`Arc<AtomicU32>`) on `StorageInternal` with a `track_redis_result()` helper that tolerates up to 10 consecutive Redis failures before propagating errors
- Wrap all background loop Redis calls (retry, schedule, cleanup, ping, resurrect, cron) and external callers (dispatcher, result collector, queue watcher) with the resilience helper
- Replace `.expect()` panic in dispatcher with proper error handling and propagation
- Include backoff sleep in dispatcher and queue watcher to prevent hot-spinning during outages

Previously, a single transient Redis error (connection blip, pool exhaustion) would shut down the entire worker or panic in the dispatcher.

## Test plan

- [x] `cargo check --all`
- [x] `cargo clippy --all-features --workspace` — no warnings
- [x] `cargo test` — all 38 tests pass
- [x] `cargo fmt --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core queue dispatch and Redis-backed background loops; incorrect handling could delay job processing or mask persistent Redis failures, though changes are localized and guarded by a failure threshold and backoff.
> 
> **Overview**
> Improves resilience to transient Redis outages by adding `StorageInternal::track_redis_result()` with a consecutive-failure counter and using it across Redis-driven loops and callers.
> 
> `dispatcher::run` now returns `Result`, stops panicking on Redis errors, and backs off briefly when Redis operations fail; the coordinator’s dynamic queue watcher and the result collector similarly tolerate transient Redis errors while continuing to run. Also bumps `oxanus-web` from `0.9.5` to `0.9.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c497800d93887cccc3fa198e349cecd11c175c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->