### PR TITLE
Bump oxanus version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.0.4]
 
 ### Added
-- BSD support for shutdown signal handling
+- BSD support for shutdown signal handling ([#41](https://github.com/pragmaplatform/oxanus/issues/41))
 
 ## [1.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.4]
+
+### Added
+- BSD support for shutdown signal handling
+
 ## [1.0.3]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxanus patch version from 1.0.3 to 1.0.4
- Add changelog entry for BSD shutdown signal handling support

## Test plan
- [ ] Verify `cargo check --all` passes
- [ ] Confirm version in `oxanus/Cargo.toml` is `1.0.4`
- [ ] Confirm changelog entry is correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates package metadata (version) and documentation, with no runtime code changes.
> 
> **Overview**
> Bumps the `oxanus` crate version from `1.0.3` to `1.0.4` (including lockfile update).
> 
> Adds a `CHANGELOG.md` entry for `1.0.4` noting *BSD shutdown signal handling* support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4017cac0cd83e0d82242e7459dfb3c530d48ea51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->