### PR TITLE
Move enqueue metadata to job derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `#[derive(oxanus::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
+
 ### Changed
 
 - Replace runtime Redis `KEYS` calls with cursor-based `SCAN` for queue discovery and orphaned processing queue recovery.
+- Move job-specific derive attributes (`unique_id`, `on_conflict`, `resurrect`, and `throttle_cost`) from `#[derive(oxanus::Worker)]` to `#[derive(oxanus::Job)]`; `Self::...` in job hooks now resolves to the job type.
 
 ## [1.1.1]
 

--- a/oxanus-macros/src/job.rs
+++ b/oxanus-macros/src/job.rs
@@ -1,0 +1,267 @@
+use darling::{Error, FromDeriveInput, FromMeta};
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Expr, Ident, LitStr, Meta, Path, Token, punctuated::Punctuated};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(oxanus), supports(struct_any))]
+struct OxanusJobArgs {
+    worker: Option<Path>,
+    unique_id: Option<UniqueIdSpec>,
+    on_conflict: Option<Ident>,
+    resurrect: Option<bool>,
+    throttle_cost: Option<ThrottleCost>,
+}
+
+#[derive(Debug)]
+enum UniqueIdSpec {
+    /// #[unique_id = "job_{id}"]
+    Shorthand(LitStr),
+
+    /// #[unique_id(fmt = "...", name = expr, ...)]
+    NamedFormatter {
+        fmt: LitStr,
+        args: Vec<(syn::Ident, Expr)>,
+    },
+
+    /// #[unique_id = Self::unique_id]
+    CustomFunc(Path),
+}
+
+#[derive(Debug)]
+enum ThrottleCost {
+    /// #[throttle_cost = 2]
+    Value(u64),
+    /// #[throttle_cost = Self::throttle_cost]
+    CustomFunc(Path),
+}
+
+impl FromMeta for UniqueIdSpec {
+    fn from_meta(meta: &Meta) -> darling::Result<Self> {
+        match meta {
+            Meta::NameValue(nv) => match &nv.value {
+                Expr::Lit(expr_lit) => {
+                    if let syn::Lit::Str(s) = &expr_lit.lit {
+                        Ok(UniqueIdSpec::Shorthand(s.clone()))
+                    } else {
+                        Err(Error::custom("unique_id must be a string literal"))
+                    }
+                }
+                Expr::Path(expr_path) => Ok(UniqueIdSpec::CustomFunc(expr_path.path.clone())),
+                _ => Err(Error::custom("Expected string literal or type path.")),
+            },
+            Meta::List(list) => {
+                let mut fmt = None;
+                let mut args = Vec::new();
+
+                let metas =
+                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+
+                for meta in metas {
+                    match meta {
+                        Meta::NameValue(nv) if nv.path.is_ident("fmt") => {
+                            #[allow(clippy::collapsible_if)] // requires 1.88
+                            if let syn::Expr::Lit(expr_lit) = nv.value {
+                                if let syn::Lit::Str(s) = expr_lit.lit {
+                                    fmt = Some(s);
+                                    continue;
+                                }
+                            }
+                            return Err(Error::custom("fmt must be a string literal"));
+                        }
+
+                        Meta::NameValue(nv) => {
+                            let ident = nv
+                                .path
+                                .get_ident()
+                                .ok_or_else(|| Error::custom("expected identifier"))?
+                                .clone();
+                            args.push((ident, nv.value));
+                        }
+
+                        _ => return Err(Error::custom("Unsupported unique_id syntax")),
+                    }
+                }
+
+                let fmt = fmt.ok_or_else(|| Error::custom("missing fmt = \"...\""))?;
+                Ok(UniqueIdSpec::NamedFormatter { fmt, args })
+            }
+            _ => Err(Error::custom("Invalid unique_id attribute")),
+        }
+    }
+}
+
+impl FromMeta for ThrottleCost {
+    fn from_meta(meta: &Meta) -> darling::Result<Self> {
+        match meta {
+            Meta::NameValue(nv) => match &nv.value {
+                Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Int(lit),
+                    ..
+                }) => {
+                    let value = lit.base10_parse::<u64>()?;
+                    Ok(Self::Value(value))
+                }
+                Expr::Path(expr_path) => Ok(Self::CustomFunc(expr_path.path.clone())),
+                other => Err(Error::custom(format!(
+                    "Unsupported throttle_cost value: {other:?}",
+                ))),
+            },
+            _ => Err(Error::custom(
+                "throttle_cost must be a name-value attribute",
+            )),
+        }
+    }
+}
+
+pub fn expand_derive_job(input: DeriveInput) -> TokenStream {
+    let args = match OxanusJobArgs::from_derive_input(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            abort!(input.ident, "{}", e);
+        }
+    };
+
+    let struct_ident = &input.ident;
+    let worker = match &args.worker {
+        Some(worker) => quote!(#worker),
+        None => {
+            let name = struct_ident.to_string();
+            let base = name.strip_suffix("Job").unwrap_or(&name);
+            let worker_ident = Ident::new(&format!("{base}Worker"), struct_ident.span());
+            quote!(#worker_ident)
+        }
+    };
+
+    let unique_id = match &args.unique_id {
+        Some(unique_id) => expand_unique_id(unique_id),
+        None => quote!(),
+    };
+
+    let on_conflict = match &args.on_conflict {
+        Some(on_conflict) => quote! {
+            fn on_conflict(&self) -> oxanus::JobConflictStrategy {
+                oxanus::JobConflictStrategy::#on_conflict
+            }
+        },
+        None => quote!(),
+    };
+
+    let resurrect = match args.resurrect {
+        Some(value) => quote! {
+            fn should_resurrect() -> bool
+            where
+                Self: Sized,
+            {
+                #value
+            }
+        },
+        None => quote!(),
+    };
+
+    let throttle_cost = match &args.throttle_cost {
+        Some(throttle_cost) => expand_throttle_cost(throttle_cost),
+        None => quote!(),
+    };
+
+    quote! {
+        #[automatically_derived]
+        impl oxanus::Job for #struct_ident {
+            fn worker_name() -> &'static str
+            where
+                Self: Sized,
+            {
+                std::any::type_name::<#worker>()
+            }
+
+            #unique_id
+
+            #on_conflict
+
+            #resurrect
+
+            #throttle_cost
+        }
+    }
+}
+
+fn extract_format_placeholders(fmt_str: &str) -> Vec<syn::Ident> {
+    let mut seen = std::collections::HashSet::new();
+    let mut result = Vec::new();
+    let mut chars = fmt_str.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            let mut name = String::new();
+            for inner in chars.by_ref() {
+                if inner == '}' {
+                    break;
+                }
+                name.push(inner);
+            }
+            if !name.is_empty()
+                && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+                && !name.starts_with(|c: char| c.is_ascii_digit())
+                && seen.insert(name.clone())
+            {
+                result.push(syn::Ident::new(&name, proc_macro2::Span::call_site()));
+            }
+        }
+    }
+    result
+}
+
+fn expand_unique_id(spec: &UniqueIdSpec) -> TokenStream {
+    let formatter = match spec {
+        UniqueIdSpec::Shorthand(fmt) => {
+            let fmt_str = fmt.value();
+            let placeholders = extract_format_placeholders(&fmt_str);
+            let args = placeholders.iter().map(|name| quote!(#name = self.#name));
+
+            quote! {
+                Some(format!(
+                    #fmt,
+                    #(#args),*
+                ))
+            }
+        }
+
+        UniqueIdSpec::NamedFormatter { fmt, args } => {
+            let args = args.iter().map(|(name, expr)| quote!(#name = #expr));
+
+            quote! {
+                Some(format!(
+                    #fmt,
+                    #(#args),*
+                ))
+            }
+        }
+
+        UniqueIdSpec::CustomFunc(func) => quote!(#func(self)),
+    };
+
+    quote! {
+        fn unique_id(&self) -> Option<String> {
+            #formatter
+        }
+    }
+}
+
+fn expand_throttle_cost(throttle_cost: &ThrottleCost) -> TokenStream {
+    match throttle_cost {
+        ThrottleCost::Value(value) => {
+            quote! {
+                fn throttle_cost(&self) -> Option<u64> {
+                    Some(#value)
+                }
+            }
+        }
+        ThrottleCost::CustomFunc(func) => {
+            quote! {
+                fn throttle_cost(&self) -> Option<u64> {
+                    #func(self)
+                }
+            }
+        }
+    }
+}

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -1,7 +1,9 @@
+mod job;
 mod queue;
 mod registry;
 mod worker;
 
+use job::*;
 use queue::*;
 use registry::*;
 use worker::*;
@@ -28,16 +30,43 @@ pub fn derive_queue(input: TokenStream) -> TokenStream {
     expand_derive_queue(input).into()
 }
 
+/// Generates impl for `oxanus::Job`.
+///
+/// Example usage:
+/// ```ignore
+/// #[derive(Serialize, oxanus::Job)]
+/// #[oxanus(on_conflict = Replace)]
+/// #[oxanus(unique_id = "foo_{id}")]
+/// #[oxanus(throttle_cost = Self::throttle_cost)]
+/// struct TestJob {
+///     id: i32,
+///     cost: u64,
+/// }
+///
+/// impl TestJob {
+///     fn throttle_cost(&self) -> Option<u64> {
+///         Some(self.cost)
+///     }
+/// }
+///
+/// #[derive(oxanus::Worker)]
+/// struct TestWorker;
+/// ```
+#[proc_macro_error]
+#[proc_macro_derive(Job, attributes(oxanus))]
+pub fn derive_job(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_job(input).into()
+}
+
 /// Generates impl for `oxanus::Worker`.
 ///
 /// Example usage:
 /// ```ignore
-/// #[derive(Serialize, oxanus::Worker)]
-/// #[oxanus(max_retries = 3, on_conflict = Replace)]
-/// #[oxanus(unique_id = "test_worker_{id}")]
-/// struct TestWorkerUniqueId {
-///     id: i32,
-/// }
+/// #[derive(oxanus::Worker)]
+/// #[oxanus(max_retries = 3)]
+/// struct TestWorkerUniqueId;
 /// ```
 #[proc_macro_error]
 #[proc_macro_derive(Worker, attributes(oxanus))]

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -2,9 +2,7 @@ use darling::{Error, FromDeriveInput, FromMeta};
 use proc_macro_error2::{abort, emit_error};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{
-    Data, DeriveInput, Expr, Fields, Ident, LitStr, Meta, Path, Token, punctuated::Punctuated,
-};
+use syn::{Data, DeriveInput, Expr, Fields, Ident, Meta, Path};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(oxanus), supports(struct_any))]
@@ -15,26 +13,7 @@ struct OxanusArgs {
     registry: Option<Path>,
     max_retries: Option<MaxRetries>,
     retry_delay: Option<RetryDelay>,
-    unique_id: Option<UniqueIdSpec>,
-    on_conflict: Option<Ident>,
     cron: Option<Cron>,
-    resurrect: Option<bool>,
-    throttle_cost: Option<ThrottleCost>,
-}
-
-#[derive(Debug)]
-enum UniqueIdSpec {
-    /// #[unique_id = "job_{id}"]
-    Shorthand(LitStr),
-
-    /// #[unique_id(fmt = "...", name = expr, ...)]
-    NamedFormatter {
-        fmt: LitStr,
-        args: Vec<(syn::Ident, Expr)>,
-    },
-
-    /// #[unique_id = mymod::func]
-    CustomFunc(Path),
 }
 
 #[derive(Debug)]
@@ -50,14 +29,6 @@ enum RetryDelay {
     /// #[retry_delay = 3]
     Value(u64),
     /// #[retry_delay = mymod::func]
-    CustomFunc(Path),
-}
-
-#[derive(Debug)]
-enum ThrottleCost {
-    /// #[throttle_cost = 2]
-    Value(u64),
-    /// #[throttle_cost = Self::throttle_cost]
     CustomFunc(Path),
 }
 
@@ -98,87 +69,6 @@ macro_rules! impl_from_meta_for_num_or_path {
 
 impl_from_meta_for_num_or_path!(MaxRetries, u32, "max_retries");
 impl_from_meta_for_num_or_path!(RetryDelay, u64, "retry_delay");
-impl_from_meta_for_num_or_path!(ThrottleCost, u64, "throttle_cost");
-
-impl FromMeta for UniqueIdSpec {
-    fn from_meta(meta: &Meta) -> darling::Result<Self> {
-        match meta {
-            Meta::NameValue(nv) => match &nv.value {
-                Expr::Lit(expr_lit) => {
-                    if let syn::Lit::Str(s) = &expr_lit.lit {
-                        Ok(UniqueIdSpec::Shorthand(s.clone()))
-                    } else {
-                        Err(Error::custom("unique_id must be a string literal"))
-                    }
-                }
-                Expr::Path(expr_path) => Ok(UniqueIdSpec::CustomFunc(expr_path.path.clone())),
-                _ => Err(Error::custom("Expected string literal or type path.")),
-            },
-            Meta::List(list) => {
-                let mut fmt = None;
-                let mut args = Vec::new();
-
-                let metas =
-                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
-
-                for meta in metas {
-                    match meta {
-                        Meta::NameValue(nv) if nv.path.is_ident("fmt") => {
-                            #[allow(clippy::collapsible_if)] // requires 1.88
-                            if let syn::Expr::Lit(expr_lit) = nv.value {
-                                if let syn::Lit::Str(s) = expr_lit.lit {
-                                    fmt = Some(s);
-                                    continue;
-                                }
-                            }
-                            return Err(Error::custom("fmt must be a string literal"));
-                        }
-
-                        Meta::NameValue(nv) => {
-                            let ident = nv
-                                .path
-                                .get_ident()
-                                .ok_or_else(|| Error::custom("expected identifier"))?
-                                .clone();
-                            args.push((ident, nv.value));
-                        }
-
-                        _ => return Err(Error::custom("Unsupported unique_id syntax")),
-                    }
-                }
-
-                let fmt = fmt.ok_or_else(|| Error::custom("missing fmt = \"...\""))?;
-                Ok(UniqueIdSpec::NamedFormatter { fmt, args })
-            }
-            _ => Err(Error::custom("Invalid unique_id attribute")),
-        }
-    }
-}
-
-fn extract_format_placeholders(fmt_str: &str) -> Vec<syn::Ident> {
-    let mut seen = std::collections::HashSet::new();
-    let mut result = Vec::new();
-    let mut chars = fmt_str.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '{' {
-            let mut name = String::new();
-            for inner in chars.by_ref() {
-                if inner == '}' {
-                    break;
-                }
-                name.push(inner);
-            }
-            if !name.is_empty()
-                && name.chars().all(|c| c.is_alphanumeric() || c == '_')
-                && !name.starts_with(|c: char| c.is_ascii_digit())
-                && seen.insert(name.clone())
-            {
-                result.push(syn::Ident::new(&name, proc_macro2::Span::call_site()));
-            }
-        }
-    }
-    result
-}
 
 pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
     let args = match OxanusArgs::from_derive_input(&input) {
@@ -211,14 +101,12 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
     };
 
     let worker_impl = expand_worker_impl(struct_ident, &type_args, &type_error, &args);
-    let job_impl = expand_job_impl(struct_ident, &type_args, &args);
     let from_context_impl = expand_from_context_impl(struct_ident, &type_context, &input);
     let registry_impl =
         expand_registry(struct_ident, &type_args, &type_context, &type_error, &args);
 
     quote! {
         #worker_impl
-        #job_impl
         #from_context_impl
         #registry_impl
     }
@@ -260,53 +148,6 @@ fn expand_worker_impl(
             #retry_delay
 
             #cron
-        }
-    }
-}
-
-fn expand_job_impl(
-    struct_ident: &Ident,
-    type_args: &TokenStream,
-    args: &OxanusArgs,
-) -> TokenStream {
-    let unique_id = match &args.unique_id {
-        Some(unique_id) => expand_unique_id(unique_id),
-        None => quote!(),
-    };
-
-    let on_conflict = match &args.on_conflict {
-        Some(on_conflict) => quote! {
-            fn on_conflict(&self) -> oxanus::JobConflictStrategy {
-                oxanus::JobConflictStrategy::#on_conflict
-            }
-        },
-        None => quote!(),
-    };
-
-    let resurrect = expand_resurrect(args.resurrect);
-
-    let throttle_cost = match &args.throttle_cost {
-        Some(throttle_cost) => expand_throttle_cost(throttle_cost),
-        None => quote!(),
-    };
-
-    quote! {
-        #[automatically_derived]
-        impl oxanus::Job for #type_args {
-            fn worker_name() -> &'static str
-            where
-                Self: Sized,
-            {
-                std::any::type_name::<#struct_ident>()
-            }
-
-            #unique_id
-
-            #on_conflict
-
-            #resurrect
-
-            #throttle_cost
         }
     }
 }
@@ -391,20 +232,6 @@ fn expand_registry(
     }
 }
 
-fn expand_resurrect(resurrect: Option<bool>) -> TokenStream {
-    match resurrect {
-        Some(value) => quote! {
-            fn should_resurrect() -> bool
-            where
-                Self: Sized,
-            {
-                #value
-            }
-        },
-        None => quote!(),
-    }
-}
-
 fn expand_max_retries(max_retries: &MaxRetries, type_args: &TokenStream) -> TokenStream {
     match max_retries {
         MaxRetries::Value(value) => {
@@ -437,61 +264,6 @@ fn expand_retry_delay(retry_delay: &RetryDelay, type_args: &TokenStream) -> Toke
             quote! {
                 fn retry_delay(&self, job: &#type_args, retries: u32) -> u64 {
                     #func(self, job, retries)
-                }
-            }
-        }
-    }
-}
-
-fn expand_unique_id(spec: &UniqueIdSpec) -> TokenStream {
-    let formatter = match spec {
-        UniqueIdSpec::Shorthand(fmt) => {
-            let fmt_str = fmt.value();
-            let placeholders = extract_format_placeholders(&fmt_str);
-            let args = placeholders.iter().map(|name| quote!(#name = self.#name));
-
-            quote! {
-                Some(format!(
-                    #fmt,
-                    #(#args),*
-                ))
-            }
-        }
-
-        UniqueIdSpec::NamedFormatter { fmt, args } => {
-            let args = args.iter().map(|(name, expr)| quote!(#name = #expr));
-
-            quote! {
-                Some(format!(
-                    #fmt,
-                    #(#args),*
-                ))
-            }
-        }
-
-        UniqueIdSpec::CustomFunc(func) => quote!(#func(self)),
-    };
-
-    quote! {
-        fn unique_id(&self) -> Option<String> {
-            #formatter
-        }
-    }
-}
-
-fn expand_throttle_cost(throttle_cost: &ThrottleCost) -> TokenStream {
-    match throttle_cost {
-        ThrottleCost::Value(value) => {
-            quote! {
-                fn throttle_cost(&self) -> Option<u64> {
-                    Some(#value)
-                }
-            }
-        }
-        ThrottleCost::CustomFunc(func) => {
-            quote! {
-                fn throttle_cost(&self) -> Option<u64> {
-                    #func(self)
                 }
             }
         }

--- a/oxanus-web/examples/web.rs
+++ b/oxanus-web/examples/web.rs
@@ -11,7 +11,7 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 struct PingJob {
     target: String,
 }

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -49,7 +49,7 @@ enum MyError {}
 #[derive(Debug, Clone)]
 struct MyContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 struct MyJob {
     data: String,
 }
@@ -117,17 +117,21 @@ It also provides management actions for wiping queues and deleting individual jo
 
 ## Core Concepts
 
-### Workers
+### Jobs and Workers
 
-Workers define the processing logic for jobs. Use the `#[derive(oxanus::Worker)]` macro or implement the `Worker` trait manually.
+Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers define the processing logic for jobs. Use the `#[derive(oxanus::Job)]` and `#[derive(oxanus::Worker)]` macros or implement the traits manually.
 
-Worker attributes:
+| `Job` attributes (enqueue-time) | `Worker` attributes (execution-time) |
+| --- | --- |
+| `#[oxanus(worker = MyWorker)]` - override inferred `FooJob` -> `FooWorker` binding | `#[oxanus(job = MyJob)]` - override inferred `FooWorker` -> `FooJob` binding |
+| `#[oxanus(unique_id = "worker_{id}")]` - define unique job identifiers | `#[oxanus(context = MyContext)]` - set worker context type |
+| `#[oxanus(on_conflict = Skip)]` - handle unique job conflicts (Skip or Replace) | `#[oxanus(error = MyError)]` - set worker error type |
+| `#[oxanus(resurrect = false)]` - disable crash resurrection for this job type | `#[oxanus(registry = MyRegistry)]` - choose component registry |
+| `#[oxanus(throttle_cost = 2)]` - set per-job throttle cost | `#[oxanus(max_retries = 3)]` - set maximum retry attempts |
+|  | `#[oxanus(retry_delay = 5)]` - set retry delay in seconds |
+|  | `#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
 
-- `#[oxanus(max_retries = 3)]` - Set maximum retry attempts
-- `#[oxanus(retry_delay = 5)]` - Set retry delay in seconds
-- `#[oxanus(unique_id = "worker_{id}")]` - Define unique job identifiers
-- `#[oxanus(on_conflict = Skip)]` - Handle job conflicts (Skip or Replace)
-- `#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - Schedule periodic jobs
+For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::...` resolves to the worker type.
 
 ### Queues
 

--- a/oxanus/examples/cron.rs
+++ b/oxanus/examples/cron.rs
@@ -10,12 +10,12 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(resurrect = false)]
 struct TestJob {}
 
 #[derive(oxanus::Worker)]
 #[oxanus(context = WorkerContext)]
-#[oxanus(resurrect = false)]
 #[oxanus(cron(schedule = "*/5 * * * * *", queue = QueueOne))]
 struct TestWorker;
 

--- a/oxanus/examples/cron_multiple.rs
+++ b/oxanus/examples/cron_multiple.rs
@@ -10,12 +10,12 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(resurrect = false)]
 struct TickJob {}
 
 #[derive(oxanus::Worker)]
 #[oxanus(context = WorkerContext)]
-#[oxanus(resurrect = false)]
 #[oxanus(cron(schedule = "* * * * * *", queue = QueueOne))]
 struct TickWorker;
 

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -11,7 +11,7 @@ enum WorkerError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 struct TestJob {}
 
 #[derive(oxanus::Worker)]

--- a/oxanus/examples/dynamic.rs
+++ b/oxanus/examples/dynamic.rs
@@ -10,16 +10,16 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Worker2SecJob {}
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct TwoSecJob {}
 
 #[derive(oxanus::Worker)]
-struct Worker2Sec;
+struct TwoSecWorker;
 
-impl Worker2Sec {
+impl TwoSecWorker {
     async fn process(
         &self,
-        _job: &Worker2SecJob,
+        _job: &TwoSecJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -50,19 +50,19 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(5);
 
     storage
-        .enqueue(QueueDynamic(Animal::Cat, 2), Worker2SecJob {})
+        .enqueue(QueueDynamic(Animal::Cat, 2), TwoSecJob {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Dog, 1), Worker2SecJob {})
+        .enqueue(QueueDynamic(Animal::Dog, 1), TwoSecJob {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Cat, 2), Worker2SecJob {})
+        .enqueue(QueueDynamic(Animal::Cat, 2), TwoSecJob {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Bird, 1), Worker2SecJob {})
+        .enqueue(QueueDynamic(Animal::Bird, 1), TwoSecJob {})
         .await?;
     storage
-        .enqueue(QueueDynamic(Animal::Dog, 1), Worker2SecJob {})
+        .enqueue(QueueDynamic(Animal::Dog, 1), TwoSecJob {})
         .await?;
 
     oxanus::run(config, ctx).await?;

--- a/oxanus/examples/foo.rs
+++ b/oxanus/examples/foo.rs
@@ -10,19 +10,19 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Worker1SecJob {
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct OneSecJob {
     id: usize,
     payload: String,
 }
 
 #[derive(oxanus::Worker)]
-struct Worker1Sec;
+struct OneSecWorker;
 
-impl Worker1Sec {
+impl OneSecWorker {
     async fn process(
         &self,
-        _job: &Worker1SecJob,
+        _job: &OneSecJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -30,19 +30,19 @@ impl Worker1Sec {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Worker2SecJob {
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct TwoSecJob {
     id: usize,
     foo: i32,
 }
 
 #[derive(oxanus::Worker)]
-struct Worker2Sec;
+struct TwoSecWorker;
 
-impl Worker2Sec {
+impl TwoSecWorker {
     async fn process(
         &self,
-        _job: &Worker2SecJob,
+        _job: &TwoSecJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
@@ -50,32 +50,32 @@ impl Worker2Sec {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkerInstantJob {}
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct InstantJob {}
 
 #[derive(oxanus::Worker)]
-struct WorkerInstant;
+struct InstantWorker;
 
-impl WorkerInstant {
+impl InstantWorker {
     async fn process(
         &self,
-        _job: &WorkerInstantJob,
+        _job: &InstantJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkerInstant2Job {}
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct Instant2Job {}
 
 #[derive(oxanus::Worker)]
-struct WorkerInstant2;
+struct Instant2Worker;
 
-impl WorkerInstant2 {
+impl Instant2Worker {
     async fn process(
         &self,
-        _job: &WorkerInstant2Job,
+        _job: &Instant2Job,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
@@ -116,31 +116,31 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     storage
         .enqueue(
             QueueOne,
-            Worker1SecJob {
+            OneSecJob {
                 id: 1,
                 payload: "test".to_string(),
             },
         )
         .await?;
     storage
-        .enqueue(QueueTwo(Animal::Dog, 1), Worker2SecJob { id: 2, foo: 42 })
+        .enqueue(QueueTwo(Animal::Dog, 1), TwoSecJob { id: 2, foo: 42 })
         .await?;
     storage
         .enqueue(
             QueueOne,
-            Worker1SecJob {
+            OneSecJob {
                 id: 3,
                 payload: "test".to_string(),
             },
         )
         .await?;
     storage
-        .enqueue(QueueTwo(Animal::Cat, 2), Worker2SecJob { id: 4, foo: 44 })
+        .enqueue(QueueTwo(Animal::Cat, 2), TwoSecJob { id: 4, foo: 44 })
         .await?;
     storage
         .enqueue_in(
             QueueOne,
-            Worker1SecJob {
+            OneSecJob {
                 id: 4,
                 payload: "test".to_string(),
             },
@@ -148,28 +148,16 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
         )
         .await?;
     storage
-        .enqueue_in(
-            QueueTwo(Animal::Bird, 7),
-            Worker2SecJob { id: 5, foo: 44 },
-            6,
-        )
+        .enqueue_in(QueueTwo(Animal::Bird, 7), TwoSecJob { id: 5, foo: 44 }, 6)
         .await?;
     storage
-        .enqueue_in(
-            QueueTwo(Animal::Bird, 7),
-            Worker2SecJob { id: 5, foo: 44 },
-            15,
-        )
+        .enqueue_in(QueueTwo(Animal::Bird, 7), TwoSecJob { id: 5, foo: 44 }, 15)
         .await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage
-        .enqueue(QueueThrottled, WorkerInstant2Job {})
-        .await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage
-        .enqueue(QueueThrottled, WorkerInstant2Job {})
-        .await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, Instant2Job {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, Instant2Job {}).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/minimal.rs
+++ b/oxanus/examples/minimal.rs
@@ -10,7 +10,7 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 struct TestJob {
     sleep_s: u64,
 }

--- a/oxanus/examples/resumable.rs
+++ b/oxanus/examples/resumable.rs
@@ -15,7 +15,7 @@ enum WorkerError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 struct ResumableTestJob {}
 
 #[derive(oxanus::Worker)]

--- a/oxanus/examples/scheduled.rs
+++ b/oxanus/examples/scheduled.rs
@@ -11,13 +11,13 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(resurrect = false)]
 struct TestJob {
     label: String,
 }
 
 #[derive(oxanus::Worker)]
-#[oxanus(resurrect = false)]
 struct TestWorker;
 
 impl TestWorker {

--- a/oxanus/examples/throttled.rs
+++ b/oxanus/examples/throttled.rs
@@ -10,33 +10,33 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkerInstantJob {}
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct InstantJob {}
 
 #[derive(oxanus::Worker)]
-struct WorkerInstant;
+struct InstantWorker;
 
-impl WorkerInstant {
+impl InstantWorker {
     async fn process(
         &self,
-        _job: &WorkerInstantJob,
+        _job: &InstantJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkerInstant2Job {}
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(throttle_cost = 2)]
+struct Instant2Job {}
 
 #[derive(oxanus::Worker)]
-#[oxanus(throttle_cost = 2)]
-struct WorkerInstant2;
+struct Instant2Worker;
 
-impl WorkerInstant2 {
+impl Instant2Worker {
     async fn process(
         &self,
-        _job: &WorkerInstant2Job,
+        _job: &Instant2Job,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
@@ -59,18 +59,14 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(8);
 
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage
-        .enqueue(QueueThrottled, WorkerInstant2Job {})
-        .await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage
-        .enqueue(QueueThrottled, WorkerInstant2Job {})
-        .await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
-    storage.enqueue(QueueThrottled, WorkerInstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, Instant2Job {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, Instant2Job {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
+    storage.enqueue(QueueThrottled, InstantJob {}).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/examples/unique.rs
+++ b/oxanus/examples/unique.rs
@@ -10,19 +10,19 @@ enum WorkerError {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Worker2SecJob {
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(unique_id = "worker2sec:{id}", on_conflict = Skip)]
+struct TwoSecJob {
     id: usize,
 }
 
 #[derive(oxanus::Worker)]
-#[oxanus(unique_id = "worker2sec:{id}", on_conflict = Skip)]
-struct Worker2Sec;
+struct TwoSecWorker;
 
-impl Worker2Sec {
+impl TwoSecWorker {
     async fn process(
         &self,
-        _job: &Worker2SecJob,
+        _job: &TwoSecJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
@@ -45,9 +45,9 @@ pub async fn main() -> Result<(), oxanus::OxanusError> {
     let storage = oxanus::Storage::builder().build_from_env()?;
     let config = ComponentRegistry::build_config(&storage);
 
-    storage.enqueue(QueueOne, Worker2SecJob { id: 1 }).await?;
-    storage.enqueue(QueueOne, Worker2SecJob { id: 1 }).await?;
-    storage.enqueue(QueueOne, Worker2SecJob { id: 2 }).await?;
+    storage.enqueue(QueueOne, TwoSecJob { id: 1 }).await?;
+    storage.enqueue(QueueOne, TwoSecJob { id: 1 }).await?;
+    storage.enqueue(QueueOne, TwoSecJob { id: 2 }).await?;
 
     oxanus::run(config, ctx).await?;
 

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -125,4 +125,4 @@ pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_factory};
 pub use registry::*;
 
 #[cfg(feature = "macros")]
-pub use oxanus_macros::{Queue, Registry, Worker};
+pub use oxanus_macros::{Job, Queue, Registry, Worker};

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -130,7 +130,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Job, JobConflictStrategy};
-    use crate as oxanus;
+    use crate::{self as oxanus, JobEnvelope};
     use serde::{Deserialize, Serialize};
     use std::io::Error as WorkerError;
 
@@ -147,11 +147,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_define_worker_with_macro() {
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         struct TestJob {}
 
         #[derive(oxanus::Worker)]
-
         struct TestWorker;
 
         impl TestWorker {
@@ -168,14 +167,15 @@ mod tests {
             oxanus::Worker::<TestJob>::max_retries(&TestWorker, &TestJob {}),
             2
         );
+        assert_eq!(TestJob::worker_name(), std::any::type_name::<TestWorker>());
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerCustomError, on_conflict = Replace)]
         struct TestWorkerCustomErrorJob {}
 
         #[derive(oxanus::Worker)]
         #[oxanus(error = std::fmt::Error, registry = ComponentRegistryFmt)]
         #[oxanus(max_retries = 3, retry_delay = 10)]
-        #[oxanus(on_conflict = Replace)]
         struct TestWorkerCustomError;
 
         impl TestWorkerCustomError {
@@ -210,14 +210,15 @@ mod tests {
             JobConflictStrategy::Replace
         );
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerUniqueId)]
+        #[oxanus(unique_id = "test_worker_{id}")]
         struct TestWorkerUniqueIdJob {
             id: i32,
             _1: i32,
         }
 
         #[derive(oxanus::Worker)]
-        #[oxanus(unique_id = "test_worker_{id}")]
         struct TestWorkerUniqueId;
 
         impl TestWorkerUniqueId {
@@ -251,14 +252,15 @@ mod tests {
             name: String,
         }
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerNestedUniqueId)]
+        #[oxanus(unique_id(fmt = "test_worker_{id}_{task}", id = self.id, task = self.task.name))]
         struct TestWorkerNestedUniqueIdJob {
             id: i32,
             task: NestedTask,
         }
 
         #[derive(oxanus::Worker)]
-        #[oxanus(unique_id(fmt = "test_worker_{id}_{task}", id = self.id, task = self.task.name))]
         struct TestWorkerNestedUniqueId;
 
         impl TestWorkerNestedUniqueId {
@@ -290,20 +292,27 @@ mod tests {
             Some("test_worker_2_task2".to_string())
         );
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerCustomUniqueId)]
+        #[oxanus(unique_id = Self::unique_id)]
+        #[oxanus(throttle_cost = Self::throttle_cost)]
         struct TestWorkerCustomUniqueIdJob {
             id: i32,
             task: NestedTask,
+            cost: u64,
         }
 
         impl TestWorkerCustomUniqueIdJob {
             fn unique_id(&self) -> Option<String> {
                 Some(format!("worker_id_{}_task_{}", self.id, self.task.name))
             }
+
+            fn throttle_cost(&self) -> Option<u64> {
+                Some(self.cost)
+            }
         }
 
         #[derive(oxanus::Worker)]
-        #[oxanus(unique_id = Self::unique_id)]
         #[oxanus(retry_delay = Self::retry_delay)]
         #[oxanus(max_retries = Self::max_retries)]
         struct TestWorkerCustomUniqueId;
@@ -331,7 +340,8 @@ mod tests {
                 id: 1,
                 task: NestedTask {
                     name: "11".to_owned(),
-                }
+                },
+                cost: 3,
             }),
             Some("worker_id_1_task_11".to_string())
         );
@@ -340,11 +350,13 @@ mod tests {
             task: NestedTask {
                 name: "22".to_owned(),
             },
+            cost: 5,
         };
         assert_eq!(
             oxanus::Job::unique_id(&job2),
             Some("worker_id_2_task_22".to_string())
         );
+        assert_eq!(oxanus::Job::throttle_cost(&job2), Some(5));
         let worker = TestWorkerCustomUniqueId;
         assert_eq!(
             oxanus::Worker::<TestWorkerCustomUniqueIdJob>::retry_delay(&worker, &job2, 1),
@@ -358,6 +370,63 @@ mod tests {
             oxanus::Worker::<TestWorkerCustomUniqueIdJob>::max_retries(&worker, &job2),
             9
         );
+        let envelope = JobEnvelope::new(
+            "default".to_owned(),
+            TestWorkerCustomUniqueIdJob {
+                id: 3,
+                task: NestedTask {
+                    name: "33".to_owned(),
+                },
+                cost: 7,
+            },
+        )
+        .expect("job-owned throttle_cost should populate the envelope");
+        assert_eq!(envelope.meta.throttle_cost, Some(7));
+
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerExplicitJobHooks)]
+        #[oxanus(unique_id = TestWorkerExplicitJobHooksJob::unique_id)]
+        #[oxanus(throttle_cost = TestWorkerExplicitJobHooksJob::throttle_cost)]
+        struct TestWorkerExplicitJobHooksJob {
+            id: i32,
+            cost: u64,
+        }
+
+        impl TestWorkerExplicitJobHooksJob {
+            fn unique_id(&self) -> Option<String> {
+                Some(format!("explicit_job_{}", self.id))
+            }
+
+            fn throttle_cost(&self) -> Option<u64> {
+                Some(self.cost)
+            }
+        }
+
+        #[derive(oxanus::Worker)]
+        struct TestWorkerExplicitJobHooks;
+
+        impl TestWorkerExplicitJobHooks {
+            async fn process(
+                &self,
+                _job: &TestWorkerExplicitJobHooksJob,
+                _ctx: &oxanus::JobContext,
+            ) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        let explicit_job = TestWorkerExplicitJobHooksJob { id: 4, cost: 9 };
+        assert_eq!(
+            oxanus::Job::unique_id(&explicit_job),
+            Some("explicit_job_4".to_string())
+        );
+        assert_eq!(oxanus::Job::throttle_cost(&explicit_job), Some(9));
+        let explicit_envelope = JobEnvelope::new(
+            "default".to_owned(),
+            TestWorkerExplicitJobHooksJob { id: 5, cost: 11 },
+        )
+        .expect("explicit job hook paths should still populate the envelope");
+        assert_eq!(explicit_envelope.meta.throttle_cost, Some(11));
     }
 
     #[tokio::test]
@@ -369,7 +438,7 @@ mod tests {
         #[derive(Serialize, oxanus::Queue)]
         struct DefaultQueue;
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         struct TestCronJob {}
 
         #[derive(oxanus::Worker)]
@@ -402,11 +471,11 @@ mod tests {
         use crate as oxanus;
         use std::io::Error as WorkerError;
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(resurrect = false)]
         struct NoResurrectJob {}
 
         #[derive(oxanus::Worker)]
-        #[oxanus(resurrect = false)]
         struct NoResurrectWorker;
 
         impl NoResurrectWorker {
@@ -421,11 +490,10 @@ mod tests {
 
         assert!(!<NoResurrectJob as oxanus::Job>::should_resurrect());
 
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         struct DefaultResurrectJob {}
 
         #[derive(oxanus::Worker)]
-
         struct DefaultResurrectWorker;
 
         impl DefaultResurrectWorker {

--- a/oxanus/tests/integration/registry.rs
+++ b/oxanus/tests/integration/registry.rs
@@ -10,7 +10,8 @@ struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
 #[oxanus(key = "two")]
 struct QueueTwo;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = WorkerCounter)]
 pub struct WorkerCounterJob {
     pub key: String,
 }
@@ -32,7 +33,8 @@ impl WorkerCounter {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = CronWorkerCounter)]
 pub struct CronWorkerCounterJob {}
 
 #[derive(oxanus::Worker)]


### PR DESCRIPTION
## Summary
- Add `#[derive(oxanus::Job)]` for enqueue-time job metadata.
- Move job-specific attributes (`unique_id`, `on_conflict`, `resurrect`, `throttle_cost`) from `Worker` derive to `Job` derive.
- Update examples and README docs to use the `FooJob` / `FooWorker` inference convention.
- Update the Unreleased changelog.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-features --workspace`
- `cargo test --workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `#[derive(oxanus::Job)]` proc-macro and changes where enqueue-time metadata is defined, which is a public API/macro surface area that can break downstream derives and subtle trait behavior.
> 
> **Overview**
> Adds a new `#[derive(oxanus::Job)]` proc-macro to define enqueue-time metadata on job structs (worker binding, `unique_id`, `on_conflict`, `resurrect`, and `throttle_cost`), including support for format-string and function-based hooks.
> 
> Removes job-metadata handling from `#[derive(oxanus::Worker)]`, updates the crate re-exports/docs/changelog accordingly, and migrates all examples/tests to derive `Job` on job types (with `Self::...` now resolving to the job type for job hooks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec1cb9ca4df6215c61a89b5ea189ffd7dc509f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->