### PR TITLE
Bump oxanus to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1]
+
+### Fixed
+
+- Clamp scheduled jobs to the current time when a past timestamp is provided.
+
 ## [1.1.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary

- Bump the `oxanus` crate from `1.1.0` to `1.1.1`.
- Update `Cargo.lock` for the crate version change.
- Add the `1.1.1` changelog entry for clamping scheduled jobs to the current time when a past timestamp is provided.

## Test plan

- `git diff --check`
- `cargo check --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure release bookkeeping (version/changelog/lockfile) with no functional code changes included in this PR.
> 
> **Overview**
> Bumps the `oxanus` crate version from `1.1.0` to `1.1.1` (including `Cargo.lock`).
> 
> Adds a `CHANGELOG.md` entry documenting a fix to clamp scheduled jobs to the current time when given a past timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c479e0e4ae59588e4099bdf7f4a6a0e5979126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->