### PR TITLE
Add scheduled jobs example

### DIFF
--- a/oxanus/examples/scheduled.rs
+++ b/oxanus/examples/scheduled.rs
@@ -1,0 +1,72 @@
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TestJob {
+    label: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(resurrect = false)]
+struct TestWorker;
+
+impl TestWorker {
+    async fn process(&self, job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+        tracing::info!("Processing job: {}", job.label);
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "one")]
+struct QueueOne;
+
+#[tokio::main]
+pub async fn main() -> Result<(), oxanus::OxanusError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
+    let storage = oxanus::Storage::builder().build_from_env()?;
+    let config = ComponentRegistry::build_config(&storage)
+        .with_graceful_shutdown(tokio::signal::ctrl_c())
+        .exit_when_processed(2);
+
+    let now = Utc::now();
+
+    storage
+        .enqueue_at(
+            QueueOne,
+            TestJob {
+                label: "30 seconds from now".into(),
+            },
+            now + chrono::Duration::seconds(30),
+        )
+        .await?;
+
+    storage
+        .enqueue_at(
+            QueueOne,
+            TestJob {
+                label: "60 seconds from now".into(),
+            },
+            now + chrono::Duration::seconds(60),
+        )
+        .await?;
+
+    oxanus::run(config, ctx).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `oxanus/examples/scheduled.rs` demonstrating `enqueue_at` to schedule jobs in the future
- Schedules one job 30s out and another 60s out, exits after both are processed

## Test plan
- [ ] `REDIS_URL=redis://127.0.0.1:6379/4 RUST_LOG=debug cargo run --example scheduled`
- [ ] Verify first job processes after ~30s, second after ~60s, then process exits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new example binary only; no library/runtime behavior changes, so risk is minimal beyond potential example compilation/dependency issues.
> 
> **Overview**
> Adds a new `scheduled` example showing how to schedule future jobs via `Storage::enqueue_at`, enqueueing two jobs (30s and 60s out) and exiting after both are processed with basic tracing setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54aa9ecd445e358a041e88dbd39a7f5932ad397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->