### PR TITLE
Add global retry delay override

### DIFF
--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::pin::Pin;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::Storage;
@@ -7,6 +8,8 @@ use crate::queue::{Queue, QueueConfig};
 use crate::storage_types::{Catalog, CronWorkerInfo, QueueInfo, QueueThrottleInfo, WorkerInfo};
 use crate::worker::{FromContext, Job, Worker};
 use crate::worker_registry::{self, WorkerConfig, WorkerConfigKind, WorkerRegistry};
+
+type RetryDelayOverrideFn<ET> = dyn Fn(&ET, u32, u64) -> Option<u64> + Send + Sync;
 
 pub struct Config<DT, ET> {
     pub(crate) registry: WorkerRegistry<DT, ET>,
@@ -16,10 +19,12 @@ pub struct Config<DT, ET> {
         Pin<Box<dyn Future<Output = Result<(), std::io::Error>> + Send + Sync>>,
     pub(crate) shutdown_timeout: std::time::Duration,
     pub(crate) cancel_token: CancellationToken,
+    pub(crate) retry_delay_override: Option<Arc<RetryDelayOverrideFn<ET>>>,
     pub storage: Storage,
 }
 
 impl<DT, ET> Config<DT, ET> {
+    /// Creates a new configuration with default settings.
     pub fn new(storage: &Storage) -> Self {
         Self {
             registry: WorkerRegistry::new(),
@@ -28,10 +33,12 @@ impl<DT, ET> Config<DT, ET> {
             shutdown_signal: Box::pin(default_shutdown_signal()),
             shutdown_timeout: std::time::Duration::from_secs(180),
             cancel_token: CancellationToken::new(),
+            retry_delay_override: None,
             storage: storage.clone(),
         }
     }
 
+    /// Registers a queue by its type.
     pub fn register_queue<Q>(mut self) -> Self
     where
         Q: Queue,
@@ -40,10 +47,12 @@ impl<DT, ET> Config<DT, ET> {
         self
     }
 
+    /// Registers a queue from a [`QueueConfig`].
     pub fn register_queue_with(&mut self, config: QueueConfig) {
         self.queues.insert(config);
     }
 
+    /// Registers a queue by its type with a custom concurrency limit.
     pub fn register_queue_with_concurrency<Q>(mut self, concurrency: usize) -> Self
     where
         Q: Queue,
@@ -54,6 +63,7 @@ impl<DT, ET> Config<DT, ET> {
         self
     }
 
+    /// Registers a worker and its associated job type.
     pub fn register_worker<W, A>(mut self) -> Self
     where
         W: Worker<A, Error = ET> + FromContext<DT> + 'static,
@@ -85,20 +95,36 @@ impl<DT, ET> Config<DT, ET> {
         self
     }
 
+    /// Registers a worker from a [`WorkerConfig`].
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT, ET>) {
         self.registry.register_worker_with(config);
     }
 
+    /// Stops processing after the given number of jobs have been processed. Useful for testing.
     pub fn exit_when_processed(mut self, processed: u64) -> Self {
         self.exit_when_processed = Some(processed);
         self
     }
 
+    /// Sets a future that triggers graceful shutdown when it completes.
+    /// Defaults to listening for SIGTERM/SIGINT on Unix and Ctrl+C on Windows.
     pub fn with_graceful_shutdown(
         mut self,
         fut: impl Future<Output = Result<(), std::io::Error>> + Send + Sync + 'static,
     ) -> Self {
         self.shutdown_signal = Box::pin(fut);
+        self
+    }
+
+    /// Sets a global callback to override the retry delay when a job fails.
+    ///
+    /// The callback receives `(error, retry_count, default_delay)` and returns
+    /// `Some(seconds)` to override or `None` to use the worker's default.
+    pub fn with_retry_delay_override(
+        mut self,
+        f: impl Fn(&ET, u32, u64) -> Option<u64> + Send + Sync + 'static,
+    ) -> Self {
+        self.retry_delay_override = Some(Arc::new(f));
         self
     }
 
@@ -110,22 +136,27 @@ impl<DT, ET> Config<DT, ET> {
         shutdown_signal
     }
 
+    /// Returns `true` if the given queue type has been registered.
     pub fn has_registered_queue<Q: Queue>(&self) -> bool {
         self.queues.contains(&Q::to_config())
     }
 
+    /// Returns `true` if a worker with the given name has been registered.
     pub fn has_registered_worker(&self, name: &str) -> bool {
         self.registry.has_registered(name)
     }
 
+    /// Returns `true` if a worker of the given type has been registered.
     pub fn has_registered_worker_type<W: 'static>(&self) -> bool {
         self.registry.has_registered(std::any::type_name::<W>())
     }
 
+    /// Returns `true` if a cron worker with the given name has been registered.
     pub fn has_registered_cron_worker(&self, name: &str) -> bool {
         self.registry.has_registered_cron(name)
     }
 
+    /// Returns `true` if a cron worker of the given type has been registered.
     pub fn has_registered_cron_worker_type<W: 'static>(&self) -> bool {
         self.registry
             .has_registered_cron(std::any::type_name::<W>())

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -76,7 +76,6 @@ where
     );
 
     let max_retries = worker.max_retries();
-    let retry_delay = worker.retry_delay(envelope.meta.retries);
 
     match result {
         ExecutionResult::NotPanic(result) => {
@@ -87,6 +86,13 @@ where
                     }
                 }
                 Err(e) => {
+                    let default_delay = worker.retry_delay(envelope.meta.retries);
+                    let retry_delay = config
+                        .retry_delay_override
+                        .as_ref()
+                        .and_then(|f| f(e, envelope.meta.retries, default_delay))
+                        .unwrap_or(default_delay);
+
                     #[cfg(feature = "sentry")]
                     sentry_core::capture_error(e);
 
@@ -104,6 +110,8 @@ where
             Ok(result.map_err(ExecutionError::NotPanic))
         }
         ExecutionResult::Panic(panic_msg) => {
+            let retry_delay = worker.retry_delay(envelope.meta.retries);
+
             #[cfg(feature = "sentry")]
             sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
 


### PR DESCRIPTION
## Summary

- Add `with_retry_delay_override` to `Config` — a global callback that receives `(&error, retry_count, default_delay)` and returns `Option<u64>` to override the retry delay on failure
- Apply the override in the executor's error handling path (panics use the default)
- Add doc comments to all public `Config` methods

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo test` passes
- [x] `cargo clippy --all-features --workspace` clean (pre-existing warning only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job retry scheduling by introducing an optional global callback that can alter retry delays on failures, which could affect throughput and backoff behavior across all workers if misconfigured.
> 
> **Overview**
> Adds `Config::with_retry_delay_override`, storing an optional `Arc` callback that can override a worker’s computed retry delay based on `(error, retry_count, default_delay)`.
> 
> Updates the executor failure path to consult this override when determining `retry_delay` for non-panic errors (panics continue using the worker default), and adds doc comments across `Config`’s public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd758a211423339bea51c81206198166d0f521c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->