### PR TITLE
Preserve state when reviving dead jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -242,6 +242,12 @@ pub(crate) async fn enqueue_job(
     let id = uuid::Uuid::new_v4().to_string();
     let args: serde_json::Value =
         serde_json::from_str(&form.args).map_err(oxanus::OxanusError::from)?;
+    let job_state: Option<serde_json::Value> = match form.state.as_deref() {
+        Some(s) if !s.is_empty() => {
+            Some(serde_json::from_str(s).map_err(oxanus::OxanusError::from)?)
+        }
+        _ => None,
+    };
 
     let envelope = oxanus::JobEnvelope {
         id: id.clone(),
@@ -258,7 +264,7 @@ pub(crate) async fn enqueue_job(
             created_at: now,
             scheduled_at: now,
             started_at: None,
-            state: None,
+            state: job_state,
             resurrect: true,
             error: None,
             throttle_cost: None,
@@ -309,6 +315,8 @@ pub(crate) struct EnqueueJobForm {
     queue: String,
     name: String,
     args: String,
+    #[serde(default)]
+    state: Option<String>,
     #[serde(default)]
     redirect: Option<String>,
 }

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -109,6 +109,11 @@
                         <input type="hidden" name="queue" value="{{ job.queue }}">
                         <input type="hidden" name="name" value="{{ job.job.name }}">
                         <input type="hidden" name="args" value="{{ job.job.args }}">
+                        {% match job.meta.state %}
+                        {% when Some with (state) %}
+                        <input type="hidden" name="state" value="{{ state }}">
+                        {% when None %}
+                        {% endmatch %}
                         <input type="hidden" name="redirect" value="/dead">
                         <button type="submit" class="px-2.5 py-1 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-xs transition-colors">Revive</button>
                     </form>

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary

- The Revive button on the dead-jobs dashboard was creating a fresh `JobEnvelope` with `state: None`, so resumable workers lost their progress and started over on revive.
- Now pass `meta.state` through a hidden form field and restore it on the new envelope so resumable workers continue from where they left off.
- Retries are still reset to 0 — otherwise a revived job at `max_retries` would immediately die again on its next failure.
- Bumps `oxanus` and `oxanus-web` to 0.9.8 (`oxanus-macros` unchanged).

## Test plan

- [ ] Manually: enqueue a \`ResumableTestWorker\` (see \`examples/resumable.rs\`), let it die after retries, click Revive in the dashboard, and confirm the next run sees the previously-saved \`progress\` rather than \`None\`.
- [ ] Manually: revive a non-resumable dead job and confirm it still runs (no state, no error).
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all-features --workspace\` (no issues)
- [x] \`cargo check --all\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the revive/enqueue path for dead jobs and introduces JSON parsing of a new form field, which could affect job execution/resume behavior if state is malformed or unexpectedly large.
> 
> **Overview**
> Reviving dead jobs from the dashboard now **preserves the job’s saved `meta.state`** instead of re-enqueuing with `state: None`, so resumable workers can continue progress after a revive.
> 
> The dead-jobs "Revive" form posts `meta.state` via a hidden `state` field, and the `enqueue_job` handler restores it into the new `JobEnvelope` (only if non-empty/valid JSON). Versions are bumped to `0.9.8` for `oxanus` and `oxanus-web` (and reflected in `Cargo.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3458d8896d5b5c93610316ccc0d66d1a02746904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->