### PR TITLE
Upgrade deadpool-redis to 0.23 and fix blocking command timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,29 +1051,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1117,7 +1098,6 @@ dependencies = [
  "oxanus-macros",
  "prometheus-client",
  "rand 0.10.1",
- "redis",
  "sentry-core",
  "serde",
  "serde_json",
@@ -1426,11 +1406,9 @@ dependencies = [
  "combine",
  "futures-util",
  "itoa",
- "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
- "sha1_smol",
  "socket2",
  "tokio",
  "tokio-util",
@@ -1608,12 +1586,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,31 +392,30 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
 dependencies = [
  "deadpool-runtime",
- "lazy_static",
  "num_cpus",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-redis"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4d00bce7a9cfd07ded19530621a7df17c4c3b1c4e8fc2262471de404ce539a"
+checksum = "bafa30c49dafe086d10116074e422ad7fc1c3cf554697e744a3ab112599ebd09"
 dependencies = [
  "deadpool",
- "redis 0.32.7",
+ "redis",
 ]
 
 [[package]]
 name = "deadpool-runtime"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
 ]
@@ -1118,7 +1117,7 @@ dependencies = [
  "oxanus-macros",
  "prometheus-client",
  "rand 0.10.1",
- "redis 1.2.0",
+ "redis",
  "sentry-core",
  "serde",
  "serde_json",
@@ -1413,27 +1412,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "redis"
-version = "0.32.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
-dependencies = [
- "bytes",
- "cfg-if",
- "combine",
- "futures-util",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "socket2",
- "tokio",
- "tokio-util",
- "url",
-]
 
 [[package]]
 name = "redis"

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "^0.4", features = ["serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 urlencoding = "2"
-uuid = { version = "^1.17", features = ["v4"] }
+uuid = { version = "^1.23", features = ["v4"] }
 
 [dev-dependencies]
 async-trait = "0.1"
@@ -32,4 +32,4 @@ oxanus = { path = "../oxanus", default-features = false, features = [
 ] }
 serde = { version = "^1.0", features = ["derive"] }
 thiserror = "^2.0"
-tokio = { version = "^1.46", features = ["full"] }
+tokio = { version = "^1.52", features = ["full"] }

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -25,20 +25,20 @@ prometheus = ["prometheus-client"]
 async-trait = "0.1"
 chrono = { version = "^0.4", features = ["serde"] }
 cron = "^0.16"
-deadpool-redis = "^0.22"
-redis = { version = "^1.0", features = ["aio", "tokio-comp"] }
+deadpool-redis = "^0.23"
+redis = { version = "^1.2", features = ["aio", "tokio-comp"] }
 futures = { version = "^0.3" }
-gethostname = "^1.0"
+gethostname = "^1.1"
 inventory = { version = "0.3", optional = true }
 prometheus-client = { version = "0.24", optional = true }
 sentry-core = { version = "^0", optional = true }
-serde = { version = "^1.0.218", features = ["derive"] }
+serde = { version = "^1.0.228", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 thiserror = "^2.0"
-tokio = { version = "^1.46", features = ["full"] }
+tokio = { version = "^1.52", features = ["full"] }
 tokio-util = { version = "^0.7" }
 tracing = { version = "^0.1", features = ["log"] }
-uuid = { version = "^1.17", features = ["serde", "v4"] }
+uuid = { version = "^1.23", features = ["serde", "v4"] }
 
 oxanus-macros = { workspace = true, optional = true }
 

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -26,13 +26,12 @@ async-trait = "0.1"
 chrono = { version = "^0.4", features = ["serde"] }
 cron = "^0.16"
 deadpool-redis = "^0.23"
-redis = { version = "^1.2", features = ["aio", "tokio-comp"] }
 futures = { version = "^0.3" }
 gethostname = "^1.1"
 inventory = { version = "0.3", optional = true }
 prometheus-client = { version = "0.24", optional = true }
 sentry-core = { version = "^0", optional = true }
-serde = { version = "^1.0.228", features = ["derive"] }
+serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 thiserror = "^2.0"
 tokio = { version = "^1.52", features = ["full"] }

--- a/oxanus/src/error.rs
+++ b/oxanus/src/error.rs
@@ -22,6 +22,10 @@ pub enum OxanusError {
     DeadpoolRedisPoolError(#[from] deadpool_redis::PoolError),
     #[error("Deadpool Redis create pool error: {0}")]
     DeadpoolRedisCreatePoolError(#[from] deadpool_redis::CreatePoolError),
+    #[error("Deadpool Redis config error: {0}")]
+    DeadpoolRedisConfigError(#[from] deadpool_redis::ConfigError),
+    #[error("Deadpool Redis build error: {0}")]
+    DeadpoolRedisBuildError(#[from] deadpool_redis::BuildError),
     #[error("Config error: {0}")]
     ConfigError(String),
     #[error("Job panicked: {0}")]

--- a/oxanus/src/storage_builder.rs
+++ b/oxanus/src/storage_builder.rs
@@ -1,3 +1,6 @@
+use deadpool_redis::Hook;
+use std::time::Duration;
+
 use crate::{OxanusError, Storage, storage_internal::StorageInternal};
 
 #[must_use]
@@ -81,7 +84,19 @@ impl StorageBuilder {
             queue_mode: Default::default(),
         });
 
-        let pool = cfg.create_pool(Some(deadpool_redis::Runtime::Tokio1))?;
+        let pool = cfg
+            .builder()?
+            .post_create(Hook::sync_fn(|conn, _| {
+                // redis 1.0 introduced a default 500ms response_timeout on
+                // MultiplexedConnection. This causes blocking Redis commands
+                // (BLMOVE, BLPOP, etc.) to time out prematurely. Disable it
+                // so that command-level timeouts govern blocking behavior.
+                conn.set_response_timeout(Duration::from_secs(60));
+                Ok(())
+            }))
+            .runtime(deadpool_redis::Runtime::Tokio1)
+            .build()?;
+
         Ok(Storage {
             internal: StorageInternal::new(pool, self.namespace),
         })


### PR DESCRIPTION
## Summary

- Upgrades `deadpool-redis` from 0.22 to 0.23, which uses `redis` 1.0+ (eliminating the duplicate redis 0.32 dependency)
- Removes the separate `redis` crate dependency (re-exported by deadpool-redis)
- Fixes blocking command timeouts caused by redis-rs 1.0's new default 500ms `response_timeout` on `MultiplexedConnection`, which broke `BLMOVE`/`BLPOP` used in job dequeuing
- Sets a 60s response timeout via a pool `post_create` hook — well above the 10s blocking dequeue timeout while still catching stuck connections

Includes the dep update commit from #53.

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all-features --workspace` clean
- [x] All 38 tests pass
- [x] `minimal` and `foo` examples run successfully with the upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core Redis/pooling dependencies and changes connection initialization to override `response_timeout`, which can affect runtime behavior and failure modes of Redis operations under load.
> 
> **Overview**
> Upgrades Redis pooling to `deadpool-redis` `0.23` (and related crate bumps), removing the older duplicated Redis dependency and aligning on `redis` `1.x` in the lockfile/workspace.
> 
> Updates `StorageBuilder::build_from_redis_url` to use the new pool `builder()` API and installs a `post_create` hook that sets a 60s `response_timeout` on each connection to prevent `BLMOVE`/`BLPOP`-style blocking commands from prematurely timing out.
> 
> Extends `OxanusError` to surface new `deadpool-redis` `ConfigError`/`BuildError` variants introduced by the builder-based pool creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ccdae3da09061909bb4e5959da5a9975fa48fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->