### PR TITLE
Bump oxanus version to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.3]
+
+### Added
+- Global retry delay override in Config
+
+## [1.0.2]
+
+### Improved
+- Use LINDEX instead of LRANGE for single-element list access
+
 ## [1.0.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxanus to 1.0.3
- Add changelog entries for 1.0.2 and 1.0.3

## Test plan
- [x] `cargo check --all` passes