### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1]
+
+### Fixed
+- Fix duplicate job scheduling across concurrent instances
+
+## [1.0.0]
+
+### Added
+- Public release
+
 ## [0.10.0]
 
 **Breaking release.** See [MIGRATION.md](MIGRATION.md) for the upgrade guide.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "darling",
  "heck",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxanus-macros/Cargo.toml
+++ b/oxanus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-macros"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxanus."

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump all crate versions (oxanus, oxanus-macros, oxanus-web) to 1.0.1
- Add changelog entries for v1.0.0 and v1.0.1

## Changes
- **v1.0.1**: Fix duplicate job scheduling across concurrent instances
- **v1.0.0**: Public release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates crate version metadata/lockfile and adds release notes, with no functional code changes in the diff.
> 
> **Overview**
> Publishes release metadata for `v1.0.1` by bumping versions of `oxanus`, `oxanus-macros`, and `oxanus-web` (including `Cargo.lock`).
> 
> Updates `CHANGELOG.md` with new entries for `1.0.0` (public release) and `1.0.1` (notes a fix for duplicate job scheduling across concurrent instances).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1951bdd8de3af8e361ffa72cb298d6d4213bacc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->