### PR TITLE
Bump oxanus version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0]
+
+### Added
+
+- Scheduled jobs example
+
+### Changed
+
+- Update dependencies, including `deadpool-redis` to 0.23, and adjust Redis connection response timeout handling for blocking commands
+
+### Fixed
+
+- Store `scheduled_at` in job metadata when scheduling jobs with `enqueue_at`
+
 ## [1.0.5]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.0.5"
+version = "1.1.0"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump the `oxanus` crate version from `1.0.5` to `1.1.0`.
- Add the `1.1.0` changelog entry while preserving the existing `1.0.5` notes.

## Test plan
- `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and a changelog entry, with no code or behavior changes in this diff.
> 
> **Overview**
> Bumps the `oxanus` crate version from `1.0.5` to `1.1.0` (including `Cargo.lock`).
> 
> Adds a `1.1.0` changelog entry documenting a scheduled-jobs example, dependency updates (notably `deadpool-redis` 0.23), and an `enqueue_at` metadata fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a434651166d72756457d32e60b4ca51ad2c7448e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->