### PR TITLE
Bump oxanus version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5]
+
+### Added
+
+- Per-queue stats API: `stats_queues()` and `stats_queues_for(patterns)` for fetching queue-level statistics independently
+
 ## [1.0.4]
 
 ### Added
+
 - BSD support for shutdown signal handling ([#41](https://github.com/pragmaplatform/oxanus/issues/41))
 
 ## [1.0.3]
 
 ### Added
+
 - Global retry delay override in Config
 
 ## [1.0.2]
 
 ### Improved
+
 - Use LINDEX instead of LRANGE for single-element list access
 
 ## [1.0.1]
 
 ### Fixed
+
 - Fix duplicate job scheduling across concurrent instances
 
 ## [1.0.0]
 
 ### Added
+
 - Public release
 
 ## [0.10.0]
@@ -32,6 +43,7 @@ All notable changes to this project will be documented in this file.
 **Breaking release.** See [MIGRATION.md](MIGRATION.md) for the upgrade guide.
 
 ### Added
+
 - **Job/Worker separation**: job data (`Job` trait) is now separate from processing logic (`Worker<Args>` trait)
 - `FromContext` trait for injecting app state into workers (auto-derived for unit and single-field structs)
 - `JobContext` replaces generic `Context<T>`
@@ -39,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - `#[oxanus(job = Type)]` attribute with `{Name}Job` convention default (strips `Worker` suffix)
 
 ### Changed
+
 - `#[derive(oxanus::Worker)]` now generates both `Job` and `Worker<Args>` impls
 - `config.register_worker::<W, J>()` replaces `config.register_worker::<W>()`
 - `storage.enqueue(queue, job)` now takes the job struct, not the worker struct
@@ -47,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - `Processable`/`BoxedProcessable` removed from public API
 
 ### Removed
+
 - `Context<T>` generic context wrapper
 - `register_cron_worker` (use `register_worker` with cron attributes)
 - `test_helper.rs` (replaced by inline test utilities)
@@ -54,171 +68,206 @@ All notable changes to this project will be documented in this file.
 ## [0.9.7]
 
 ### Added
+
 - Add stat cards to queues tab
 
 ### Fixed
+
 - Retry cron job enqueue on transient Redis failure
 - Handle transient Redis errors without full shutdown
 
 ## [0.9.6]
 
 ### Fixed
+
 - Show stats tiles on dynamic sub-queue detail pages
 
 ## [0.9.5]
 
 ### Added
+
 - Make queue name clickable in job cards linking to queue detail page
 - Show dynamic child queues in Active Queues sections on dashboard and busy pages
 
 ## [0.9.4]
 
 ### Added
+
 - Queue stats tiles to queue detail page
 - Add latency tile to overview dashboard
 
 ## [0.9.3]
 
 ### Added
+
 - Truncate long errors and add Copy Error Info button in web dashboard
 
 ### Fixed
+
 - Fix panic instrumentation: trace was missing `success` value instead of recording `false`
 
 ## [0.9.2]
 
 ### Added
+
 - Web UI dashboard (`oxanus-web` crate) for monitoring jobs, queues, and cron
 - Revive button to dead jobs dashboard
 - Link enqueued stat box to queues tab in web dashboard
 
 ### Changed
+
 - Eliminate redundant Redis fetch in job execution hot path
 - Deduplicate relative time filter and pre-compute concurrency map
 
 ## [0.9.1]
 
 ### Fixed
+
 - Fix queue latency calculation by falling back to `created_at` when `scheduled_at` is zero
 
 ## [0.9.0]
 
 ### Added
+
 - Throttling: support custom cost per job
 - Throttling: skip Redis calls when throttle cost is zero
 - Store error message on dead and retried jobs
 - `JobMeta`: don't serialize None fields
 
 ### Changed
+
 - Relax sentry version requirement
 - Update dependencies
 
 ## [0.8.20]
 
 ### Added
+
 - Conductor workspace setup and archive scripts
 
 ## [0.8.19]
 
 ### Added
+
 - Failed count to global stats
 
 ### Changed
+
 - Tweak dead trimming
 
 ## [0.8.18]
 
 ### Fixed
+
 - Fix resurrect orphaning (with regression test)
 
 ## [0.8.17]
 
 ### Added
+
 - Track `started_at` for a job
 
 ## [0.8.16]
 
 ### Added
+
 - Expose `delete_job`
 - Error when updating state of non-existing job
 
 ## [0.8.15]
 
 ### Added
+
 - Add resurrect flag
 
 ## [0.8.14]
 
 ### Changed
+
 - Rename catalog function
 
 ## [0.8.13]
 
 ### Added
+
 - Include queues in catalog
 
 ## [0.8.12]
 
 ### Added
+
 - Workers catalog
 
 ## [0.8.11]
 
 ### Added
+
 - `list_scheduled` function
 
 ## [0.8.10]
 
 ### Fixed
+
 - Fix `list_dead` and `list_retries`
 
 ## [0.8.9]
 
 ### Added
+
 - `list_dead` and `list_retries` functions
 
 ## [0.8.8]
 
 ### Added
+
 - Export `JobEnvelope`
 
 ## [0.8.7]
 
 ### Added
+
 - `list_queue_jobs` and `wipe_queue` functions
 
 ## [0.8.6]
 
 ### Added
+
 - Export stats types
 
 ## [0.8.4]
 
 ### Added
+
 - `JobMeta`: add `created_at`/`scheduled_at` functions returning datetime
 
 ### Changed
+
 - Revert back to deadpool-redis 0.22
 
 ## [0.8.2]
 
 ### Added
+
 - Export `JobState` and `JobMeta`
 
 ### Changed
+
 - Update dependencies
 
 ## [0.8.1]
 
 ### Added
+
 - Prometheus metrics
 
 ### Fixed
+
 - Fix reported latency
 
 ## [0.8.0]
 
 ### Added
+
 - Worker derive macro
 - Queue derive macro
 - Component registry with macros
@@ -228,6 +277,7 @@ All notable changes to this project will be documented in this file.
 - `max_retries` support custom function
 
 ### Changed
+
 - Change Cron worker API and update examples
 - Namespace `unique_id` with job name
 - Restore `register_cron_worker` API
@@ -236,58 +286,70 @@ All notable changes to this project will be documented in this file.
 ## [0.7.0]
 
 ### Added
+
 - Report process' `started_at`
 
 ## [0.6.3]
 
 ### Changed
+
 - Update dependencies
 
 ## [0.6.2]
 
 ### Changed
+
 - Upgrade dependencies (Redis to 1.0)
 
 ## [0.6.0]
 
 ### Changed
+
 - Rework storage builder
 
 ## [0.5.2]
 
 ### Added
+
 - Implement on-conflict strategy for unique jobs
 
 ## [0.5.1]
 
 ### Changed
+
 - Enqueue immediately with `enqueue_at` when time is lower than now
 
 ## [0.5.0]
 
 ### Added
+
 - Expose `enqueue_at` in public interface
 
 ### Fixed
+
 - Fix cron/unique jobs not being retried
 
 ## [0.4.0]
 
 ### Added
+
 - Optimize connection management
 - Optimize `enqueue_scheduled` with pipeline
 
 ### Changed
+
 - Switch time types from `u64` to `i64`
 - Improve tracing
 - Change age to latency and add `scheduled_at`
 
 ### Fixed
+
 - Fix cleanup timestamp check
 
 ## [0.3.x]
 
 ### Added
+
 - Implement shutdown timeout
 - Add cron job validation
 - Firehose (optional, disabled by default)
@@ -304,12 +366,14 @@ All notable changes to this project will be documented in this file.
 - Add drain
 
 ### Changed
+
 - Improve error handling
 - Improve storage builder
 - Reliability improvements
 - Rework stats with grouping of dynamic queues
 
 ### Fixed
+
 - Fix handling of critical failure
 - Fix double in dynamic queue key
 - Account for job not existing anymore when retrying
@@ -321,6 +385,7 @@ All notable changes to this project will be documented in this file.
 ## [0.2.0]
 
 ### Added
+
 - Support for cron jobs
 - Namespace storage support
 - Redis pool (deadpool-redis)
@@ -330,6 +395,7 @@ All notable changes to this project will be documented in this file.
 - Dead queue trimming
 
 ### Changed
+
 - Rename `WorkerContext` to `Context`
 - Clean up public API
 - Accept any future as shutdown signal
@@ -337,6 +403,7 @@ All notable changes to this project will be documented in this file.
 ## [0.1.0]
 
 ### Added
+
 - Initial release
 - Job processing with Redis backend
 - Scheduling and retrying

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxanus crate version from 1.0.4 to 1.0.5
- Update CHANGELOG with new per-queue stats API (`stats_queues`, `stats_queues_for`) and shared helper refactor

## Test plan
- [x] `cargo check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only a crate version bump and changelog update; no functional code changes are included in this diff.
> 
> **Overview**
> Bumps the `oxanus` crate version from `1.0.4` to `1.0.5`.
> 
> Updates `CHANGELOG.md` with release notes for `1.0.5`, documenting the new per-queue stats API (`stats_queues` and `stats_queues_for`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a3afd38dcd058c6bd751cefcf139f432bbd78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->