### PR TITLE
Bump oxanus version to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bumps `oxanus` crate version from 1.0.1 to 1.0.2

## Test plan
- [x] Verify `Cargo.toml` and `Cargo.lock` reflect the new version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only increments the crate version in `Cargo.toml` and `Cargo.lock` with no functional code changes.
> 
> **Overview**
> Bumps the `oxanus` crate version from `1.0.1` to `1.0.2` in `oxanus/Cargo.toml` and updates the corresponding entry in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1844ac7e498777266d87b1048a3934aaa6bc67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->