### PR TITLE
build(deps): Update deps.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,31 +392,30 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
 dependencies = [
  "deadpool-runtime",
- "lazy_static",
  "num_cpus",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-redis"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4d00bce7a9cfd07ded19530621a7df17c4c3b1c4e8fc2262471de404ce539a"
+checksum = "bafa30c49dafe086d10116074e422ad7fc1c3cf554697e744a3ab112599ebd09"
 dependencies = [
  "deadpool",
- "redis 0.32.7",
+ "redis",
 ]
 
 [[package]]
 name = "deadpool-runtime"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
 ]
@@ -1118,7 +1117,7 @@ dependencies = [
  "oxanus-macros",
  "prometheus-client",
  "rand 0.10.1",
- "redis 1.2.0",
+ "redis",
  "sentry-core",
  "serde",
  "serde_json",
@@ -1413,27 +1412,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "redis"
-version = "0.32.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
-dependencies = [
- "bytes",
- "cfg-if",
- "combine",
- "futures-util",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "socket2",
- "tokio",
- "tokio-util",
- "url",
-]
 
 [[package]]
 name = "redis"

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "^0.4", features = ["serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 urlencoding = "2"
-uuid = { version = "^1.17", features = ["v4"] }
+uuid = { version = "^1.23", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
@@ -32,4 +32,4 @@ oxanus = { path = "../oxanus", default-features = false, features = [
 ] }
 serde = { version = "^1.0", features = ["derive"] }
 thiserror = "^2.0"
-tokio = { version = "^1.46", features = ["full"] }
+tokio = { version = "^1.52", features = ["full"] }

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -25,20 +25,20 @@ prometheus = ["prometheus-client"]
 async-trait = "0.1"
 chrono = { version = "^0.4", features = ["serde"] }
 cron = "^0.16"
-deadpool-redis = "^0.22"
-redis = { version = "^1.0", features = ["aio", "tokio-comp"] }
+deadpool-redis = "^0.23"
+redis = { version = "^1.2", features = ["aio", "tokio-comp"] }
 futures = { version = "^0.3" }
-gethostname = "^1.0"
+gethostname = "^1.1"
 inventory = { version = "0.3", optional = true }
 prometheus-client = { version = "0.24", optional = true }
 sentry-core = { version = "^0", optional = true }
-serde = { version = "^1.0.218", features = ["derive"] }
+serde = { version = "^1.0.228", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 thiserror = "^2.0"
-tokio = { version = "^1.46", features = ["full"] }
+tokio = { version = "^1.52", features = ["full"] }
 tokio-util = { version = "^0.7" }
 tracing = { version = "^0.1", features = ["log"] }
-uuid = { version = "^1.17", features = ["serde", "v4"] }
+uuid = { version = "^1.23", features = ["serde", "v4"] }
 
 oxanus-macros = { workspace = true, optional = true }
 


### PR DESCRIPTION
Update all dependencies.

I noticed a duplicate, very old version of `redis` crate was being pulled in due to outdated deps.