### PR TITLE
Add BSD support for shutdown signal handling

### DIFF
--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -216,7 +216,7 @@ impl<DT, ET> Config<DT, ET> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_family = "unix")]
 async fn default_shutdown_signal() -> Result<(), std::io::Error> {
     let ctrl_c = tokio::signal::ctrl_c();
     let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;


### PR DESCRIPTION
## Summary
- Replace `#[cfg(any(target_os = "linux", target_os = "macos"))]` with `#[cfg(target_family = "unix")]` for the shutdown signal handler
- This adds support for all BSD variants (FreeBSD, OpenBSD, NetBSD, DragonFlyBSD) and any other Unix-like OS, since they all support the same `tokio::signal::unix` APIs

Closes https://github.com/pragmaplatform/oxanus/issues/41

## Test plan
- [x] `cargo check --all` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small compile-time `cfg` broadened from linux/macos to all Unix targets, only affecting which shutdown signal implementation is built.
> 
> **Overview**
> Expands the Unix graceful-shutdown implementation to compile on all `target_family = "unix"` platforms (instead of only Linux/macOS), enabling BSD variants to use the same SIGTERM/Ctrl+C shutdown handling via `tokio::signal::unix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57a8704917de61b703c1b58522669c1a83724e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->