### PR TITLE
Fix duplicate job scheduling across concurrent instances

### DIFF
--- a/oxanus/examples/cron_multiple.rs
+++ b/oxanus/examples/cron_multiple.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TickJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerContext)]
+#[oxanus(resurrect = false)]
+#[oxanus(cron(schedule = "* * * * * *", queue = QueueOne))]
+struct TickWorker;
+
+impl TickWorker {
+    async fn process(&self, _job: &TickJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        println!("tick at {}", chrono::Utc::now().timestamp());
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "cron_multiple")]
+struct QueueOne;
+
+#[tokio::main]
+pub async fn main() -> Result<(), oxanus::OxanusError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let storage = oxanus::Storage::builder().build_from_env()?;
+
+    let (tx, _rx) = tokio::sync::broadcast::channel::<()>(1);
+
+    let mut handles = Vec::new();
+
+    for _ in 0..4 {
+        let storage = storage.clone();
+        let mut rx = tx.subscribe();
+
+        handles.push(tokio::spawn(async move {
+            let ctx = oxanus::ContextValue::new(WorkerContext {});
+            let config =
+                ComponentRegistry::build_config(&storage).with_graceful_shutdown(async move {
+                    rx.recv().await.ok();
+                    Ok(())
+                });
+
+            oxanus::run(config, ctx).await
+        }));
+    }
+
+    tokio::signal::ctrl_c().await.ok();
+    tx.send(()).ok();
+
+    for handle in handles {
+        handle.await.ok();
+    }
+
+    Ok(())
+}

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -421,28 +421,40 @@ impl StorageInternal {
             return Ok(0);
         }
 
-        let envelopes = self.get_many(&job_ids).await?;
-        let mut map: HashMap<&str, Vec<&JobEnvelope>> = HashMap::new();
+        let mut claim_pipe = redis::pipe();
+        for job_id in &job_ids {
+            claim_pipe.zrem(schedule_queue, job_id);
+        }
+        let claimed: Vec<u32> = claim_pipe.query_async(&mut redis).await?;
+
+        let claimed_job_ids: Vec<String> = job_ids
+            .into_iter()
+            .zip(claimed.iter())
+            .filter(|(_, removed)| **removed > 0)
+            .map(|(id, _)| id)
+            .collect();
+
+        if claimed_job_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let envelopes = self.get_many(&claimed_job_ids).await?;
         let envelopes_count = envelopes.len();
 
+        let mut enqueue_pipe = redis::pipe();
+        let mut map: HashMap<&str, Vec<&str>> = HashMap::new();
+
         for envelope in envelopes.iter() {
-            map.entry(&envelope.queue).or_default().push(envelope);
+            map.entry(&envelope.queue)
+                .or_default()
+                .push(envelope.id.as_str());
         }
 
-        let mut pipe = redis::pipe();
-
-        for (queue, envelopes) in map {
-            let job_ids: Vec<&str> = envelopes
-                .iter()
-                .map(|envelope| envelope.id.as_str())
-                .collect();
-
-            pipe.lpush(self.namespace_queue(queue), job_ids);
+        for (queue, job_ids) in map {
+            enqueue_pipe.lpush(self.namespace_queue(queue), job_ids);
         }
 
-        pipe.zrembyscore(schedule_queue, 0, now);
-
-        let _: () = pipe.query_async(&mut redis).await?;
+        let _: () = enqueue_pipe.query_async(&mut redis).await?;
 
         Ok(envelopes_count)
     }


### PR DESCRIPTION
## Summary

- Replace bulk `ZREMBYSCORE` with per-job `ZREM` claims in `enqueue_scheduled` to prevent duplicate job execution when multiple Oxanus instances poll concurrently
- Only the instance whose `ZREM` returns 1 (actually removed) proceeds to enqueue the job
- Add `cron_multiple` example demonstrating 4 concurrent processes sharing a 1s cron without duplicates

## How it works

Previously, `enqueue_scheduled` used `ZRANGEBYSCORE` to read ready jobs, then `ZREMBYSCORE` to remove them. Two instances could both read the same jobs and both `LPUSH` them before either removed them.

Now each job is claimed individually via `ZREM`, which returns 1 only for the first caller. Jobs are only enqueued by the instance that successfully claimed them.

## Test plan

- [x] `cargo test` — 26/27 pass (1 pre-existing flaky timing test)
- [x] `cargo clippy --all-features --workspace` — clean
- [ ] Run `cron_multiple` example against Redis to verify no duplicate ticks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scheduling/enqueueing logic and changes Redis command patterns, which could affect job throughput or lead to missed enqueues if the claim/enqueue flow has edge cases.
> 
> **Overview**
> **Prevents duplicate scheduled/cron job enqueueing under concurrent pollers.** `enqueue_scheduled` now *claims* ready job IDs by issuing per-job `ZREM` calls and only enqueues IDs successfully removed, replacing the previous bulk removal approach that could allow multiple instances to enqueue the same scheduled job.
> 
> Adds a new `cron_multiple` example that runs 4 concurrent Oxanus workers against the same Redis-backed cron queue to demonstrate/verify the no-duplicate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87191f8fe84641a911b9a65aba290961596824f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->