### PR TITLE
Use LINDEX instead of LRANGE for single-element access

### DIFF
--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -582,8 +582,8 @@ impl StorageInternal {
         redis: &mut deadpool_redis::Connection,
         queue: &str,
     ) -> Result<f64, OxanusError> {
-        let result: Vec<String> = (*redis).lrange(self.namespace_queue(queue), -1, -1).await?;
-        match result.first() {
+        let result: Option<String> = (*redis).lindex(self.namespace_queue(queue), -1).await?;
+        match result.as_ref() {
             Some(job_id) => {
                 let envelope = self.get_job_w_conn(redis, job_id).await?;
                 Ok(envelope.map_or(0.0, |envelope| {
@@ -1136,10 +1136,8 @@ impl StorageInternal {
     #[cfg(test)]
     async fn currently_processing_job_ids(&self) -> Result<Vec<String>, OxanusError> {
         let mut redis = self.connection().await?;
-        let job_ids: Vec<String> = (*redis)
-            .lrange(self.current_processing_queue(), 0, 0)
-            .await?;
-        Ok(job_ids)
+        let job_id: Option<String> = (*redis).lindex(self.current_processing_queue(), 0).await?;
+        Ok(job_id.into_iter().collect())
     }
 
     fn current_process(&self) -> Process {


### PR DESCRIPTION
## Summary
- Replace `LRANGE key -1 -1` and `LRANGE key 0 0` with `LINDEX key -1` and `LINDEX key 0` in storage internals
- LINDEX is the idiomatic Redis command for fetching a single element by index, avoiding the overhead of returning a list

## Test plan
- [x] `cargo check --all` passes
- [x] All 38 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Redis command swap with equivalent behavior; main risk is any subtle difference in client return typing/empty-queue handling.
> 
> **Overview**
> Replaces Redis `LRANGE` calls that fetched a single element (`0..0` and `-1..-1`) with `LINDEX` in storage internals.
> 
> This updates `latency_micros_w_conn` and the test-only `currently_processing_job_ids` helper to work with `Option<String>` results, reducing list-allocation overhead while keeping the same semantics when queues are empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da875bb3c368a8540960dd57eedb8455cec14361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->