### PR TITLE
Add per-queue stats API (stats_queues, stats_queues_for)

### DIFF
--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -4,7 +4,7 @@ use crate::{
     error::OxanusError,
     job_envelope::{JobEnvelope, JobId},
     queue::Queue,
-    stats::{Process, Stats},
+    stats::{Process, QueueStats, Stats},
     storage_builder::StorageBuilder,
     storage_internal::StorageInternal,
     storage_types::QueueListOpts,
@@ -235,11 +235,39 @@ impl Storage {
         self.internal.delete_job(id).await
     }
 
-    /// Returns the stats for all queues.
+    /// Returns per-queue statistics for queues matching the given patterns.
+    ///
+    /// Each pattern is matched against queue names using the same glob syntax
+    /// as Redis SCAN (e.g. `"email*"`, `"*"`).
+    ///
+    /// # Arguments
+    ///
+    /// * `patterns` - Glob patterns to match queue names against
     ///
     /// # Returns
     ///
-    /// The stats for all queues, or an [`OxanusError`] if the operation fails.
+    /// Statistics for matching queues, or an [`OxanusError`] if the operation fails.
+    pub async fn stats_queues_for(
+        &self,
+        patterns: &[&str],
+    ) -> Result<Vec<QueueStats>, OxanusError> {
+        self.internal.stats_queues_for(patterns).await
+    }
+
+    /// Returns per-queue statistics for all queues.
+    ///
+    /// # Returns
+    ///
+    /// Statistics for all queues, or an [`OxanusError`] if the operation fails.
+    pub async fn stats_queues(&self) -> Result<Vec<QueueStats>, OxanusError> {
+        self.internal.stats_queues().await
+    }
+
+    /// Returns the full stats including global aggregates, processes, and per-queue stats.
+    ///
+    /// # Returns
+    ///
+    /// The full stats, or an [`OxanusError`] if the operation fails.
     pub async fn stats(&self) -> Result<Stats, OxanusError> {
         self.internal.stats().await
     }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -619,15 +619,101 @@ impl StorageInternal {
         Ok(count as usize)
     }
 
+    pub async fn stats_queues_for(
+        &self,
+        patterns: &[&str],
+    ) -> Result<Vec<QueueStats>, OxanusError> {
+        let mut redis = self.connection().await?;
+        let mut matched_queues = Vec::new();
+        for pattern in patterns {
+            matched_queues.extend(self.queues(pattern).await?);
+        }
+        matched_queues.sort();
+        matched_queues.dedup();
+
+        self.build_queue_stats(&mut redis, &matched_queues, true)
+            .await
+    }
+
+    pub async fn stats_queues(&self) -> Result<Vec<QueueStats>, OxanusError> {
+        let mut redis = self.connection().await?;
+        let queues = self.queues("*").await?;
+        self.build_queue_stats(&mut redis, &queues, false).await
+    }
+
     pub async fn stats(&self) -> Result<Stats, OxanusError> {
         let mut redis = self.connection().await?;
+
+        let queues = self.queues("*").await?;
+        let values = self.build_queue_stats(&mut redis, &queues, false).await?;
+
+        let mut processed_count_total = 0;
+        let mut enqueued_count_total = 0;
+        let mut failed_count_total = 0;
+        let mut latency_s_max: f64 = 0.0;
+
+        for value in &values {
+            if value.latency_s > latency_s_max {
+                latency_s_max = value.latency_s;
+            }
+            for dq in &value.queues {
+                if dq.latency_s > latency_s_max {
+                    latency_s_max = dq.latency_s;
+                }
+            }
+            processed_count_total += value.processed;
+            enqueued_count_total += value.enqueued;
+            failed_count_total += value.failed;
+        }
+
+        let processes = self.processes().await?;
+
+        let mut processing = vec![];
+
+        for process in processes.iter() {
+            let processing_queue = self.processing_queue(&process.id());
+            let job_ids: Vec<String> = (*redis).lrange(&processing_queue, 0, -1).await?;
+
+            for job_id in job_ids {
+                if let Some(envelope) = self.get_job(&job_id).await? {
+                    processing.push(StatsProcessing {
+                        process_id: process.id(),
+                        job_envelope: envelope,
+                    });
+                }
+            }
+        }
+
+        Ok(Stats {
+            global: StatsGlobal {
+                jobs: self.jobs_count().await?,
+                enqueued: enqueued_count_total,
+                processed: processed_count_total,
+                failed: failed_count_total,
+                dead: self.dead_count().await?,
+                scheduled: self.scheduled_count().await?,
+                retries: self.retries_count().await?,
+                latency_s_max,
+            },
+            processing,
+            processes,
+            queues: values,
+        })
+    }
+
+    async fn build_queue_stats(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        queues: &[String],
+        filter: bool,
+    ) -> Result<Vec<QueueStats>, OxanusError> {
         let list: HashMap<String, i64> = (*redis).hgetall(&self.keys.stats).await?;
 
         let mut map = HashMap::new();
-        let mut queue_values = Vec::new();
+        let mut queue_values: Vec<(String, String, i64)> = Vec::new();
 
-        for queue in self.queues("*").await? {
-            queue_values.push((queue, "processed".to_string(), 0));
+        for queue in queues {
+            queue_values.push((queue.clone(), "processed".to_string(), 0));
         }
 
         for (key, value) in list {
@@ -641,6 +727,19 @@ impl StorageInternal {
                 Some(queue_key) => queue_key,
                 None => continue,
             };
+
+            if filter {
+                let base_key = queue_full_key
+                    .split_once('#')
+                    .map_or(queue_full_key, |(base, _)| base);
+                let matches = queues.iter().any(|q| {
+                    let q_base = q.split_once('#').map_or(q.as_str(), |(base, _)| base);
+                    q_base == base_key || q == queue_full_key
+                });
+                if !matches {
+                    continue;
+                }
+            }
 
             queue_values.push((queue_full_key.to_string(), stat_key.to_string(), value));
         }
@@ -712,27 +811,17 @@ impl StorageInternal {
 
         let mut values: Vec<QueueStats> = map.into_values().collect();
 
-        let mut processed_count_total = 0;
-        let mut enqueued_count_total = 0;
-        let mut failed_count_total = 0;
-        let mut latency_s_max = 0.0;
-
         for value in values.iter_mut() {
             if value.queues.is_empty() {
-                value.enqueued = self.enqueued_count_w_conn(&mut redis, &value.key).await?;
-                value.latency_s = self.latency_s_w_conn(&mut redis, &value.key).await?;
-                if value.latency_s > latency_s_max {
-                    latency_s_max = value.latency_s;
-                }
+                value.enqueued = self.enqueued_count_w_conn(redis, &value.key).await?;
+                value.latency_s = self.latency_s_w_conn(redis, &value.key).await?;
             } else {
                 for dynamic_queue in value.queues.iter_mut() {
                     let dynamic_queue_key = format!("{}#{}", value.key, dynamic_queue.suffix);
                     let enqueued = self
-                        .enqueued_count_w_conn(&mut redis, &dynamic_queue_key)
+                        .enqueued_count_w_conn(redis, &dynamic_queue_key)
                         .await?;
-                    let latency_s = self
-                        .latency_s_w_conn(&mut redis, &dynamic_queue_key)
-                        .await?;
+                    let latency_s = self.latency_s_w_conn(redis, &dynamic_queue_key).await?;
 
                     dynamic_queue.enqueued = enqueued;
                     dynamic_queue.latency_s = latency_s;
@@ -740,55 +829,16 @@ impl StorageInternal {
                     if value.latency_s < latency_s {
                         value.latency_s = latency_s;
                     }
-                    if dynamic_queue.latency_s > latency_s_max {
-                        latency_s_max = dynamic_queue.latency_s;
-                    }
                     value.enqueued += enqueued;
                 }
             }
-
-            processed_count_total += value.processed;
-            enqueued_count_total += value.enqueued;
-            failed_count_total += value.failed;
 
             value.queues.sort_by(|a, b| a.suffix.cmp(&b.suffix));
         }
 
         values.sort_by(|a, b| a.key.cmp(&b.key));
 
-        let processes = self.processes().await?;
-
-        let mut processing = vec![];
-
-        for process in processes.iter() {
-            let processing_queue = self.processing_queue(&process.id());
-            let job_ids: Vec<String> = (*redis).lrange(&processing_queue, 0, -1).await?;
-
-            for job_id in job_ids {
-                if let Some(envelope) = self.get_job(&job_id).await? {
-                    processing.push(StatsProcessing {
-                        process_id: process.id(),
-                        job_envelope: envelope,
-                    });
-                }
-            }
-        }
-
-        Ok(Stats {
-            global: StatsGlobal {
-                jobs: self.jobs_count().await?,
-                enqueued: enqueued_count_total,
-                processed: processed_count_total,
-                failed: failed_count_total,
-                dead: self.dead_count().await?,
-                scheduled: self.scheduled_count().await?,
-                retries: self.retries_count().await?,
-                latency_s_max,
-            },
-            processing,
-            processes,
-            queues: values,
-        })
+        Ok(values)
     }
 
     pub async fn update_stats(&self, result: JobResult) -> Result<(), OxanusError> {

--- a/oxanus/tests/integration/stats.rs
+++ b/oxanus/tests/integration/stats.rs
@@ -97,6 +97,36 @@ pub async fn test_stats() -> TestResult {
     assert_eq!(stats.queues[1].failed, 0);
     assert!(stats.queues[1].latency_s > 0.0);
 
+    // stats_queues returns all queues, same as stats().queues
+    let queue_stats = storage.stats_queues().await?;
+    assert_eq!(queue_stats.len(), 2);
+    assert_eq!(queue_stats[0].key, "dynamic");
+    assert_eq!(queue_stats[0].enqueued, 6);
+    assert_eq!(queue_stats[0].queues.len(), 4);
+    assert_eq!(queue_stats[1].key, "static");
+    assert_eq!(queue_stats[1].enqueued, 2);
+
+    // stats_queues_for with a single pattern
+    let queue_stats = storage.stats_queues_for(&["static"]).await?;
+    assert_eq!(queue_stats.len(), 1);
+    assert_eq!(queue_stats[0].key, "static");
+    assert_eq!(queue_stats[0].enqueued, 2);
+
+    // stats_queues_for with a single pattern matching the dynamic queue
+    let queue_stats = storage.stats_queues_for(&["dynamic*"]).await?;
+    assert_eq!(queue_stats.len(), 1);
+    assert_eq!(queue_stats[0].key, "dynamic");
+    assert_eq!(queue_stats[0].enqueued, 6);
+    assert_eq!(queue_stats[0].queues.len(), 4);
+
+    // stats_queues_for with multiple patterns
+    let queue_stats = storage.stats_queues_for(&["static", "dynamic*"]).await?;
+    assert_eq!(queue_stats.len(), 2);
+
+    // stats_queues_for with a pattern matching nothing
+    let queue_stats = storage.stats_queues_for(&["nonexistent"]).await?;
+    assert_eq!(queue_stats.len(), 0);
+
     let stats = oxanus::run(config, ctx).await?;
 
     assert_eq!(stats.processed, 8);
@@ -158,6 +188,27 @@ pub async fn test_stats() -> TestResult {
     assert_eq!(stats.queues[1].panicked, 0);
     assert_eq!(stats.queues[1].failed, 0);
     assert_eq!(stats.queues[1].latency_s, 0.0);
+
+    // stats_queues after processing
+    let queue_stats = storage.stats_queues().await?;
+    assert_eq!(queue_stats.len(), 2);
+    assert_eq!(queue_stats[0].key, "dynamic");
+    assert_eq!(queue_stats[0].processed, 6);
+    assert_eq!(queue_stats[0].succeeded, 6);
+    assert_eq!(queue_stats[0].enqueued, 0);
+    assert_eq!(queue_stats[1].key, "static");
+    assert_eq!(queue_stats[1].processed, 2);
+    assert_eq!(queue_stats[1].succeeded, 2);
+    assert_eq!(queue_stats[1].enqueued, 0);
+
+    // stats_queues_for after processing -- queues are drained so keys no longer
+    // exist in Redis; stats_queues_for only returns stats for queues whose keys
+    // still exist, so these should be empty
+    let queue_stats = storage.stats_queues_for(&["dynamic*"]).await?;
+    assert_eq!(queue_stats.len(), 0);
+
+    let queue_stats = storage.stats_queues_for(&["static"]).await?;
+    assert_eq!(queue_stats.len(), 0);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `stats_queues()` and `stats_queues_for(patterns)` to the public `Storage` API for fetching per-queue statistics independently of the full `stats()` call
- Extract shared queue stats logic into a `build_queue_stats` helper that accepts an existing Redis connection, eliminating redundant connections
- Add comprehensive integration tests covering pre- and post-processing scenarios for both new methods

## Test plan
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes (38 tests, including new stats_queues/stats_queues_for assertions)
- [ ] Verify new API works correctly in downstream consumers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new public stats endpoints and refactors `stats()` aggregation logic; incorrect filtering/aggregation could lead to misleading monitoring data or unexpected empty results for drained queues.
> 
> **Overview**
> Adds new public `Storage` APIs `stats_queues()` and `stats_queues_for(patterns)` to fetch **per-queue statistics** without calling full `stats()`.
> 
> Refactors `StorageInternal::stats()` to reuse a new `build_queue_stats` helper, and adds optional filtering so pattern-based queries only return queues with matching Redis keys (including dynamic `#suffix` queues). Integration tests are expanded to cover the new methods before and after processing, including the behavior where `stats_queues_for` returns empty once queues are drained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a5e7265772f55602b71984f8b37aaf74f55c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->