### PR TITLE
Bump oxanus and oxanus-web to 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.7]
+
+### Added
+- Add stat cards to queues tab
+
+### Fixed
+- Retry cron job enqueue on transient Redis failure
+- Handle transient Redis errors without full shutdown
+
 ## [0.9.6]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.5"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.5"
+version = "0.9.7"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxanus from 0.9.5 to 0.9.7
- Bump oxanus-web from 0.9.6 to 0.9.7
- Update changelog with new entries for stat cards on queues tab and transient Redis error fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/version bump plus changelog updates only; no functional code changes are included in this diff, so runtime risk is minimal aside from downstream consumers relying on the new version numbers.
> 
> **Overview**
> Bumps crate versions to `0.9.7` for both `oxanus` and `oxanus-web` (including `Cargo.lock`).
> 
> Updates `CHANGELOG.md` with `0.9.7` notes covering *queues tab stat cards* and *improved resilience to transient Redis failures* (retry cron enqueue and avoid full shutdown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7706c860e215c648396dfbb38c134d8184892b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->