### PR TITLE
Update actions/checkout to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       RUST_LOG: trace
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Summary
- Updates `actions/checkout` from v4 to v6 to resolve the Node.js 20 deprecation warning
- Node.js 20 actions will be forced to Node.js 24 starting June 2nd, 2026

## Test plan
- [x] Verify CI workflow runs successfully with the updated action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates `actions/checkout` in the test workflow; impact is limited to GitHub Actions behavior during checkout.
> 
> **Overview**
> Updates `.github/workflows/test.yml` to use `actions/checkout@v6` (from `v4`) to keep the CI workflow compatible with newer GitHub Actions Node runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5072e09f7c85c126f850aaf0b9b26918809c2b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->