### PR TITLE
Run CI on pull requests, including from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- The workflow trigger was `on: push`, which doesn't fire for PRs from forked repos. Pushes happen on the fork, not here, so CI never started for fork PRs (e.g. #56).
- Add `pull_request` trigger so CI runs on every PR, including from forks.
- Restrict `push` to `main` only, to avoid duplicate runs on local feature branches (the PR run already covers them).

## Notes
- Secrets are not exposed to `pull_request` runs from forks by default — safe for fork PRs.
- The `cargo publish` step is already gated on `github.ref == 'refs/heads/main'`, so it stays push-only in practice.
- After merging this, existing open PRs from forks need a new push (or close+reopen) to trigger the new workflow.

## Test plan
- [ ] Merge to main
- [ ] Reopen or push to PR #56 and verify CI runs against the fork
- [ ] Verify a normal in-repo PR still gets exactly one CI run (not two)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that expands CI coverage to PRs (including forks) and reduces duplicate runs by limiting push triggers to `main`.
> 
> **Overview**
> Updates the `Test` GitHub Actions workflow triggers to run on `pull_request` events (so CI runs for fork PRs) and to run on `push` only for the `main` branch to avoid duplicate CI runs on feature-branch pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4057d7ba1b8a7adb1fbdf1a8647eccf5b52ca7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->