### PR TITLE
Add basic web dashboard example for oxanus-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,11 +1149,14 @@ version = "1.0.1"
 dependencies = [
  "askama",
  "askama_web",
+ "async-trait",
  "axum",
  "chrono",
  "oxanus",
  "serde",
  "serde_json",
+ "thiserror",
+ "tokio",
  "urlencoding",
  "uuid",
 ]

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -24,3 +24,12 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 urlencoding = "2"
 uuid = { version = "^1.17", features = ["v4"] }
+
+[dev-dependencies]
+async-trait = "0.1"
+oxanus = { path = "../oxanus", default-features = false, features = [
+    "registry",
+] }
+serde = { version = "^1.0", features = ["derive"] }
+thiserror = "^2.0"
+tokio = { version = "^1.46", features = ["full"] }

--- a/oxanus-web/examples/web.rs
+++ b/oxanus-web/examples/web.rs
@@ -1,0 +1,49 @@
+// cargo run --package oxanus-web --example web
+
+use serde::{Deserialize, Serialize};
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PingJob {
+    target: String,
+}
+
+#[derive(oxanus::Worker)]
+struct PingWorker;
+
+impl PingWorker {
+    async fn process(&self, _job: &PingJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "ping", concurrency = 5)]
+struct PingQueue;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = oxanus::Storage::builder().build_from_env()?;
+    let config = ComponentRegistry::build_config(&storage);
+    let catalog = config.catalog();
+
+    let base_path = "/oxanus";
+    let oxanus_state =
+        oxanus_web::OxanusWebState::new(config.storage.clone(), catalog, base_path.to_string());
+
+    let app = axum::Router::new().nest(base_path, oxanus_web::router(oxanus_state));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    println!("Oxanus web UI available at http://localhost:3000{base_path}");
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add a minimal axum example (`oxanus-web/examples/web.rs`) that mounts the oxanus web dashboard at `/oxanus`
- Add required dev-dependencies (`async-trait`, `oxanus`, `serde`, `thiserror`, `tokio`) to `oxanus-web/Cargo.toml`

## Test plan
- [x] `cargo check --package oxanus-web --example web` compiles
- [x] `cargo clippy` passes with no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an example binary and dev-dependencies only, with no changes to the library’s runtime behavior.
> 
> **Overview**
> Adds a minimal runnable `axum` example (`oxanus-web/examples/web.rs`) that mounts the Oxanus web dashboard under `/oxanus` using `OxanusWebState` and `oxanus_web::router`.
> 
> Updates `oxanus-web` with new dev-dependencies (`tokio`, `thiserror`, `async-trait`, and a local `oxanus` with `registry` feature) to support building and running the example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417c3549f0a2ad66def11692155d78006d902600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->