### PR TITLE
Add stat cards to queues tab and widen layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -55,7 +55,7 @@ pub(crate) async fn queues_list(
     Ok(QueuesTemplate {
         base_path: state.base_path,
         active_tab: "/queues",
-        queues: stats.queues,
+        stats,
         concurrency_map: state.concurrency_map,
         sort: sort.to_string(),
         dir: dir.to_string(),

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -79,7 +79,7 @@ impl BusyTemplate {
 pub(crate) struct QueuesTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
-    pub queues: Vec<oxanus::QueueStats>,
+    pub stats: oxanus::Stats,
     pub concurrency_map: HashMap<String, usize>,
     pub sort: String,
     pub dir: String,

--- a/oxanus-web/templates/_stats_cards.html
+++ b/oxanus-web/templates/_stats_cards.html
@@ -1,0 +1,34 @@
+        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4 mb-10">
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
+                <div class="text-2xl font-semibold text-green-400">{{ stats.global.processed|format_number_i64 }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
+                <div class="text-2xl font-semibold text-red-400">{{ stats.global.failed|format_number_i64 }}</div>
+            </div>
+            <a href="{{ base_path }}/busy" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Busy</div>
+                <div class="text-2xl font-semibold text-purple-400">{{ stats.processing.len() }}</div>
+            </a>
+            <a href="{{ base_path }}/queues" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Enqueued</div>
+                <div class="text-2xl font-semibold text-blue-400">{{ stats.global.enqueued|format_number }}</div>
+            </a>
+            <a href="{{ base_path }}/retries" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Retries</div>
+                <div class="text-2xl font-semibold text-orange-400">{{ stats.global.retries|format_number }}</div>
+            </a>
+            <a href="{{ base_path }}/scheduled" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Scheduled</div>
+                <div class="text-2xl font-semibold text-yellow-400">{{ stats.global.scheduled|format_number }}</div>
+            </a>
+            <a href="{{ base_path }}/dead" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Dead</div>
+                <div class="text-2xl font-semibold text-red-400">{{ stats.global.dead|format_number }}</div>
+            </a>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Latency</div>
+                <div class="text-2xl font-semibold text-yellow-400">{{ stats.global.latency_s_max|format_latency }}</div>
+            </div>
+        </div>

--- a/oxanus-web/templates/busy.html
+++ b/oxanus-web/templates/busy.html
@@ -8,7 +8,7 @@
 
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>

--- a/oxanus-web/templates/cron.html
+++ b/oxanus-web/templates/cron.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>

--- a/oxanus-web/templates/dashboard.html
+++ b/oxanus-web/templates/dashboard.html
@@ -8,47 +8,14 @@
 
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>
 
         {% include "_tabs.html" %}
 
-        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4 mb-10">
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
-                <div class="text-2xl font-semibold text-green-400">{{ stats.global.processed|format_number_i64 }}</div>
-            </div>
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
-                <div class="text-2xl font-semibold text-red-400">{{ stats.global.failed|format_number_i64 }}</div>
-            </div>
-            <a href="{{ base_path }}/busy" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Busy</div>
-                <div class="text-2xl font-semibold text-purple-400">{{ stats.processing.len() }}</div>
-            </a>
-            <a href="{{ base_path }}/queues" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Enqueued</div>
-                <div class="text-2xl font-semibold text-blue-400">{{ stats.global.enqueued|format_number }}</div>
-            </a>
-            <a href="{{ base_path }}/retries" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Retries</div>
-                <div class="text-2xl font-semibold text-orange-400">{{ stats.global.retries|format_number }}</div>
-            </a>
-            <a href="{{ base_path }}/scheduled" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Scheduled</div>
-                <div class="text-2xl font-semibold text-yellow-400">{{ stats.global.scheduled|format_number }}</div>
-            </a>
-            <a href="{{ base_path }}/dead" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Dead</div>
-                <div class="text-2xl font-semibold text-red-400">{{ stats.global.dead|format_number }}</div>
-            </a>
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Latency</div>
-                <div class="text-2xl font-semibold text-yellow-400">{{ stats.global.latency_s_max|format_latency }}</div>
-            </div>
-        </div>
+        {% include "_stats_cards.html" %}
 
         <section class="mb-10">
             <h2 class="text-lg font-semibold mb-4">Active Processes ({{ stats.processes.len() }})</h2>

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>

--- a/oxanus-web/templates/queue_detail.html
+++ b/oxanus-web/templates/queue_detail.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>

--- a/oxanus-web/templates/queues.html
+++ b/oxanus-web/templates/queues.html
@@ -7,16 +7,18 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="mb-6">
             <h1 class="text-2xl font-bold tracking-tight">Oxanus Dashboard</h1>
         </div>
 
         {% include "_tabs.html" %}
 
-        <h2 class="text-lg font-semibold mb-4">Queues ({{ queues.len() }})</h2>
+        {% include "_stats_cards.html" %}
 
-        {% if queues.is_empty() %}
+        <h2 class="text-lg font-semibold mb-4">Queues ({{ stats.queues.len() }})</h2>
+
+        {% if stats.queues.is_empty() %}
         <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
             No queues
         </div>
@@ -36,7 +38,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for queue in &queues %}
+                    {% for queue in &stats.queues %}
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                         <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
                         <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>


### PR DESCRIPTION
## Summary
- Add the overview stat cards (Processed, Failed, Busy, Enqueued, Retries, Scheduled, Dead, Latency) to the queues tab
- Extract stat cards into a shared `_stats_cards.html` partial to avoid duplication between dashboard and queues pages
- Change `max-w-7xl` to `max-w-[88rem]` across all templates

## Test plan
- [ ] Verify stat cards appear on the queues tab
- [ ] Verify dashboard still shows stat cards correctly
- [ ] Verify wider layout renders properly on all pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/template refactor that changes how queue stats are passed into the `queues` template and widens page containers; no persistence, auth, or core scheduling logic changes.
> 
> **Overview**
> Adds the dashboard overview stat cards to the **Queues** page by extracting the cards into a shared Askama partial (`_stats_cards.html`) and including it from both `dashboard.html` and `queues.html`.
> 
> Updates the queues handler/template plumbing to pass full `stats` (instead of just `queues`) so the shared cards can render, and widens the layout across all pages by changing the main container from `max-w-7xl` to `max-w-[88rem]`.
> 
> Bumps `oxanus-web` version to `0.9.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38650948774e800fd16941695afade7727ae804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->