### PR TITLE
store scheduled_at time in job meta when using enqueue_at

### DIFF
--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -92,6 +92,16 @@ impl JobEnvelope {
         })
     }
 
+    pub(crate) fn new_scheduled<T: Job>(
+        queue: String,
+        job: T,
+        scheduled_at: DateTime<Utc>,
+    ) -> Result<Self, OxanusError> {
+        let mut new_job_envelope = Self::new(queue, job)?;
+        new_job_envelope.meta.scheduled_at = scheduled_at.timestamp_micros();
+        Ok(new_job_envelope)
+    }
+
     pub(crate) fn new_cron(
         queue: String,
         id: String,

--- a/oxanus/src/job_envelope.rs
+++ b/oxanus/src/job_envelope.rs
@@ -97,9 +97,7 @@ impl JobEnvelope {
         job: T,
         scheduled_at: DateTime<Utc>,
     ) -> Result<Self, OxanusError> {
-        let mut new_job_envelope = Self::new(queue, job)?;
-        new_job_envelope.meta.scheduled_at = scheduled_at.timestamp_micros();
-        Ok(new_job_envelope)
+        Ok(Self::new(queue, job)?.with_scheduled_at(scheduled_at))
     }
 
     pub(crate) fn new_cron(
@@ -130,6 +128,11 @@ impl JobEnvelope {
                 throttle_cost: None,
             },
         })
+    }
+
+    pub(crate) fn with_scheduled_at(mut self, scheduled_at: DateTime<Utc>) -> Self {
+        self.meta.scheduled_at = scheduled_at.timestamp_micros();
+        self
     }
 
     pub(crate) fn with_error(mut self, error: String) -> Self {

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -412,7 +412,6 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use crate as oxanus;
-    use crate::queue::Queue;
     use crate::test_helper;
     use serde::Serialize;
     use testresult::TestResult;

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -408,3 +408,49 @@ impl Storage {
         Ok(PrometheusMetrics::from_stats(&stats))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate as oxanus;
+    use crate::test_helper;
+    use serde::Serialize;
+    use testresult::TestResult;
+
+    #[derive(oxanus::Registry)]
+    #[allow(dead_code)]
+    struct ComponentRegistry(oxanus::ComponentRegistry<(), ()>);
+
+    #[derive(Serialize, oxanus::Queue)]
+    #[oxanus(key = "test")]
+    struct TestQueue;
+
+    #[derive(Serialize)]
+    struct TestJob {}
+
+    impl crate::worker::Job for TestJob {
+        fn worker_name() -> &'static str {
+            "TestJob"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_at_stores_scheduled_at() -> TestResult {
+        let storage = test_helper::storage()?;
+
+        let scheduled_time = chrono::Utc::now() + chrono::Duration::hours(1);
+
+        let job_id = storage.enqueue_at(TestQueue, TestJob {}, scheduled_time).await?;
+
+        assert_eq!(storage.enqueued_count(TestQueue).await?, 0);
+        assert_eq!(storage.scheduled_count().await?, 1);
+
+        let job = storage.internal.get_job(&job_id).await?.expect("job should exist");
+        assert_eq!(
+            job.meta.scheduled_at,
+            scheduled_time.timestamp_micros(),
+            "scheduled_at in job meta should match the requested schedule time"
+        );
+
+        Ok(())
+    }
+}

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -439,12 +439,18 @@ mod tests {
 
         let scheduled_time = chrono::Utc::now() + chrono::Duration::hours(1);
 
-        let job_id = storage.enqueue_at(TestQueue, TestJob {}, scheduled_time).await?;
+        let job_id = storage
+            .enqueue_at(TestQueue, TestJob {}, scheduled_time)
+            .await?;
 
         assert_eq!(storage.enqueued_count(TestQueue).await?, 0);
         assert_eq!(storage.scheduled_count().await?, 1);
 
-        let job = storage.internal.get_job(&job_id).await?.expect("job should exist");
+        let job = storage
+            .internal
+            .get_job(&job_id)
+            .await?
+            .expect("job should exist");
         assert_eq!(
             job.meta.scheduled_at,
             scheduled_time.timestamp_micros(),

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -411,18 +411,27 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
-    use crate as oxanus;
-    use crate::test_helper;
+    use crate::queue::Queue;
+    use crate::{test_helper, QueueConfig, QueueKind};
     use serde::Serialize;
     use testresult::TestResult;
 
-    #[derive(oxanus::Registry)]
-    #[allow(dead_code)]
-    struct ComponentRegistry(oxanus::ComponentRegistry<(), ()>);
-
-    #[derive(Serialize, oxanus::Queue)]
-    #[oxanus(key = "test")]
+    #[derive(Serialize, Clone, Copy)]
     struct TestQueue;
+
+    impl Queue for TestQueue {
+        fn key(&self) -> String {
+            "test".to_string()
+        }
+
+        fn to_config() -> QueueConfig {
+            QueueConfig{
+                kind: QueueKind::Static{ key: "test".to_string() },
+                concurrency: 1,
+                throttle: None,
+            }
+        }
+    }
 
     #[derive(Serialize)]
     struct TestJob {}

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -155,7 +155,7 @@ impl Storage {
 
         tracing::trace!("Scheduling job {:?} at {}", envelope, time);
 
-        self.internal.enqueue_at(envelope, time).await
+        self.internal.enqueue_at(envelope).await
     }
 
     /// Returns the number of jobs currently enqueued in the specified queue.

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -412,6 +412,7 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use crate as oxanus;
+    use crate::queue::Queue;
     use crate::test_helper;
     use serde::Serialize;
     use testresult::TestResult;

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -412,7 +412,7 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use crate::queue::Queue;
-    use crate::{test_helper, QueueConfig, QueueKind};
+    use crate::{QueueConfig, QueueKind, test_helper};
     use serde::Serialize;
     use testresult::TestResult;
 
@@ -425,8 +425,10 @@ mod tests {
         }
 
         fn to_config() -> QueueConfig {
-            QueueConfig{
-                kind: QueueKind::Static{ key: "test".to_string() },
+            QueueConfig {
+                kind: QueueKind::Static {
+                    key: "test".to_string(),
+                },
                 concurrency: 1,
                 throttle: None,
             }

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -151,7 +151,7 @@ impl Storage {
         job: T,
         time: DateTime<Utc>,
     ) -> Result<JobId, OxanusError> {
-        let envelope = JobEnvelope::new(queue.key().clone(), job)?;
+        let envelope = JobEnvelope::new_scheduled(queue.key().clone(), job, time)?;
 
         tracing::trace!("Scheduling job {:?} at {}", envelope, time);
 

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use deadpool_redis::redis::{self, AsyncCommands};
 use std::{
     collections::{HashMap, HashSet},
@@ -1255,8 +1254,7 @@ mod tests {
     use crate as oxanus;
     use crate::Queue;
     use crate::test_helper::{random_string, redis_pool};
-    use chrono::Duration;
-    use rand::{Rng, RngExt, random};
+    use rand::RngExt;
     use serde::Serialize;
     use testresult::TestResult;
 
@@ -1772,14 +1770,14 @@ mod tests {
             .enqueue_at(TestQueue, TestJob {}, scheduled_at)
             .await?;
         let after = chrono::Utc::now().timestamp_micros();
-        assert_eq!(internal_storage.enqueued_count(&TestQueue.key()).await?, 0);
+        assert_eq!(internal_storage.enqueued_count(&TestQueue{}.key()).await?, 0);
         assert_eq!(internal_storage.scheduled_count().await?, 1);
 
         let job = internal_storage
             .get_job(&returned_id)
             .await?
             .expect("job should exist");
-        assert_eq!(job.queue, TestQueue.key());
+        assert_eq!(job.queue, TestQueue{}.key());
 
         assert!(job.meta.scheduled_at >= before + delay);
         assert!(job.meta.scheduled_at <= after + delay);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -193,10 +193,7 @@ impl StorageInternal {
         }
     }
 
-    pub async fn enqueue_at(
-        &self,
-        envelope: JobEnvelope,
-    ) -> Result<JobId, OxanusError> {
+    pub async fn enqueue_at(&self, envelope: JobEnvelope) -> Result<JobId, OxanusError> {
         if envelope.meta.scheduled_at <= chrono::Utc::now().timestamp_micros() {
             return self.enqueue(envelope).await;
         }
@@ -218,7 +215,11 @@ impl StorageInternal {
                         &envelope.id,
                         serde_json::to_string(&envelope)?,
                     )
-                    .zadd(&self.keys.schedule, &envelope.id, envelope.meta.scheduled_at)
+                    .zadd(
+                        &self.keys.schedule,
+                        &envelope.id,
+                        envelope.meta.scheduled_at,
+                    )
                     .query_async(&mut redis)
                     .await?;
             }
@@ -229,7 +230,11 @@ impl StorageInternal {
                         &envelope.id,
                         serde_json::to_string(&envelope)?,
                     )
-                    .zadd(&self.keys.schedule, &envelope.id, envelope.meta.scheduled_at)
+                    .zadd(
+                        &self.keys.schedule,
+                        &envelope.id,
+                        envelope.meta.scheduled_at,
+                    )
                     .query_async(&mut redis)
                     .await?;
             }
@@ -1246,14 +1251,14 @@ impl StorageInternal {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Duration;
+    use super::*;
     use crate as oxanus;
-    use rand::{random, Rng, RngExt};
+    use crate::Queue;
+    use crate::test_helper::{random_string, redis_pool};
+    use chrono::Duration;
+    use rand::{Rng, RngExt, random};
     use serde::Serialize;
     use testresult::TestResult;
-    use crate::Queue;
-    use super::*;
-    use crate::test_helper::{random_string, redis_pool};
 
     #[derive(oxanus::Registry)]
     #[allow(dead_code)]
@@ -1718,7 +1723,9 @@ mod tests {
             },
         };
         let delay_s = rand::rng().random_range(1..3600);
-        let delay = chrono::Duration::seconds(delay_s).num_microseconds().unwrap();
+        let delay = chrono::Duration::seconds(delay_s)
+            .num_microseconds()
+            .unwrap();
 
         let before = chrono::Utc::now().timestamp_micros();
         let returned_id = storage.enqueue_in(envelope, delay_s as u64).await?;
@@ -1761,12 +1768,17 @@ mod tests {
         let scheduled_at = chrono::Utc::now() + chrono::Duration::microseconds(delay);
 
         let before = chrono::Utc::now().timestamp_micros();
-        let returned_id = storage.enqueue_at(TestQueue, TestJob{}, scheduled_at).await?;
+        let returned_id = storage
+            .enqueue_at(TestQueue, TestJob {}, scheduled_at)
+            .await?;
         let after = chrono::Utc::now().timestamp_micros();
         assert_eq!(internal_storage.enqueued_count(&TestQueue.key()).await?, 0);
         assert_eq!(internal_storage.scheduled_count().await?, 1);
 
-        let job = internal_storage.get_job(&returned_id).await?.expect("job should exist");
+        let job = internal_storage
+            .get_job(&returned_id)
+            .await?
+            .expect("job should exist");
         assert_eq!(job.queue, TestQueue.key());
 
         assert!(job.meta.scheduled_at >= before + delay);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1252,7 +1252,7 @@ impl StorageInternal {
 mod tests {
     use super::*;
     use crate as oxanus;
-    use crate::Queue;
+    use crate::queue::Queue;
     use crate::test_helper::{random_string, redis_pool};
     use rand::RngExt;
     use serde::Serialize;
@@ -1759,7 +1759,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enqueue_at_job_envelope() -> TestResult {
-        let storage = crate::Storage::builder().build_from_env()?;
+        let storage = crate::test_helper::storage()?;
         let internal_storage = &storage.internal;
 
         let delay = rand::rng().random_range(1_000_000..10_000_000);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -189,16 +189,15 @@ impl StorageInternal {
             self.enqueue(envelope).await
         } else {
             let time = chrono::Utc::now() + chrono::Duration::seconds(delay_s as i64);
-            self.enqueue_at(envelope, time).await
+            self.enqueue_at(envelope.with_scheduled_at(time)).await
         }
     }
 
     pub async fn enqueue_at(
         &self,
         envelope: JobEnvelope,
-        time: DateTime<Utc>,
     ) -> Result<JobId, OxanusError> {
-        if time <= chrono::Utc::now() {
+        if envelope.meta.scheduled_at <= chrono::Utc::now().timestamp_micros() {
             return self.enqueue(envelope).await;
         }
 
@@ -219,7 +218,7 @@ impl StorageInternal {
                         &envelope.id,
                         serde_json::to_string(&envelope)?,
                     )
-                    .zadd(&self.keys.schedule, &envelope.id, time.timestamp_micros())
+                    .zadd(&self.keys.schedule, &envelope.id, envelope.meta.scheduled_at)
                     .query_async(&mut redis)
                     .await?;
             }
@@ -230,7 +229,7 @@ impl StorageInternal {
                         &envelope.id,
                         serde_json::to_string(&envelope)?,
                     )
-                    .zadd(&self.keys.schedule, &envelope.id, time.timestamp_micros())
+                    .zadd(&self.keys.schedule, &envelope.id, envelope.meta.scheduled_at)
                     .query_async(&mut redis)
                     .await?;
             }
@@ -1084,7 +1083,7 @@ impl StorageInternal {
                     cron_job.resurrect,
                 )?;
 
-                match self.track_redis_result(self.enqueue_at(envelope, next).await)? {
+                match self.track_redis_result(self.enqueue_at(envelope).await)? {
                     Some(_) => break,
                     None => {
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1252,7 +1252,6 @@ impl StorageInternal {
 mod tests {
     use super::*;
     use crate as oxanus;
-    use crate::queue::Queue;
     use crate::test_helper::{random_string, redis_pool};
     use rand::RngExt;
     use serde::Serialize;
@@ -1753,39 +1752,6 @@ mod tests {
         let envelope = JobEnvelope::new_scheduled(queue.clone(), TestJob {}, scheduled_at)?;
 
         assert_eq!(envelope.meta.scheduled_at, scheduled_at.timestamp_micros());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_enqueue_at_job_envelope() -> TestResult {
-        let storage = crate::test_helper::storage()?;
-        let internal_storage = &storage.internal;
-
-        let delay = rand::rng().random_range(1_000_000..10_000_000);
-        let scheduled_at = chrono::Utc::now() + chrono::Duration::microseconds(delay);
-
-        let before = chrono::Utc::now().timestamp_micros();
-        let returned_id = storage
-            .enqueue_at(TestQueue, TestJob {}, scheduled_at)
-            .await?;
-        let after = chrono::Utc::now().timestamp_micros();
-        assert_eq!(
-            internal_storage.enqueued_count(&TestQueue {}.key()).await?,
-            0
-        );
-        assert_eq!(internal_storage.scheduled_count().await?, 1);
-
-        let job = internal_storage
-            .get_job(&returned_id)
-            .await?
-            .expect("job should exist");
-        assert_eq!(job.queue, TestQueue {}.key());
-
-        assert!(job.meta.scheduled_at >= before + delay);
-        assert!(job.meta.scheduled_at <= after + delay);
-        assert_eq!(job.meta.retries, 0);
-        assert!(job.meta.error.is_none());
 
         Ok(())
     }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1251,7 +1251,7 @@ mod tests {
     use rand::{random, Rng, RngExt};
     use serde::Serialize;
     use testresult::TestResult;
-
+    use crate::Queue;
     use super::*;
     use crate::test_helper::{random_string, redis_pool};
 
@@ -1724,7 +1724,7 @@ mod tests {
         let returned_id = storage.enqueue_in(envelope, delay_s as u64).await?;
         let after = chrono::Utc::now().timestamp_micros();
         assert_eq!(returned_id, id);
-        assert_eq!(storage.enqueued_count(&queue).await?, 1);
+        assert_eq!(storage.enqueued_count(&queue).await?, 0);
 
         let job = storage.get_job(&id).await?.expect("job should exist");
         assert_eq!(job.queue, queue);
@@ -1755,23 +1755,17 @@ mod tests {
     async fn test_enqueue_at_job_envelope() -> TestResult {
         let storage = crate::Storage::builder().build_from_env()?;
         let internal_storage = &storage.internal;
-        let queue = random_string();
 
-        let now = chrono::Utc::now().timestamp_micros();
-        let id = uuid::Uuid::new_v4().to_string();
-        let delay = rand::rng().random_range(1..1_000_000);
+        let delay = rand::rng().random_range(1_000_000..10_000_000);
         let scheduled_at = chrono::Utc::now() + chrono::Duration::microseconds(delay);
 
         let before = chrono::Utc::now().timestamp_micros();
         let returned_id = storage.enqueue_at(TestQueue, TestJob{}, scheduled_at).await?;
         let after = chrono::Utc::now().timestamp_micros();
-        assert_eq!(returned_id, id);
-        assert_eq!(internal_storage.enqueued_count(&queue).await?, 1);
+        assert_eq!(internal_storage.enqueued_count(&TestQueue.key()).await?, 0);
 
-        let job = internal_storage.get_job(&id).await?.expect("job should exist");
-        assert_eq!(job.queue, queue);
-        assert_eq!(job.job.name, "MyWorker");
-        assert_eq!(job.job.args, serde_json::json!({"key": "value"}));
+        let job = internal_storage.get_job(&returned_id).await?.expect("job should exist");
+        assert_eq!(job.queue, TestQueue.key());
 
         assert!(job.meta.scheduled_at >= before + delay);
         assert!(job.meta.scheduled_at <= after + delay);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1248,7 +1248,7 @@ impl StorageInternal {
 mod tests {
     use chrono::Duration;
     use crate as oxanus;
-    use rand::random;
+    use rand::{random, Rng, RngExt};
     use serde::Serialize;
     use testresult::TestResult;
 
@@ -1717,7 +1717,7 @@ mod tests {
                 throttle_cost: None,
             },
         };
-        let delay_s = 1234;
+        let delay_s = rand::rng().random_range(1..3600);
         let delay = chrono::Duration::seconds(delay_s).num_microseconds().unwrap();
 
         let before = chrono::Utc::now().timestamp_micros();
@@ -1741,7 +1741,8 @@ mod tests {
     #[tokio::test]
     async fn test_envelope_new_scheduled() -> TestResult {
         let queue = random_string();
-        let scheduled_at = chrono::Utc::now() + chrono::Duration::seconds(random::<i64>());
+        let delay_s = rand::rng().random_range(1..3600);
+        let scheduled_at = chrono::Utc::now() + chrono::Duration::seconds(delay_s);
 
         let envelope = JobEnvelope::new_scheduled(queue.clone(), TestJob {}, scheduled_at)?;
 
@@ -1758,7 +1759,7 @@ mod tests {
 
         let now = chrono::Utc::now().timestamp_micros();
         let id = uuid::Uuid::new_v4().to_string();
-        let delay = random::<i64>();
+        let delay = rand::rng().random_range(1..1_000_000);
         let scheduled_at = chrono::Utc::now() + chrono::Duration::microseconds(delay);
 
         let before = chrono::Utc::now().timestamp_micros();

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1725,6 +1725,7 @@ mod tests {
         let after = chrono::Utc::now().timestamp_micros();
         assert_eq!(returned_id, id);
         assert_eq!(storage.enqueued_count(&queue).await?, 0);
+        assert_eq!(storage.scheduled_count().await?, 1);
 
         let job = storage.get_job(&id).await?.expect("job should exist");
         assert_eq!(job.queue, queue);
@@ -1763,6 +1764,7 @@ mod tests {
         let returned_id = storage.enqueue_at(TestQueue, TestJob{}, scheduled_at).await?;
         let after = chrono::Utc::now().timestamp_micros();
         assert_eq!(internal_storage.enqueued_count(&TestQueue.key()).await?, 0);
+        assert_eq!(internal_storage.scheduled_count().await?, 1);
 
         let job = internal_storage.get_job(&returned_id).await?.expect("job should exist");
         assert_eq!(job.queue, TestQueue.key());

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1251,19 +1251,10 @@ impl StorageInternal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate as oxanus;
     use crate::test_helper::{random_string, redis_pool};
     use rand::RngExt;
     use serde::Serialize;
     use testresult::TestResult;
-
-    #[derive(oxanus::Registry)]
-    #[allow(dead_code)]
-    struct ComponentRegistry(oxanus::ComponentRegistry<(), ()>);
-
-    #[derive(Serialize, oxanus::Queue)]
-    #[oxanus(key = "test")]
-    struct TestQueue;
 
     #[derive(Serialize)]
     struct TestJob {}

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1770,14 +1770,17 @@ mod tests {
             .enqueue_at(TestQueue, TestJob {}, scheduled_at)
             .await?;
         let after = chrono::Utc::now().timestamp_micros();
-        assert_eq!(internal_storage.enqueued_count(&TestQueue{}.key()).await?, 0);
+        assert_eq!(
+            internal_storage.enqueued_count(&TestQueue {}.key()).await?,
+            0
+        );
         assert_eq!(internal_storage.scheduled_count().await?, 1);
 
         let job = internal_storage
             .get_job(&returned_id)
             .await?
             .expect("job should exist");
-        assert_eq!(job.queue, TestQueue{}.key());
+        assert_eq!(job.queue, TestQueue {}.key());
 
         assert!(job.meta.scheduled_at >= before + delay);
         assert!(job.meta.scheduled_at <= after + delay);

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -1246,11 +1246,22 @@ impl StorageInternal {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Duration;
+    use crate as oxanus;
+    use rand::random;
     use serde::Serialize;
     use testresult::TestResult;
 
     use super::*;
     use crate::test_helper::{random_string, redis_pool};
+
+    #[derive(oxanus::Registry)]
+    #[allow(dead_code)]
+    struct ComponentRegistry(oxanus::ComponentRegistry<(), ()>);
+
+    #[derive(Serialize, oxanus::Queue)]
+    #[oxanus(key = "test")]
+    struct TestQueue;
 
     #[derive(Serialize)]
     struct TestJob {}
@@ -1672,6 +1683,97 @@ mod tests {
         assert_eq!(job.queue, queue);
         assert_eq!(job.job.name, "MyWorker");
         assert_eq!(job.job.args, serde_json::json!({"key": "value"}));
+        assert_eq!(job.meta.retries, 0);
+        assert!(job.meta.error.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_in_envelope() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        let now = chrono::Utc::now().timestamp_micros();
+        let id = uuid::Uuid::new_v4().to_string();
+        let envelope = JobEnvelope {
+            id: id.clone(),
+            queue: queue.clone(),
+            job: crate::job_envelope::JobData {
+                name: "MyWorker".to_string(),
+                args: serde_json::json!({"key": "value"}),
+            },
+            meta: crate::job_envelope::JobMeta {
+                id: id.clone(),
+                retries: 0,
+                unique: false,
+                on_conflict: None,
+                created_at: now,
+                scheduled_at: now,
+                started_at: None,
+                state: None,
+                resurrect: true,
+                error: None,
+                throttle_cost: None,
+            },
+        };
+        let delay_s = 1234;
+        let delay = chrono::Duration::seconds(delay_s).num_microseconds().unwrap();
+
+        let before = chrono::Utc::now().timestamp_micros();
+        let returned_id = storage.enqueue_in(envelope, delay_s as u64).await?;
+        let after = chrono::Utc::now().timestamp_micros();
+        assert_eq!(returned_id, id);
+        assert_eq!(storage.enqueued_count(&queue).await?, 1);
+
+        let job = storage.get_job(&id).await?.expect("job should exist");
+        assert_eq!(job.queue, queue);
+        assert_eq!(job.job.name, "MyWorker");
+        assert_eq!(job.job.args, serde_json::json!({"key": "value"}));
+
+        assert!(job.meta.scheduled_at >= (before + delay));
+        assert!(job.meta.scheduled_at <= (after + delay));
+        assert_eq!(job.meta.retries, 0);
+        assert!(job.meta.error.is_none());
+
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_envelope_new_scheduled() -> TestResult {
+        let queue = random_string();
+        let scheduled_at = chrono::Utc::now() + chrono::Duration::seconds(random::<i64>());
+
+        let envelope = JobEnvelope::new_scheduled(queue.clone(), TestJob {}, scheduled_at)?;
+
+        assert_eq!(envelope.meta.scheduled_at, scheduled_at.timestamp_micros());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_at_job_envelope() -> TestResult {
+        let storage = crate::Storage::builder().build_from_env()?;
+        let internal_storage = &storage.internal;
+        let queue = random_string();
+
+        let now = chrono::Utc::now().timestamp_micros();
+        let id = uuid::Uuid::new_v4().to_string();
+        let delay = random::<i64>();
+        let scheduled_at = chrono::Utc::now() + chrono::Duration::microseconds(delay);
+
+        let before = chrono::Utc::now().timestamp_micros();
+        let returned_id = storage.enqueue_at(TestQueue, TestJob{}, scheduled_at).await?;
+        let after = chrono::Utc::now().timestamp_micros();
+        assert_eq!(returned_id, id);
+        assert_eq!(internal_storage.enqueued_count(&queue).await?, 1);
+
+        let job = internal_storage.get_job(&id).await?.expect("job should exist");
+        assert_eq!(job.queue, queue);
+        assert_eq!(job.job.name, "MyWorker");
+        assert_eq!(job.job.args, serde_json::json!({"key": "value"}));
+
+        assert!(job.meta.scheduled_at >= before + delay);
+        assert!(job.meta.scheduled_at <= after + delay);
         assert_eq!(job.meta.retries, 0);
         assert!(job.meta.error.is_none());
 

--- a/oxanus/src/test_helper.rs
+++ b/oxanus/src/test_helper.rs
@@ -14,3 +14,11 @@ pub async fn redis_pool() -> Result<deadpool_redis::Pool, deadpool_redis::PoolEr
 
     Ok(pool)
 }
+
+pub fn storage() -> Result<crate::Storage, crate::OxanusError> {
+    dotenvy::from_filename(".env.test").ok();
+    let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL is not set");
+    crate::Storage::builder()
+        .namespace(random_string())
+        .build_from_redis_url(redis_url)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the scheduling API to rely on `JobEnvelope.meta.scheduled_at` rather than a separate timestamp parameter, which could affect when jobs are considered immediately enqueued vs. scheduled. Risk is contained to enqueue/scheduling paths and is covered by new tests.
> 
> **Overview**
> **Scheduling now persists and uses `scheduled_at` from the job envelope metadata.** `Storage::enqueue_at` builds envelopes via `JobEnvelope::new_scheduled(...)`, and `StorageInternal::enqueue_at` no longer accepts a separate `time` argument, instead reading `envelope.meta.scheduled_at` for both the “enqueue immediately vs schedule” decision and the Redis ZSET score.
> 
> Adds helpers (`JobEnvelope::new_scheduled`, `JobEnvelope::with_scheduled_at`) and new tests in `storage.rs`/`storage_internal.rs` plus a small `test_helper::storage()` builder to validate that scheduled jobs are stored with the correct `meta.scheduled_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef8654dd976723180187b16fdf79d91d174aab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->