### PR TITLE
Add batch workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0] - 2026-05-02
+## [Unreleased]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [2.0.0] - 2026-05-02
 
 ### Added
 
 - Add `#[derive(oxanus::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
+- Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
 
 ### Changed
 
 - Replace runtime Redis `KEYS` calls with cursor-based `SCAN` for queue discovery and orphaned processing queue recovery.
 - Move job-specific derive attributes (`unique_id`, `on_conflict`, `resurrect`, and `throttle_cost`) from `#[derive(oxanus::Worker)]` to `#[derive(oxanus::Job)]`; `Self::...` in job hooks now resolves to the job type.
+- Change worker execution to own job values and route all worker execution through the batched runtime path; job types no longer need `Sync`.
 
 ## [1.1.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1089,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1107,12 +1113,13 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
  "uuid",
 ]
 
 [[package]]
 name = "oxanus-macros"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "darling",
  "heck",
@@ -1124,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "askama",
  "askama_web",
@@ -1576,6 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1694,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1808,6 +1839,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +1965,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -2053,6 +2138,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxanus"
-version = "2.0.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-macros"
-version = "2.0.0"
+version = "1.0.1"
 dependencies = [
  "darling",
  "heck",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "oxanus-web"
-version = "2.0.0"
+version = "1.0.1"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxanus"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxanus = { version = "^2.0", path = "oxanus" }
-oxanus-macros = { version = "^2.0", path = "oxanus-macros" }
+oxanus = { version = "^1.0", path = "oxanus" }
+oxanus-macros = { version = "^1.0", path = "oxanus-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxanus"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxanus = { version = "^1.0", path = "oxanus" }
-oxanus-macros = { version = "^1.0", path = "oxanus-macros" }
+oxanus = { version = "^2.0", path = "oxanus" }
+oxanus-macros = { version = "^2.0", path = "oxanus-macros" }

--- a/oxanus-macros/Cargo.toml
+++ b/oxanus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-macros"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxanus."

--- a/oxanus-macros/Cargo.toml
+++ b/oxanus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-macros"
-version = "2.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxanus."

--- a/oxanus-macros/src/lib.rs
+++ b/oxanus-macros/src/lib.rs
@@ -66,6 +66,7 @@ pub fn derive_job(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(oxanus::Worker)]
 /// #[oxanus(max_retries = 3)]
+/// #[oxanus(batch_size = 10, batch_timeout_ms = 500)]
 /// struct TestWorkerUniqueId;
 /// ```
 #[proc_macro_error]

--- a/oxanus-macros/src/worker.rs
+++ b/oxanus-macros/src/worker.rs
@@ -13,6 +13,8 @@ struct OxanusArgs {
     registry: Option<Path>,
     max_retries: Option<MaxRetries>,
     retry_delay: Option<RetryDelay>,
+    batch_size: Option<usize>,
+    batch_timeout_ms: Option<u64>,
     cron: Option<Cron>,
 }
 
@@ -133,21 +135,40 @@ fn expand_worker_impl(
         None => quote!(),
     };
 
+    let batch_config = expand_batch_config(struct_ident, args);
+    let process = if batch_config.is_some() {
+        quote! {
+            async fn run_batch(&self, jobs: Vec<oxanus::BatchItem<#type_args>>) -> Result<(), Self::Error> {
+                self.process_batch(jobs).await
+            }
+        }
+    } else {
+        quote! {
+            async fn run_batch(&self, jobs: Vec<oxanus::BatchItem<#type_args>>) -> Result<(), Self::Error> {
+                for oxanus::BatchItem { job, ctx } in jobs {
+                    self.process(job, &ctx).await?;
+                }
+
+                Ok(())
+            }
+        }
+    };
+
     quote! {
         #[automatically_derived]
         #[async_trait::async_trait]
         impl oxanus::Worker<#type_args> for #struct_ident {
             type Error = #type_error;
 
-            async fn process(&self, job: &#type_args, ctx: &oxanus::JobContext) -> Result<(), Self::Error> {
-                self.process(job, ctx).await
-            }
+            #process
 
             #max_retries
 
             #retry_delay
 
             #cron
+
+            #batch_config
         }
     }
 }
@@ -221,6 +242,8 @@ fn expand_registry(
                         oxanus::ComponentDefinition::Worker(oxanus::WorkerConfig {
                             name: std::any::type_name::<#struct_ident>().to_owned(),
                             factory: oxanus::job_factory::<#struct_ident, #type_args, #type_context, #type_error>,
+                            batch_factory: oxanus::job_batch_factory::<#struct_ident, #type_args, #type_context, #type_error>,
+                            batch_config: <#struct_ident as oxanus::Worker<#type_args>>::batch_config(),
                             kind: <#struct_ident as oxanus::Worker<#type_args>>::to_config(),
                         })
                     }
@@ -267,6 +290,31 @@ fn expand_retry_delay(retry_delay: &RetryDelay, type_args: &TokenStream) -> Toke
                 }
             }
         }
+    }
+}
+
+fn expand_batch_config(struct_ident: &Ident, args: &OxanusArgs) -> Option<TokenStream> {
+    match (args.batch_size, args.batch_timeout_ms) {
+        (Some(size), Some(timeout_ms)) => {
+            if size == 0 {
+                abort!(struct_ident, "batch_size must be greater than zero");
+            }
+
+            Some(quote! {
+                fn batch_config() -> Option<oxanus::WorkerBatchConfig>
+                where
+                    Self: Sized,
+                {
+                    Some(oxanus::WorkerBatchConfig::new(
+                        #size,
+                        std::time::Duration::from_millis(#timeout_ms),
+                    ))
+                }
+            })
+        }
+        (None, None) => None,
+        (Some(_), None) => abort!(struct_ident, "batch_size requires batch_timeout_ms"),
+        (None, Some(_)) => abort!(struct_ident, "batch_timeout_ms requires batch_size"),
     }
 }
 

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "2.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus-web/Cargo.toml
+++ b/oxanus-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus-web"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxanus job queue system."

--- a/oxanus-web/examples/web.rs
+++ b/oxanus-web/examples/web.rs
@@ -20,7 +20,7 @@ struct PingJob {
 struct PingWorker;
 
 impl PingWorker {
-    async fn process(&self, _job: &PingJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, _job: PingJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         Ok(())
     }
 }

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "2.0.0"
+version = "1.1.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxanus/Cargo.toml
+++ b/oxanus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxanus"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."
@@ -47,6 +47,7 @@ dotenvy = "^0.15"
 rand = "^0.10"
 testresult = "^0.4"
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
+trybuild = "1.0"
 
 oxanus = { path = ".", default-features = false, features = ["registry"] }
 

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -58,7 +58,7 @@ struct MyJob {
 struct MyWorker;
 
 impl MyWorker {
-    async fn process(&self, job: &MyJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
+    async fn process(&self, job: MyJob, _ctx: &oxanus::JobContext) -> Result<(), MyError> {
         println!("Processing: {}", job.data);
         Ok(())
     }
@@ -130,6 +130,7 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 | `#[oxanus(throttle_cost = 2)]` - set per-job throttle cost | `#[oxanus(max_retries = 3)]` - set maximum retry attempts |
 |  | `#[oxanus(retry_delay = 5)]` - set retry delay in seconds |
 |  | `#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
+|  | `#[oxanus(batch_size = 100, batch_timeout_ms = 500)]` - process jobs in batches |
 
 For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::...` resolves to the worker type.
 

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -134,6 +134,8 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 
 For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::...` resolves to the worker type.
 
+Batch workers use all-or-nothing result semantics: if `process_batch` returns `Ok(())`, every job in the batch is marked successful; if it returns an error or panics, every job in that batch follows the normal retry or failure path. Batch handlers should therefore be idempotent, or should only commit external side effects after the whole batch is ready to succeed.
+
 ### Queues
 
 Queues are the channels through which jobs flow. Use the `#[derive(oxanus::Queue)]` macro or implement the `Queue` trait manually.

--- a/oxanus/benches/concurrency.rs
+++ b/oxanus/benches/concurrency.rs
@@ -37,12 +37,14 @@ impl oxanus::FromContext<WorkerState> for WorkerNoop {
 impl oxanus::Worker<WorkerNoopJob> for WorkerNoop {
     type Error = ServiceError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        job: &WorkerNoopJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<WorkerNoopJob>>,
     ) -> Result<(), ServiceError> {
-        tokio::time::sleep(std::time::Duration::from_millis(job.sleep_ms)).await;
+        for item in jobs {
+            let job = item.job;
+            tokio::time::sleep(std::time::Duration::from_millis(job.sleep_ms)).await;
+        }
         Ok(())
     }
 }

--- a/oxanus/benches/concurrency.rs
+++ b/oxanus/benches/concurrency.rs
@@ -19,6 +19,8 @@ pub enum ServiceError {
 #[derive(Debug, Clone)]
 pub struct WorkerState {}
 
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = ServiceError, registry = None)]
 pub struct WorkerNoop;
 
 impl oxanus::Job for WorkerNoopJob {
@@ -27,24 +29,13 @@ impl oxanus::Job for WorkerNoopJob {
     }
 }
 
-impl oxanus::FromContext<WorkerState> for WorkerNoop {
-    fn from_context(_ctx: &WorkerState) -> Self {
-        Self
-    }
-}
-
-#[async_trait::async_trait]
-impl oxanus::Worker<WorkerNoopJob> for WorkerNoop {
-    type Error = ServiceError;
-
-    async fn run_batch(
+impl WorkerNoop {
+    async fn process(
         &self,
-        jobs: Vec<oxanus::BatchItem<WorkerNoopJob>>,
+        job: WorkerNoopJob,
+        _ctx: &oxanus::JobContext,
     ) -> Result<(), ServiceError> {
-        for item in jobs {
-            let job = item.job;
-            tokio::time::sleep(std::time::Duration::from_millis(job.sleep_ms)).await;
-        }
+        tokio::time::sleep(std::time::Duration::from_millis(job.sleep_ms)).await;
         Ok(())
     }
 }

--- a/oxanus/examples/batch.rs
+++ b/oxanus/examples/batch.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct EmailJob {
+    to: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(batch_size = 4, batch_timeout_ms = 500)]
+struct EmailWorker;
+
+impl EmailWorker {
+    async fn process_batch(
+        &self,
+        jobs: Vec<oxanus::BatchItem<EmailJob>>,
+    ) -> Result<(), WorkerError> {
+        let recipients = jobs
+            .iter()
+            .map(|item| item.job.to.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("Sending {} emails in one batch: {recipients}", jobs.len());
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxanus::Queue)]
+#[oxanus(key = "email_batches", concurrency = 4)]
+struct EmailQueue;
+
+#[tokio::main]
+pub async fn main() -> Result<(), oxanus::OxanusError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let ctx = oxanus::ContextValue::new(WorkerContext {});
+    let storage = oxanus::Storage::builder().build_from_env()?;
+    let config = ComponentRegistry::build_config(&storage).exit_when_processed(10);
+
+    for i in 0..10 {
+        storage
+            .enqueue(
+                EmailQueue,
+                EmailJob {
+                    to: format!("user{i}@example.com"),
+                },
+            )
+            .await?;
+    }
+
+    oxanus::run(config, ctx).await?;
+
+    Ok(())
+}

--- a/oxanus/examples/cron.rs
+++ b/oxanus/examples/cron.rs
@@ -20,7 +20,7 @@ struct TestJob {}
 struct TestWorker;
 
 impl TestWorker {
-    async fn process(&self, _job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }

--- a/oxanus/examples/cron_multiple.rs
+++ b/oxanus/examples/cron_multiple.rs
@@ -20,7 +20,7 @@ struct TickJob {}
 struct TickWorker;
 
 impl TickWorker {
-    async fn process(&self, _job: &TickJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TickJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         println!("tick at {}", chrono::Utc::now().timestamp());
         Ok(())
     }

--- a/oxanus/examples/cron_w_err.rs
+++ b/oxanus/examples/cron_w_err.rs
@@ -21,7 +21,7 @@ struct TestJob {}
 struct TestWorker;
 
 impl TestWorker {
-    async fn process(&self, _job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         if rand::rng().random_bool(0.5) {
             Err(WorkerError::GenericError("foo".to_string()))
         } else {

--- a/oxanus/examples/dynamic.rs
+++ b/oxanus/examples/dynamic.rs
@@ -17,11 +17,7 @@ struct TwoSecJob {}
 struct TwoSecWorker;
 
 impl TwoSecWorker {
-    async fn process(
-        &self,
-        _job: &TwoSecJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TwoSecJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
     }

--- a/oxanus/examples/foo.rs
+++ b/oxanus/examples/foo.rs
@@ -20,11 +20,7 @@ struct OneSecJob {
 struct OneSecWorker;
 
 impl OneSecWorker {
-    async fn process(
-        &self,
-        _job: &OneSecJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
+    async fn process(&self, _job: OneSecJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
         Ok(())
     }
@@ -40,11 +36,7 @@ struct TwoSecJob {
 struct TwoSecWorker;
 
 impl TwoSecWorker {
-    async fn process(
-        &self,
-        _job: &TwoSecJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TwoSecJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
         Ok(())
     }
@@ -59,7 +51,7 @@ struct InstantWorker;
 impl InstantWorker {
     async fn process(
         &self,
-        _job: &InstantJob,
+        _job: InstantJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
@@ -75,7 +67,7 @@ struct Instant2Worker;
 impl Instant2Worker {
     async fn process(
         &self,
-        _job: &Instant2Job,
+        _job: Instant2Job,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())

--- a/oxanus/examples/minimal.rs
+++ b/oxanus/examples/minimal.rs
@@ -19,7 +19,7 @@ struct TestJob {
 struct TestWorker;
 
 impl TestWorker {
-    async fn process(&self, job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, job: TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_secs(job.sleep_s)).await;
         Ok(())
     }

--- a/oxanus/examples/resumable.rs
+++ b/oxanus/examples/resumable.rs
@@ -25,7 +25,7 @@ struct ResumableTestWorker;
 impl ResumableTestWorker {
     async fn process(
         &self,
-        _job: &ResumableTestJob,
+        _job: ResumableTestJob,
         ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         let progress = ctx.state.get::<i32>().await?;

--- a/oxanus/examples/scheduled.rs
+++ b/oxanus/examples/scheduled.rs
@@ -21,7 +21,7 @@ struct TestJob {
 struct TestWorker;
 
 impl TestWorker {
-    async fn process(&self, job: &TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
+    async fn process(&self, job: TestJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tracing::info!("Processing job: {}", job.label);
         Ok(())
     }

--- a/oxanus/examples/throttled.rs
+++ b/oxanus/examples/throttled.rs
@@ -19,7 +19,7 @@ struct InstantWorker;
 impl InstantWorker {
     async fn process(
         &self,
-        _job: &InstantJob,
+        _job: InstantJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())
@@ -36,7 +36,7 @@ struct Instant2Worker;
 impl Instant2Worker {
     async fn process(
         &self,
-        _job: &Instant2Job,
+        _job: Instant2Job,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         Ok(())

--- a/oxanus/examples/unique.rs
+++ b/oxanus/examples/unique.rs
@@ -20,11 +20,7 @@ struct TwoSecJob {
 struct TwoSecWorker;
 
 impl TwoSecWorker {
-    async fn process(
-        &self,
-        _job: &TwoSecJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
+    async fn process(&self, _job: TwoSecJob, _ctx: &oxanus::JobContext) -> Result<(), WorkerError> {
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
         Ok(())
     }

--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -67,13 +67,15 @@ impl<DT, ET> Config<DT, ET> {
     pub fn register_worker<W, A>(mut self) -> Self
     where
         W: Worker<A, Error = ET> + FromContext<DT> + 'static,
-        A: Job + serde::de::DeserializeOwned + Send + Sync + 'static,
+        A: Job + serde::de::DeserializeOwned + Send + 'static,
         DT: Clone + Send + Sync + 'static,
         ET: std::error::Error + Send + Sync + 'static,
     {
         let name = A::worker_name().to_string();
         let factory = worker_registry::job_factory::<W, A, DT, ET>;
+        let batch_factory = worker_registry::job_batch_factory::<W, A, DT, ET>;
         let kind = <W as Worker<A>>::to_config();
+        let batch_config = W::batch_config();
 
         if let WorkerConfigKind::Cron { .. } = &kind {
             assert!(
@@ -90,6 +92,8 @@ impl<DT, ET> Config<DT, ET> {
         self.registry.register_worker_with(WorkerConfig {
             name,
             factory,
+            batch_factory,
+            batch_config,
             kind,
         });
         self

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -268,7 +268,7 @@ where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let batch_size = batch_config.size.max(1);
+    let batch_size = batch_config.size();
     let (tx, rx) = mpsc::channel(batch_size * 2);
     tokio::spawn(async move {
         if let Err(e) = run_batcher(
@@ -300,7 +300,7 @@ where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let batch_size = batch_config.size.max(1);
+    let batch_size = batch_config.size();
     let mut pending = Vec::with_capacity(batch_size);
 
     loop {
@@ -326,7 +326,7 @@ where
             }
         }
 
-        if pending.len() >= batch_size || batch_config.timeout.is_zero() {
+        if pending.len() >= batch_size || batch_config.timeout().is_zero() {
             spawn_batch(
                 Arc::clone(&config),
                 ctx.clone(),
@@ -337,7 +337,7 @@ where
             continue;
         }
 
-        let timeout = tokio::time::sleep(batch_config.timeout);
+        let timeout = tokio::time::sleep(batch_config.timeout());
         tokio::pin!(timeout);
 
         loop {
@@ -490,31 +490,33 @@ where
         }
     };
 
-    let mut invalid_jobs = batch.invalid.iter().collect::<Vec<_>>();
-    invalid_jobs.sort_by_key(|invalid| std::cmp::Reverse(invalid.index));
+    let invalid_by_index = invalid_jobs_by_index(batch.invalid, envelopes.len());
+    if !invalid_by_index.is_empty() {
+        let mut valid_envelopes =
+            Vec::with_capacity(envelopes.len().saturating_sub(invalid_by_index.len()));
+        let mut valid_permits =
+            Vec::with_capacity(permits.len().saturating_sub(invalid_by_index.len()));
 
-    let mut last_removed_index = None;
-    for invalid in invalid_jobs {
-        if invalid.index >= envelopes.len() {
-            continue;
+        for (index, (envelope, permit)) in envelopes.into_iter().zip(permits).enumerate() {
+            if let Some(error) = invalid_by_index.get(&index) {
+                let err_msg = format!("Invalid job: {worker_name} - {error}");
+                tracing::error!("{}", err_msg);
+
+                if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
+                    #[cfg(feature = "sentry")]
+                    sentry_core::capture_error(&e);
+                    tracing::error!("Failed to kill job: {}", e);
+                }
+
+                drop(permit);
+            } else {
+                valid_envelopes.push(envelope);
+                valid_permits.push(permit);
+            }
         }
-        if last_removed_index == Some(invalid.index) {
-            continue;
-        }
-        last_removed_index = Some(invalid.index);
 
-        let envelope = envelopes.remove(invalid.index);
-        let permit = permits.remove(invalid.index);
-        let err_msg = format!("Invalid job: {worker_name} - {}", invalid.error);
-        tracing::error!("{}", err_msg);
-
-        if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_error(&e);
-            tracing::error!("Failed to kill job: {}", e);
-        }
-
-        drop(permit);
+        envelopes = valid_envelopes;
+        permits = valid_permits;
     }
 
     let Some(job) = batch.job else {
@@ -527,6 +529,21 @@ where
     process_batch_result(result_tx, &result, envelopes).await;
 
     Ok(())
+}
+
+fn invalid_jobs_by_index(
+    invalid_jobs: Vec<crate::worker_registry::InvalidBatchJob>,
+    envelope_count: usize,
+) -> HashMap<usize, String> {
+    let mut invalid_by_index = HashMap::new();
+    for invalid in invalid_jobs {
+        if invalid.index < envelope_count {
+            invalid_by_index
+                .entry(invalid.index)
+                .or_insert(invalid.error);
+        }
+    }
+    invalid_by_index
 }
 
 async fn process_result<ET>(

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, mpsc};
 use tokio::task::JoinSet;
 
+use crate::WorkerBatchConfig;
 use crate::config::Config;
 use crate::context::ContextValue;
 use crate::error::OxanusError;
@@ -30,8 +31,10 @@ where
     let concurrency = queue_config.concurrency;
     let (result_tx, result_rx) = mpsc::channel::<JobResult>(concurrency);
     let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(concurrency);
+    let (batch_error_tx, mut batch_error_rx) = mpsc::channel::<OxanusError>(concurrency.max(1));
     let semaphores = Arc::new(SemaphoresMap::new(concurrency));
     let mut joinset = JoinSet::new();
+    let mut batchers: HashMap<BatchKey, mpsc::Sender<PendingJob>> = HashMap::new();
 
     joinset.spawn(result_collector::run(
         result_rx,
@@ -49,16 +52,25 @@ where
         tokio::select! {
             job = job_rx.recv() => {
                 if let Some(job) = job {
-                    joinset.spawn(process_job(
+                    route_job(
                         Arc::clone(&config),
                         ctx.clone(),
                         result_tx.clone(),
+                        batch_error_tx.clone(),
                         job,
-                    ));
+                        &mut batchers,
+                        &mut joinset,
+                    )
+                    .await?;
                 }
             }
             Some(task_result) = joinset.join_next() => {
                 task_result??;
+            }
+            batch_error = batch_error_rx.recv() => {
+                if let Some(error) = batch_error {
+                    return Err(error);
+                }
             }
             _ = config.cancel_token.cancelled() => {
                 break;
@@ -71,19 +83,74 @@ where
     Ok(())
 }
 
-async fn process_job<DT, ET>(
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+struct BatchKey {
+    worker: String,
+    queue: String,
+}
+
+impl BatchKey {
+    fn from_envelope(envelope: &JobEnvelope) -> Self {
+        Self {
+            worker: envelope.job.name.clone(),
+            queue: envelope.queue.clone(),
+        }
+    }
+}
+
+struct PendingJob {
+    envelope: JobEnvelope,
+    permit: OwnedSemaphorePermit,
+}
+
+async fn route_job<DT, ET>(
     config: Arc<Config<DT, ET>>,
     ctx: ContextValue<DT>,
     result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
     job_event: WorkerJob,
+    batchers: &mut HashMap<BatchKey, mpsc::Sender<PendingJob>>,
+    joinset: &mut JoinSet<Result<(), OxanusError>>,
 ) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let pending = match load_pending_job(Arc::clone(&config), job_event).await? {
+        Some(pending) => pending,
+        None => return Ok(()),
+    };
+
+    if let Some(batch_config) = config.registry.batch_config(&pending.envelope.job.name) {
+        send_to_batcher(
+            config,
+            ctx,
+            result_tx,
+            batch_error_tx,
+            batchers,
+            pending,
+            batch_config,
+        )
+        .await;
+        return Ok(());
+    }
+
+    joinset.spawn(process_pending_job(config, ctx, result_tx, pending));
+
+    Ok(())
+}
+
+async fn load_pending_job<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    job_event: WorkerJob,
+) -> Result<Option<PendingJob>, OxanusError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
     tracing::trace!("Processing job: {:?}", job_event);
 
-    let mut envelope: JobEnvelope = match config.storage.internal.get_job(&job_event.job_id).await {
+    let envelope: JobEnvelope = match config.storage.internal.get_job(&job_event.job_id).await {
         Ok(Some(envelope)) => envelope,
         Ok(None) => {
             tracing::warn!("Job {} not found", job_event.job_id);
@@ -92,13 +159,13 @@ where
                 sentry_core::capture_error(&e);
                 tracing::error!("Failed to delete job: {}", e);
             }
-            return Ok(());
+            return Ok(None);
         }
         Err(e) => {
             #[cfg(feature = "sentry")]
             sentry_core::capture_error(&e);
             tracing::error!("Failed to get job envelope: {}", e);
-            return Ok(());
+            return Ok(None);
         }
     };
 
@@ -108,6 +175,24 @@ where
         envelope = %serde_json::to_value(&envelope)?,
         "Received envelope"
     );
+
+    Ok(Some(PendingJob {
+        envelope,
+        permit: job_event.permit,
+    }))
+}
+
+async fn process_pending_job<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    pending: PendingJob,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let mut envelope = pending.envelope;
     let job = match config
         .registry
         .build(&envelope.job.name, envelope.job.args.clone(), &ctx.0)
@@ -125,10 +210,270 @@ where
         }
     };
 
-    let result = executor::run(config, job, &mut envelope).await?;
-    drop(job_event.permit);
+    let result = executor::run(Arc::clone(&config), job, &mut envelope).await?;
+    drop(pending.permit);
 
     process_result(result_tx, result, envelope).await;
+
+    Ok(())
+}
+
+async fn send_to_batcher<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
+    batchers: &mut HashMap<BatchKey, mpsc::Sender<PendingJob>>,
+    pending: PendingJob,
+    batch_config: WorkerBatchConfig,
+) where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let key = BatchKey::from_envelope(&pending.envelope);
+    let mut pending = pending;
+
+    loop {
+        let tx = batchers
+            .entry(key.clone())
+            .or_insert_with(|| {
+                spawn_batcher(
+                    Arc::clone(&config),
+                    ctx.clone(),
+                    result_tx.clone(),
+                    batch_error_tx.clone(),
+                    batch_config.clone(),
+                )
+            })
+            .clone();
+
+        match tx.send(pending).await {
+            Ok(()) => break,
+            Err(err) => {
+                pending = err.0;
+                batchers.remove(&key);
+            }
+        }
+    }
+}
+
+fn spawn_batcher<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
+    batch_config: WorkerBatchConfig,
+) -> mpsc::Sender<PendingJob>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let batch_size = batch_config.size.max(1);
+    let (tx, rx) = mpsc::channel(batch_size * 2);
+    tokio::spawn(async move {
+        if let Err(e) = run_batcher(
+            config,
+            ctx,
+            result_tx,
+            batch_error_tx.clone(),
+            batch_config,
+            rx,
+        )
+        .await
+        {
+            tracing::error!(error = %e, "Batcher exited with error");
+            batch_error_tx.send(e).await.ok();
+        }
+    });
+    tx
+}
+
+async fn run_batcher<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
+    batch_config: WorkerBatchConfig,
+    mut rx: mpsc::Receiver<PendingJob>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let batch_size = batch_config.size.max(1);
+    let mut pending = Vec::with_capacity(batch_size);
+
+    loop {
+        tokio::select! {
+            job = rx.recv(), if pending.is_empty() => {
+                match job {
+                    Some(job) => pending.push(job),
+                    None => return Ok(()),
+                }
+            }
+            _ = config.cancel_token.cancelled(), if pending.is_empty() => {
+                return Ok(());
+            }
+        }
+
+        if pending.len() >= batch_size || batch_config.timeout.is_zero() {
+            spawn_batch(
+                Arc::clone(&config),
+                ctx.clone(),
+                result_tx.clone(),
+                batch_error_tx.clone(),
+                &mut pending,
+            );
+            continue;
+        }
+
+        let timeout = tokio::time::sleep(batch_config.timeout);
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                job = rx.recv() => {
+                    match job {
+                        Some(job) => {
+                            pending.push(job);
+                            if pending.len() >= batch_size {
+                                break;
+                            }
+                        }
+                        None => {
+                            spawn_batch(
+                                Arc::clone(&config),
+                                ctx.clone(),
+                                result_tx.clone(),
+                                batch_error_tx.clone(),
+                                &mut pending,
+                            );
+                            return Ok(());
+                        }
+                    }
+                }
+                _ = &mut timeout => {
+                    break;
+                }
+                _ = config.cancel_token.cancelled() => {
+                    spawn_batch(
+                        Arc::clone(&config),
+                        ctx.clone(),
+                        result_tx.clone(),
+                        batch_error_tx.clone(),
+                        &mut pending,
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
+        spawn_batch(
+            Arc::clone(&config),
+            ctx.clone(),
+            result_tx.clone(),
+            batch_error_tx.clone(),
+            &mut pending,
+        );
+    }
+}
+
+fn spawn_batch<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
+    pending: &mut Vec<PendingJob>,
+) where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if pending.is_empty() {
+        return;
+    }
+
+    let batch = std::mem::take(pending);
+    tokio::spawn(async move {
+        if let Err(e) = process_pending_batch(config, ctx, result_tx, batch).await {
+            tracing::error!(error = %e, "Failed to process job batch");
+            batch_error_tx.send(e).await.ok();
+        }
+    });
+}
+
+async fn process_pending_batch<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    pending: Vec<PendingJob>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let mut envelopes = Vec::with_capacity(pending.len());
+    let mut permits = Vec::with_capacity(pending.len());
+    for pending_job in pending {
+        envelopes.push(pending_job.envelope);
+        permits.push(pending_job.permit);
+    }
+
+    let Some(first_envelope) = envelopes.first() else {
+        return Ok(());
+    };
+    let worker_name = first_envelope.job.name.clone();
+    let args = envelopes
+        .iter()
+        .map(|envelope| envelope.job.args.clone())
+        .collect();
+    let batch = match config.registry.build_batch(&worker_name, args, &ctx.0) {
+        Ok(batch) => batch,
+        Err(e) => {
+            let err_msg = format!("Invalid job batch: {worker_name} - {e}");
+            tracing::error!("{}", err_msg);
+            for envelope in &envelopes {
+                if let Err(e) = config
+                    .storage
+                    .internal
+                    .kill(envelope, err_msg.clone())
+                    .await
+                {
+                    #[cfg(feature = "sentry")]
+                    sentry_core::capture_error(&e);
+                    tracing::error!("Failed to kill job: {}", e);
+                }
+            }
+            return Ok(());
+        }
+    };
+
+    for invalid in batch.invalid.iter().rev() {
+        if invalid.index >= envelopes.len() {
+            continue;
+        }
+
+        let envelope = envelopes.remove(invalid.index);
+        let permit = permits.remove(invalid.index);
+        let err_msg = format!("Invalid job: {worker_name} - {}", invalid.error);
+        tracing::error!("{}", err_msg);
+
+        if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_error(&e);
+            tracing::error!("Failed to kill job: {}", e);
+        }
+
+        drop(permit);
+    }
+
+    let Some(job) = batch.job else {
+        return Ok(());
+    };
+
+    let result = executor::run_batch(Arc::clone(&config), job, &mut envelopes).await?;
+    drop(permits);
+
+    process_batch_result(result_tx, &result, envelopes).await;
 
     Ok(())
 }
@@ -149,6 +494,26 @@ async fn process_result<ET>(
     };
 
     result_tx.send(JobResult { envelope, kind }).await.ok();
+}
+
+async fn process_batch_result<ET>(
+    result_tx: mpsc::Sender<JobResult>,
+    result: &Result<(), ExecutionError<ET>>,
+    envelopes: Vec<JobEnvelope>,
+) where
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    for envelope in envelopes {
+        let kind = match result {
+            Ok(()) => JobResultKind::Success,
+            Err(e) => match e {
+                ExecutionError::NotPanic(_) => JobResultKind::Failed,
+                ExecutionError::Panic() => JobResultKind::Panicked,
+            },
+        };
+
+        result_tx.send(JobResult { envelope, kind }).await.ok();
+    }
 }
 
 async fn run_queue_watcher<DT, ET>(

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -312,6 +312,16 @@ where
                 }
             }
             _ = config.cancel_token.cancelled(), if pending.is_empty() => {
+                flush_batcher(
+                    Arc::clone(&config),
+                    ctx.clone(),
+                    result_tx.clone(),
+                    batch_error_tx.clone(),
+                    &mut rx,
+                    &mut pending,
+                    batch_size,
+                )
+                .await;
                 return Ok(());
             }
         }
@@ -356,13 +366,16 @@ where
                     break;
                 }
                 _ = config.cancel_token.cancelled() => {
-                    spawn_batch(
+                    flush_batcher(
                         Arc::clone(&config),
                         ctx.clone(),
                         result_tx.clone(),
                         batch_error_tx.clone(),
+                        &mut rx,
                         &mut pending,
-                    );
+                        batch_size,
+                    )
+                    .await;
                     return Ok(());
                 }
             }
@@ -376,6 +389,36 @@ where
             &mut pending,
         );
     }
+}
+
+async fn flush_batcher<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    ctx: ContextValue<DT>,
+    result_tx: mpsc::Sender<JobResult>,
+    batch_error_tx: mpsc::Sender<OxanusError>,
+    rx: &mut mpsc::Receiver<PendingJob>,
+    pending: &mut Vec<PendingJob>,
+    batch_size: usize,
+) where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    rx.close();
+
+    while let Some(job) = rx.recv().await {
+        pending.push(job);
+        if pending.len() >= batch_size {
+            spawn_batch(
+                Arc::clone(&config),
+                ctx.clone(),
+                result_tx.clone(),
+                batch_error_tx.clone(),
+                pending,
+            );
+        }
+    }
+
+    spawn_batch(config, ctx, result_tx, batch_error_tx, pending);
 }
 
 fn spawn_batch<DT, ET>(
@@ -447,10 +490,18 @@ where
         }
     };
 
-    for invalid in batch.invalid.iter().rev() {
+    let mut invalid_jobs = batch.invalid.iter().collect::<Vec<_>>();
+    invalid_jobs.sort_by_key(|invalid| std::cmp::Reverse(invalid.index));
+
+    let mut last_removed_index = None;
+    for invalid in invalid_jobs {
         if invalid.index >= envelopes.len() {
             continue;
         }
+        if last_removed_index == Some(invalid.index) {
+            continue;
+        }
+        last_removed_index = Some(invalid.index);
 
         let envelope = envelopes.remove(invalid.index);
         let permit = permits.remove(invalid.index);
@@ -612,5 +663,118 @@ async fn wait_for_workers_to_finish<DT, ET>(
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PendingJob, process_pending_batch};
+    use crate::test_helper::{random_string, redis_pool};
+    use crate::worker_registry::{self, BatchBuild, InvalidBatchJob, WorkerConfigKind};
+    use crate::{Config, ContextValue, Job, JobEnvelope, Storage, Worker, WorkerConfig};
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+    use testresult::TestResult;
+    use tokio::sync::{Semaphore, mpsc};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct UnsortedInvalidJob;
+
+    impl Job for UnsortedInvalidJob {
+        fn worker_name() -> &'static str {
+            std::any::type_name::<UnsortedInvalidWorker>()
+        }
+    }
+
+    struct UnsortedInvalidWorker;
+
+    impl crate::FromContext<()> for UnsortedInvalidWorker {
+        fn from_context(_ctx: &()) -> Self {
+            Self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Worker<UnsortedInvalidJob> for UnsortedInvalidWorker {
+        type Error = std::io::Error;
+
+        async fn run_batch(
+            &self,
+            _jobs: Vec<crate::BatchItem<UnsortedInvalidJob>>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn unsorted_invalid_batch_factory(
+        _values: Vec<serde_json::Value>,
+        _ctx: &(),
+    ) -> Result<BatchBuild<std::io::Error>, crate::OxanusError> {
+        Ok(BatchBuild {
+            job: None,
+            invalid: vec![
+                InvalidBatchJob {
+                    index: 1,
+                    error: "second invalid".to_string(),
+                },
+                InvalidBatchJob {
+                    index: 0,
+                    error: "first invalid".to_string(),
+                },
+            ],
+        })
+    }
+
+    #[tokio::test]
+    async fn process_pending_batch_handles_unsorted_invalid_indexes() -> TestResult {
+        let pool = redis_pool().await?;
+        let storage = Storage::builder()
+            .namespace(random_string())
+            .build_from_pool(pool)?;
+        let queue = random_string();
+        let mut config = Config::new(&storage);
+        config.register_worker_with(WorkerConfig {
+            name: UnsortedInvalidJob::worker_name().to_string(),
+            factory: worker_registry::job_factory::<
+                UnsortedInvalidWorker,
+                UnsortedInvalidJob,
+                (),
+                std::io::Error,
+            >,
+            batch_factory: unsorted_invalid_batch_factory,
+            batch_config: Some(crate::WorkerBatchConfig::new(
+                2,
+                std::time::Duration::from_millis(100),
+            )),
+            kind: WorkerConfigKind::Normal,
+        });
+
+        let envelopes = vec![
+            JobEnvelope::new(queue.clone(), UnsortedInvalidJob)?,
+            JobEnvelope::new(queue.clone(), UnsortedInvalidJob)?,
+        ];
+        for envelope in &envelopes {
+            storage.internal.enqueue(envelope.clone()).await?;
+        }
+        for _ in &envelopes {
+            storage.internal.dequeue(&queue).await?;
+        }
+
+        let semaphore = Arc::new(Semaphore::new(envelopes.len()));
+        let mut pending = Vec::with_capacity(envelopes.len());
+        for envelope in envelopes {
+            pending.push(PendingJob {
+                envelope,
+                permit: Arc::clone(&semaphore).acquire_owned().await?,
+            });
+        }
+        let (result_tx, _result_rx) = mpsc::channel(1);
+
+        process_pending_batch(Arc::new(config), ContextValue::new(()), result_tx, pending).await?;
+
+        assert_eq!(storage.dead_count().await?, 2);
+        assert_eq!(storage.jobs_count().await?, 0);
+
+        Ok(())
     }
 }

--- a/oxanus/src/drainer.rs
+++ b/oxanus/src/drainer.rs
@@ -80,7 +80,7 @@ where
         state: JobState::new(config.storage.clone(), job_id, envelope.meta.state.clone()),
     };
 
-    let job_result = job.process(&job_ctx).await;
+    let job_result = job.process(vec![job_ctx]).await;
 
     match job_result {
         Ok(()) => {

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -28,8 +28,7 @@ where
     ET: std::error::Error + Send + Sync + 'static,
 {
     config.storage.internal.set_started_at(envelope).await?;
-    let max_retries = worker.max_retries(0);
-    let default_delay = worker.retry_delay(0, envelope.meta.retries);
+    let policy = execution_policy(&worker, 0, envelope);
 
     tracing::info!(
         job_id = envelope.id,
@@ -39,24 +38,9 @@ where
         "Job started"
     );
     let start = std::time::Instant::now();
-    let job_ctx = job_context(&config.storage, envelope);
+    let job_contexts = vec![job_context(&config.storage, envelope)];
 
-    let result = match AssertUnwindSafe(process(worker, vec![job_ctx], envelope))
-        .catch_unwind()
-        .await
-    {
-        Ok(result) => ExecutionResult::NotPanic(result),
-        Err(panic) => {
-            let panic_msg = if let Some(s) = panic.downcast_ref::<&str>() {
-                (*s).to_string()
-            } else if let Some(s) = panic.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic occurred".to_string()
-            };
-            ExecutionResult::Panic(panic_msg)
-        }
-    };
+    let result = run_process(worker, job_contexts, envelope).await;
 
     let duration = start.elapsed();
     let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
@@ -70,46 +54,7 @@ where
         "Job finished"
     );
 
-    match result {
-        ExecutionResult::NotPanic(result) => {
-            match &result {
-                Ok(()) => {
-                    if let Err(e) = config.storage.internal.finish_with_success(envelope).await {
-                        tracing::error!("Failed to finish job: {}", e);
-                    }
-                }
-                Err(e) => {
-                    let retry_delay = config
-                        .retry_delay_override
-                        .as_ref()
-                        .and_then(|f| f(e, envelope.meta.retries, default_delay))
-                        .unwrap_or(default_delay);
-
-                    #[cfg(feature = "sentry")]
-                    sentry_core::capture_error(e);
-
-                    tracing::error!(
-                        job_id = envelope.id,
-                        queue = envelope.queue,
-                        worker = envelope.job.name,
-                        "Job failed"
-                    );
-
-                    handle_err(config, &e.to_string(), envelope, retry_delay, max_retries).await;
-                }
-            }
-
-            Ok(result.map_err(ExecutionError::NotPanic))
-        }
-        ExecutionResult::Panic(panic_msg) => {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
-
-            handle_err(config, &panic_msg, envelope, default_delay, max_retries).await;
-
-            Ok(Err(ExecutionError::Panic()))
-        }
-    }
+    Ok(finish_job_result(config.as_ref(), result, envelope, &policy).await)
 }
 
 pub async fn run_batch<DT, ET>(
@@ -136,10 +81,7 @@ where
     let policies: Vec<JobExecutionPolicy> = envelopes
         .iter()
         .enumerate()
-        .map(|(index, envelope)| JobExecutionPolicy {
-            max_retries: worker.max_retries(index),
-            retry_delay: worker.retry_delay(index, envelope.meta.retries),
-        })
+        .map(|(index, envelope)| execution_policy(&worker, index, envelope))
         .collect();
 
     config
@@ -161,27 +103,9 @@ where
         "Job batch started"
     );
     let start = std::time::Instant::now();
-    let job_contexts = envelopes
-        .iter()
-        .map(|envelope| job_context(&config.storage, envelope))
-        .collect();
+    let job_contexts = job_contexts(&config.storage, envelopes);
 
-    let result = match AssertUnwindSafe(process(worker, job_contexts, first_envelope))
-        .catch_unwind()
-        .await
-    {
-        Ok(result) => ExecutionResult::NotPanic(result),
-        Err(panic) => {
-            let panic_msg = if let Some(s) = panic.downcast_ref::<&str>() {
-                (*s).to_string()
-            } else if let Some(s) = panic.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic occurred".to_string()
-            };
-            ExecutionResult::Panic(panic_msg)
-        }
-    };
+    let result = run_process(worker, job_contexts, first_envelope).await;
 
     let duration = start.elapsed();
     let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
@@ -194,50 +118,162 @@ where
         "Job batch finished"
     );
 
+    Ok(finish_batch_result(config.as_ref(), result, envelopes, &policies).await)
+}
+
+struct JobExecutionPolicy {
+    max_retries: u32,
+    retry_delay: u64,
+}
+
+fn execution_policy<ET>(
+    worker: &BoxedProcessable<ET>,
+    index: usize,
+    envelope: &JobEnvelope,
+) -> JobExecutionPolicy
+where
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    JobExecutionPolicy {
+        max_retries: worker.max_retries(index),
+        retry_delay: worker.retry_delay(index, envelope.meta.retries),
+    }
+}
+
+async fn run_process<ET>(
+    worker: BoxedProcessable<ET>,
+    job_contexts: Vec<JobContext>,
+    envelope: &JobEnvelope,
+) -> ExecutionResult<ET>
+where
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    match AssertUnwindSafe(process(worker, job_contexts, envelope))
+        .catch_unwind()
+        .await
+    {
+        Ok(result) => ExecutionResult::NotPanic(result),
+        Err(panic) => ExecutionResult::Panic(panic_message(panic)),
+    }
+}
+
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic occurred".to_string()
+    }
+}
+
+async fn finish_job_result<DT, ET>(
+    config: &Config<DT, ET>,
+    result: ExecutionResult<ET>,
+    envelope: &JobEnvelope,
+    policy: &JobExecutionPolicy,
+) -> Result<(), ExecutionError<ET>>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
     match result {
-        ExecutionResult::NotPanic(result) => {
-            match &result {
-                Ok(()) => {
-                    if let Err(e) = config
-                        .storage
-                        .internal
-                        .finish_with_success_batch(envelopes)
-                        .await
-                    {
-                        tracing::error!("Failed to finish job batch: {}", e);
-                    }
-                }
-                Err(e) => {
-                    #[cfg(feature = "sentry")]
-                    sentry_core::capture_error(e);
+        ExecutionResult::NotPanic(Ok(())) => {
+            if let Err(e) = config.storage.internal.finish_with_success(envelope).await {
+                tracing::error!("Failed to finish job: {}", e);
+            }
+            Ok(())
+        }
+        ExecutionResult::NotPanic(Err(e)) => {
+            let retry_delay = retry_delay(config, &e, envelope, policy);
 
-                    tracing::error!(
-                        batch_size = envelopes.len(),
-                        queue = queue,
-                        worker = worker_name,
-                        "Job batch failed"
-                    );
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_error(&e);
 
-                    for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
-                        let retry_delay = config
-                            .retry_delay_override
-                            .as_ref()
-                            .and_then(|f| f(e, envelope.meta.retries, policy.retry_delay))
-                            .unwrap_or(policy.retry_delay);
+            tracing::error!(
+                job_id = envelope.id,
+                queue = envelope.queue,
+                worker = envelope.job.name,
+                "Job failed"
+            );
 
-                        handle_err(
-                            Arc::clone(&config),
-                            &e.to_string(),
-                            envelope,
-                            retry_delay,
-                            policy.max_retries,
-                        )
-                        .await;
-                    }
-                }
+            handle_err(
+                config,
+                &e.to_string(),
+                envelope,
+                retry_delay,
+                policy.max_retries,
+            )
+            .await;
+
+            Err(ExecutionError::NotPanic(e))
+        }
+        ExecutionResult::Panic(panic_msg) => {
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
+
+            handle_err(
+                config,
+                &panic_msg,
+                envelope,
+                policy.retry_delay,
+                policy.max_retries,
+            )
+            .await;
+
+            Err(ExecutionError::Panic())
+        }
+    }
+}
+
+async fn finish_batch_result<DT, ET>(
+    config: &Config<DT, ET>,
+    result: ExecutionResult<ET>,
+    envelopes: &[JobEnvelope],
+    policies: &[JobExecutionPolicy],
+) -> Result<(), ExecutionError<ET>>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    match result {
+        ExecutionResult::NotPanic(Ok(())) => {
+            if let Err(e) = config
+                .storage
+                .internal
+                .finish_with_success_batch(envelopes)
+                .await
+            {
+                tracing::error!("Failed to finish job batch: {}", e);
+            }
+            Ok(())
+        }
+        ExecutionResult::NotPanic(Err(e)) => {
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_error(&e);
+
+            if let Some(envelope) = envelopes.first() {
+                tracing::error!(
+                    batch_size = envelopes.len(),
+                    queue = envelope.queue,
+                    worker = envelope.job.name,
+                    "Job batch failed"
+                );
             }
 
-            Ok(result.map_err(ExecutionError::NotPanic))
+            let err_msg = e.to_string();
+            for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
+                handle_err(
+                    config,
+                    &err_msg,
+                    envelope,
+                    retry_delay(config, &e, envelope, policy),
+                    policy.max_retries,
+                )
+                .await;
+            }
+
+            Err(ExecutionError::NotPanic(e))
         }
         ExecutionResult::Panic(panic_msg) => {
             #[cfg(feature = "sentry")]
@@ -245,7 +281,7 @@ where
 
             for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
                 handle_err(
-                    Arc::clone(&config),
+                    config,
                     &panic_msg,
                     envelope,
                     policy.retry_delay,
@@ -254,14 +290,25 @@ where
                 .await;
             }
 
-            Ok(Err(ExecutionError::Panic()))
+            Err(ExecutionError::Panic())
         }
     }
 }
 
-struct JobExecutionPolicy {
-    max_retries: u32,
-    retry_delay: u64,
+fn retry_delay<DT, ET>(
+    config: &Config<DT, ET>,
+    error: &ET,
+    envelope: &JobEnvelope,
+    policy: &JobExecutionPolicy,
+) -> u64
+where
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    config
+        .retry_delay_override
+        .as_ref()
+        .and_then(|f| f(error, envelope.meta.retries, policy.retry_delay))
+        .unwrap_or(policy.retry_delay)
 }
 
 #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, name = "job", fields(
@@ -304,8 +351,15 @@ fn job_context(storage: &crate::Storage, envelope: &JobEnvelope) -> JobContext {
     }
 }
 
+fn job_contexts(storage: &crate::Storage, envelopes: &[JobEnvelope]) -> Vec<JobContext> {
+    envelopes
+        .iter()
+        .map(|envelope| job_context(storage, envelope))
+        .collect()
+}
+
 async fn handle_err<DT, ET>(
-    config: Arc<Config<DT, ET>>,
+    config: &Config<DT, ET>,
     err_msg: &str,
     envelope: &JobEnvelope,
     retry_delay: u64,

--- a/oxanus/src/executor.rs
+++ b/oxanus/src/executor.rs
@@ -28,6 +28,8 @@ where
     ET: std::error::Error + Send + Sync + 'static,
 {
     config.storage.internal.set_started_at(envelope).await?;
+    let max_retries = worker.max_retries(0);
+    let default_delay = worker.retry_delay(0, envelope.meta.retries);
 
     tracing::info!(
         job_id = envelope.id,
@@ -37,16 +39,9 @@ where
         "Job started"
     );
     let start = std::time::Instant::now();
-    let job_ctx = JobContext {
-        meta: envelope.meta.clone(),
-        state: JobState::new(
-            config.storage.clone(),
-            envelope.id.clone(),
-            envelope.meta.state.clone(),
-        ),
-    };
+    let job_ctx = job_context(&config.storage, envelope);
 
-    let result = match AssertUnwindSafe(process(&worker, job_ctx, envelope))
+    let result = match AssertUnwindSafe(process(worker, vec![job_ctx], envelope))
         .catch_unwind()
         .await
     {
@@ -75,8 +70,6 @@ where
         "Job finished"
     );
 
-    let max_retries = worker.max_retries();
-
     match result {
         ExecutionResult::NotPanic(result) => {
             match &result {
@@ -86,7 +79,6 @@ where
                     }
                 }
                 Err(e) => {
-                    let default_delay = worker.retry_delay(envelope.meta.retries);
                     let retry_delay = config
                         .retry_delay_override
                         .as_ref()
@@ -110,16 +102,166 @@ where
             Ok(result.map_err(ExecutionError::NotPanic))
         }
         ExecutionResult::Panic(panic_msg) => {
-            let retry_delay = worker.retry_delay(envelope.meta.retries);
-
             #[cfg(feature = "sentry")]
             sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
 
-            handle_err(config, &panic_msg, envelope, retry_delay, max_retries).await;
+            handle_err(config, &panic_msg, envelope, default_delay, max_retries).await;
 
             Ok(Err(ExecutionError::Panic()))
         }
     }
+}
+
+pub async fn run_batch<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    worker: BoxedProcessable<ET>,
+    envelopes: &mut [JobEnvelope],
+) -> Result<Result<(), ExecutionError<ET>>, OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if envelopes.is_empty() {
+        return Ok(Ok(()));
+    }
+
+    if worker.len() != envelopes.len() {
+        return Err(OxanusError::GenericError(format!(
+            "Batch worker has {} jobs but received {} envelopes",
+            worker.len(),
+            envelopes.len()
+        )));
+    }
+
+    let policies: Vec<JobExecutionPolicy> = envelopes
+        .iter()
+        .enumerate()
+        .map(|(index, envelope)| JobExecutionPolicy {
+            max_retries: worker.max_retries(index),
+            retry_delay: worker.retry_delay(index, envelope.meta.retries),
+        })
+        .collect();
+
+    config
+        .storage
+        .internal
+        .set_started_at_batch(envelopes)
+        .await?;
+
+    let first_envelope = envelopes
+        .first()
+        .expect("envelopes is not empty because it was checked above");
+    let queue = first_envelope.queue.clone();
+    let worker_name = first_envelope.job.name.clone();
+
+    tracing::info!(
+        batch_size = envelopes.len(),
+        queue = queue,
+        worker = worker_name,
+        "Job batch started"
+    );
+    let start = std::time::Instant::now();
+    let job_contexts = envelopes
+        .iter()
+        .map(|envelope| job_context(&config.storage, envelope))
+        .collect();
+
+    let result = match AssertUnwindSafe(process(worker, job_contexts, first_envelope))
+        .catch_unwind()
+        .await
+    {
+        Ok(result) => ExecutionResult::NotPanic(result),
+        Err(panic) => {
+            let panic_msg = if let Some(s) = panic.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else if let Some(s) = panic.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred".to_string()
+            };
+            ExecutionResult::Panic(panic_msg)
+        }
+    };
+
+    let duration = start.elapsed();
+    let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
+    tracing::info!(
+        batch_size = envelopes.len(),
+        queue = queue,
+        worker = worker_name,
+        success = !is_err,
+        duration = duration.as_millis(),
+        "Job batch finished"
+    );
+
+    match result {
+        ExecutionResult::NotPanic(result) => {
+            match &result {
+                Ok(()) => {
+                    if let Err(e) = config
+                        .storage
+                        .internal
+                        .finish_with_success_batch(envelopes)
+                        .await
+                    {
+                        tracing::error!("Failed to finish job batch: {}", e);
+                    }
+                }
+                Err(e) => {
+                    #[cfg(feature = "sentry")]
+                    sentry_core::capture_error(e);
+
+                    tracing::error!(
+                        batch_size = envelopes.len(),
+                        queue = queue,
+                        worker = worker_name,
+                        "Job batch failed"
+                    );
+
+                    for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
+                        let retry_delay = config
+                            .retry_delay_override
+                            .as_ref()
+                            .and_then(|f| f(e, envelope.meta.retries, policy.retry_delay))
+                            .unwrap_or(policy.retry_delay);
+
+                        handle_err(
+                            Arc::clone(&config),
+                            &e.to_string(),
+                            envelope,
+                            retry_delay,
+                            policy.max_retries,
+                        )
+                        .await;
+                    }
+                }
+            }
+
+            Ok(result.map_err(ExecutionError::NotPanic))
+        }
+        ExecutionResult::Panic(panic_msg) => {
+            #[cfg(feature = "sentry")]
+            sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
+
+            for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
+                handle_err(
+                    Arc::clone(&config),
+                    &panic_msg,
+                    envelope,
+                    policy.retry_delay,
+                    policy.max_retries,
+                )
+                .await;
+            }
+
+            Ok(Err(ExecutionError::Panic()))
+        }
+    }
+}
+
+struct JobExecutionPolicy {
+    max_retries: u32,
+    retry_delay: u64,
 }
 
 #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, name = "job", fields(
@@ -132,8 +274,8 @@ where
     success = false,
 )))]
 async fn process<ET>(
-    worker: &BoxedProcessable<ET>,
-    job_ctx: JobContext,
+    worker: BoxedProcessable<ET>,
+    job_contexts: Vec<JobContext>,
     #[cfg_attr(not(feature = "tracing-instrument"), allow(unused_variables))]
     envelope: &JobEnvelope,
 ) -> Result<(), ET>
@@ -143,12 +285,23 @@ where
     #[cfg(feature = "tracing-instrument")]
     let span = tracing::Span::current();
 
-    let result = worker.process(&job_ctx).await;
+    let result = worker.process(job_contexts).await;
 
     #[cfg(feature = "tracing-instrument")]
     span.record("success", result.is_ok());
 
     result
+}
+
+fn job_context(storage: &crate::Storage, envelope: &JobEnvelope) -> JobContext {
+    JobContext {
+        meta: envelope.meta.clone(),
+        state: JobState::new(
+            storage.clone(),
+            envelope.id.clone(),
+            envelope.meta.state.clone(),
+        ),
+    }
 }
 
 async fn handle_err<DT, ET>(

--- a/oxanus/src/lib.rs
+++ b/oxanus/src/lib.rs
@@ -118,8 +118,8 @@ pub use crate::stats::*;
 pub use crate::storage::Storage;
 pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};
 pub use crate::storage_types::*;
-pub use crate::worker::{FromContext, Job, Worker};
-pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_factory};
+pub use crate::worker::{BatchItem, FromContext, Job, Worker, WorkerBatchConfig};
+pub use crate::worker_registry::{WorkerConfig, WorkerConfigKind, job_batch_factory, job_factory};
 
 #[cfg(feature = "registry")]
 pub use registry::*;

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -368,6 +368,21 @@ impl StorageInternal {
         Ok(())
     }
 
+    pub async fn update_jobs(&self, envelopes: &[JobEnvelope]) -> Result<(), OxanusError> {
+        if envelopes.is_empty() {
+            return Ok(());
+        }
+
+        let items = envelopes
+            .iter()
+            .map(|envelope| Ok((envelope.id.as_str(), serde_json::to_string(envelope)?)))
+            .collect::<Result<Vec<_>, OxanusError>>()?;
+
+        let mut redis = self.connection().await?;
+        let _: () = redis.hset_multiple(&self.keys.jobs, &items).await?;
+        Ok(())
+    }
+
     pub async fn update_state(
         &self,
         id: &JobId,
@@ -385,6 +400,18 @@ impl StorageInternal {
     pub async fn set_started_at(&self, envelope: &mut JobEnvelope) -> Result<(), OxanusError> {
         envelope.meta.started_at = Some(chrono::Utc::now().timestamp_micros());
         self.update_job(envelope).await?;
+        Ok(())
+    }
+
+    pub async fn set_started_at_batch(
+        &self,
+        envelopes: &mut [JobEnvelope],
+    ) -> Result<(), OxanusError> {
+        let now = chrono::Utc::now().timestamp_micros();
+        for envelope in envelopes.iter_mut() {
+            envelope.meta.started_at = Some(now);
+        }
+        self.update_jobs(envelopes).await?;
         Ok(())
     }
 
@@ -431,6 +458,30 @@ impl StorageInternal {
             .lrem(self.current_processing_queue(), 1, &envelope.id)
             .query_async(&mut redis)
             .await?;
+        Ok(())
+    }
+
+    pub async fn finish_with_success_batch(
+        &self,
+        envelopes: &[JobEnvelope],
+    ) -> Result<(), OxanusError> {
+        if envelopes.is_empty() {
+            return Ok(());
+        }
+
+        let job_ids = envelopes
+            .iter()
+            .map(|envelope| envelope.id.as_str())
+            .collect::<Vec<_>>();
+        let processing_queue = self.current_processing_queue();
+        let mut pipe = redis::pipe();
+        pipe.hdel(&self.keys.jobs, &job_ids);
+        for job_id in job_ids {
+            pipe.lrem(&processing_queue, 1, job_id);
+        }
+
+        let mut redis = self.connection().await?;
+        let _: () = pipe.query_async(&mut redis).await?;
         Ok(())
     }
 
@@ -1701,6 +1752,86 @@ mod tests {
             .await?
             .expect("job should exist");
         assert_eq!(persisted.meta.started_at, Some(started_at));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_set_started_at_batch() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        let mut envelopes = vec![
+            JobEnvelope::new(queue.clone(), TestJob {})?,
+            JobEnvelope::new(queue.clone(), TestJob {})?,
+        ];
+        for envelope in &envelopes {
+            assert!(envelope.meta.started_at.is_none());
+            storage.enqueue(envelope.clone()).await?;
+        }
+
+        let before = chrono::Utc::now().timestamp_micros();
+        storage.set_started_at_batch(&mut envelopes).await?;
+        let after = chrono::Utc::now().timestamp_micros();
+
+        let started_at = envelopes
+            .first()
+            .expect("batch should contain an envelope")
+            .meta
+            .started_at
+            .expect("started_at should be set");
+        assert!(started_at >= before);
+        assert!(started_at <= after);
+
+        for envelope in &envelopes {
+            assert_eq!(envelope.meta.started_at, Some(started_at));
+            let persisted = storage
+                .get_job(&envelope.id)
+                .await?
+                .expect("job should exist");
+            assert_eq!(persisted.meta.started_at, Some(started_at));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_finish_with_success_batch() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        let envelopes = vec![
+            JobEnvelope::new(queue.clone(), TestJob {})?,
+            JobEnvelope::new(queue.clone(), TestJob {})?,
+        ];
+        for envelope in &envelopes {
+            storage.enqueue(envelope.clone()).await?;
+        }
+
+        for envelope in &envelopes {
+            assert_eq!(storage.dequeue(&queue).await?, Some(envelope.id.clone()));
+        }
+
+        let mut redis = storage.connection().await?;
+        let processing_before: Vec<JobId> = (*redis)
+            .lrange(storage.current_processing_queue(), 0, -1)
+            .await?;
+        assert_eq!(processing_before.len(), 2);
+        drop(redis);
+
+        storage.finish_with_success_batch(&envelopes).await?;
+
+        for envelope in &envelopes {
+            assert!(storage.get_job(&envelope.id).await?.is_none());
+        }
+        assert_eq!(storage.enqueued_count(&queue).await?, 0);
+        assert_eq!(storage.jobs_count().await?, 0);
+
+        let mut redis = storage.connection().await?;
+        let processing_after: Vec<JobId> = (*redis)
+            .lrange(storage.current_processing_queue(), 0, -1)
+            .await?;
+        assert!(processing_after.is_empty());
 
         Ok(())
     }

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -4,14 +4,22 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct WorkerBatchConfig {
-    pub size: usize,
-    pub timeout: std::time::Duration,
+    size: usize,
+    timeout: std::time::Duration,
 }
 
 impl WorkerBatchConfig {
     pub fn new(size: usize, timeout: std::time::Duration) -> Self {
         assert!(size > 0, "batch size must be greater than zero");
         Self { size, timeout }
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn timeout(&self) -> std::time::Duration {
+        self.timeout
     }
 }
 
@@ -532,8 +540,11 @@ mod tests {
 
         let batch_config = <TestWorkerBatch as oxanus::Worker<TestWorkerBatchJob>>::batch_config()
             .expect("batch attributes should generate worker batch config");
-        assert_eq!(batch_config.size, 25);
-        assert_eq!(batch_config.timeout, std::time::Duration::from_millis(150));
+        assert_eq!(batch_config.size(), 25);
+        assert_eq!(
+            batch_config.timeout(),
+            std::time::Duration::from_millis(150)
+        );
     }
 
     #[tokio::test]

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -2,7 +2,20 @@ use crate::{
     QueueConfig, WorkerConfigKind, context::JobContext, job_envelope::JobConflictStrategy,
 };
 
-pub trait Job: Send + Sync + serde::Serialize {
+#[derive(Debug, Clone)]
+pub struct WorkerBatchConfig {
+    pub size: usize,
+    pub timeout: std::time::Duration,
+}
+
+impl WorkerBatchConfig {
+    pub fn new(size: usize, timeout: std::time::Duration) -> Self {
+        assert!(size > 0, "batch size must be greater than zero");
+        Self { size, timeout }
+    }
+}
+
+pub trait Job: Send + serde::Serialize {
     fn worker_name() -> &'static str
     where
         Self: Sized;
@@ -27,11 +40,17 @@ pub trait Job: Send + Sync + serde::Serialize {
     }
 }
 
+#[derive(Clone)]
+pub struct BatchItem<Args> {
+    pub job: Args,
+    pub ctx: JobContext,
+}
+
 #[async_trait::async_trait]
-pub trait Worker<Args: Send + Sync>: Send + Sync {
+pub trait Worker<Args: Send + 'static>: Send + Sync {
     type Error: std::error::Error + Send + Sync;
 
-    async fn process(&self, job: &Args, ctx: &JobContext) -> Result<(), Self::Error>;
+    async fn run_batch(&self, jobs: Vec<BatchItem<Args>>) -> Result<(), Self::Error>;
 
     fn max_retries(&self, _job: &Args) -> u32 {
         2
@@ -64,6 +83,13 @@ pub trait Worker<Args: Send + Sync>: Send + Sync {
         None
     }
 
+    fn batch_config() -> Option<WorkerBatchConfig>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
     fn to_config() -> WorkerConfigKind
     where
         Self: Sized,
@@ -90,12 +116,13 @@ pub trait FromContext<T> {
 }
 
 #[async_trait::async_trait]
-pub trait Processable: Send + Sync {
+pub trait Processable: Send {
     type Error: std::error::Error + Send + Sync;
 
-    async fn process(&self, ctx: &JobContext) -> Result<(), Self::Error>;
-    fn max_retries(&self) -> u32;
-    fn retry_delay(&self, retries: u32) -> u64;
+    async fn process(self: Box<Self>, contexts: Vec<JobContext>) -> Result<(), Self::Error>;
+    fn len(&self) -> usize;
+    fn max_retries(&self, index: usize) -> u32;
+    fn retry_delay(&self, index: usize, retries: u32) -> u64;
 }
 
 pub type BoxedProcessable<ET> = Box<dyn Processable<Error = ET>>;
@@ -105,24 +132,80 @@ pub(crate) struct BoundJob<W, A> {
     pub job: A,
 }
 
+pub(crate) struct BoundBatchJob<W, A> {
+    pub worker: W,
+    pub jobs: Vec<A>,
+}
+
 #[async_trait::async_trait]
 impl<W, A> Processable for BoundJob<W, A>
 where
     W: Worker<A> + Send + Sync + 'static,
-    A: Send + Sync + 'static,
+    A: Send + 'static,
 {
     type Error = W::Error;
 
-    async fn process(&self, ctx: &JobContext) -> Result<(), Self::Error> {
-        self.worker.process(&self.job, ctx).await
+    async fn process(self: Box<Self>, contexts: Vec<JobContext>) -> Result<(), Self::Error> {
+        assert_eq!(contexts.len(), 1, "single job must have one context");
+        let ctx = contexts
+            .into_iter()
+            .next()
+            .expect("single job context exists after length check");
+        self.worker
+            .run_batch(vec![BatchItem { job: self.job, ctx }])
+            .await
     }
 
-    fn max_retries(&self) -> u32 {
+    fn len(&self) -> usize {
+        1
+    }
+
+    fn max_retries(&self, index: usize) -> u32 {
+        assert_eq!(index, 0, "single job index must be zero");
         self.worker.max_retries(&self.job)
     }
 
-    fn retry_delay(&self, retries: u32) -> u64 {
+    fn retry_delay(&self, index: usize, retries: u32) -> u64 {
+        assert_eq!(index, 0, "single job index must be zero");
         self.worker.retry_delay(&self.job, retries)
+    }
+}
+
+#[async_trait::async_trait]
+impl<W, A> Processable for BoundBatchJob<W, A>
+where
+    W: Worker<A> + Send + Sync + 'static,
+    A: Send + 'static,
+{
+    type Error = W::Error;
+
+    async fn process(self: Box<Self>, contexts: Vec<JobContext>) -> Result<(), Self::Error> {
+        assert_eq!(
+            self.jobs.len(),
+            contexts.len(),
+            "batch jobs and contexts must have the same length"
+        );
+        let items = self
+            .jobs
+            .into_iter()
+            .zip(contexts)
+            .map(|(job, ctx)| BatchItem { job, ctx })
+            .collect();
+        self.worker.run_batch(items).await
+    }
+
+    fn len(&self) -> usize {
+        self.jobs.len()
+    }
+
+    fn max_retries(&self, index: usize) -> u32 {
+        let job = self.jobs.get(index).expect("batch job index out of bounds");
+        self.worker.max_retries(job)
+    }
+
+    fn retry_delay(&self, index: usize, retries: u32) -> u64 {
+        let job = self.jobs.get(index).expect("batch job index out of bounds");
+        self.worker.retry_delay(job, retries)
     }
 }
 
@@ -156,7 +239,7 @@ mod tests {
         impl TestWorker {
             async fn process(
                 &self,
-                _job: &TestJob,
+                _job: TestJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -181,7 +264,7 @@ mod tests {
         impl TestWorkerCustomError {
             async fn process(
                 &self,
-                _job: &TestWorkerCustomErrorJob,
+                _job: TestWorkerCustomErrorJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), std::fmt::Error> {
                 use std::fmt::Write;
@@ -224,7 +307,7 @@ mod tests {
         impl TestWorkerUniqueId {
             async fn process(
                 &self,
-                _job: &TestWorkerUniqueIdJob,
+                _job: TestWorkerUniqueIdJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -266,7 +349,7 @@ mod tests {
         impl TestWorkerNestedUniqueId {
             async fn process(
                 &self,
-                _job: &TestWorkerNestedUniqueIdJob,
+                _job: TestWorkerNestedUniqueIdJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -320,7 +403,7 @@ mod tests {
         impl TestWorkerCustomUniqueId {
             async fn process(
                 &self,
-                _job: &TestWorkerCustomUniqueIdJob,
+                _job: TestWorkerCustomUniqueIdJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -408,7 +491,7 @@ mod tests {
         impl TestWorkerExplicitJobHooks {
             async fn process(
                 &self,
-                _job: &TestWorkerExplicitJobHooksJob,
+                _job: TestWorkerExplicitJobHooksJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -427,6 +510,30 @@ mod tests {
         )
         .expect("explicit job hook paths should still populate the envelope");
         assert_eq!(explicit_envelope.meta.throttle_cost, Some(11));
+
+        #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+        #[oxanus(worker = TestWorkerBatch)]
+        struct TestWorkerBatchJob {
+            value: u32,
+        }
+
+        #[derive(oxanus::Worker)]
+        #[oxanus(batch_size = 25, batch_timeout_ms = 150)]
+        struct TestWorkerBatch;
+
+        impl TestWorkerBatch {
+            async fn process_batch(
+                &self,
+                _jobs: Vec<oxanus::BatchItem<TestWorkerBatchJob>>,
+            ) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        let batch_config = <TestWorkerBatch as oxanus::Worker<TestWorkerBatchJob>>::batch_config()
+            .expect("batch attributes should generate worker batch config");
+        assert_eq!(batch_config.size, 25);
+        assert_eq!(batch_config.timeout, std::time::Duration::from_millis(150));
     }
 
     #[tokio::test]
@@ -448,7 +555,7 @@ mod tests {
         impl TestCronWorker {
             async fn process(
                 &self,
-                _job: &TestCronJob,
+                _job: TestCronJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -481,7 +588,7 @@ mod tests {
         impl NoResurrectWorker {
             async fn process(
                 &self,
-                _job: &NoResurrectJob,
+                _job: NoResurrectJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())
@@ -499,7 +606,7 @@ mod tests {
         impl DefaultResurrectWorker {
             async fn process(
                 &self,
-                _job: &DefaultResurrectJob,
+                _job: DefaultResurrectJob,
                 _ctx: &oxanus::JobContext,
             ) -> Result<(), WorkerError> {
                 Ok(())

--- a/oxanus/src/worker_registry.rs
+++ b/oxanus/src/worker_registry.rs
@@ -1,20 +1,35 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use crate::WorkerBatchConfig;
 use crate::error::OxanusError;
-use crate::worker::{BoundJob, BoxedProcessable, FromContext, Worker};
+use crate::worker::{BoundBatchJob, BoundJob, BoxedProcessable, FromContext, Worker};
 
-pub(crate) type JobFactory<DT, ET> =
+pub type JobFactory<DT, ET> =
     fn(serde_json::Value, &DT) -> Result<BoxedProcessable<ET>, OxanusError>;
+pub type JobBatchFactory<DT, ET> =
+    fn(Vec<serde_json::Value>, &DT) -> Result<BatchBuild<ET>, OxanusError>;
+
+pub struct BatchBuild<ET> {
+    pub job: Option<BoxedProcessable<ET>>,
+    pub invalid: Vec<InvalidBatchJob>,
+}
+
+pub struct InvalidBatchJob {
+    pub index: usize,
+    pub error: String,
+}
 
 pub struct WorkerRegistry<DT, ET> {
-    jobs: HashMap<String, JobFactory<DT, ET>>,
+    jobs: HashMap<String, WorkerFactories<DT, ET>>,
     pub schedules: HashMap<String, CronJob>,
 }
 
 pub struct WorkerConfig<DT, ET> {
     pub name: String,
     pub factory: JobFactory<DT, ET>,
+    pub batch_factory: JobBatchFactory<DT, ET>,
+    pub batch_config: Option<WorkerBatchConfig>,
     pub kind: WorkerConfigKind,
 }
 
@@ -40,13 +55,53 @@ pub fn job_factory<W, A, DT, ET>(
 ) -> Result<BoxedProcessable<ET>, OxanusError>
 where
     W: Worker<A, Error = ET> + FromContext<DT> + 'static,
-    A: serde::de::DeserializeOwned + Send + Sync + 'static,
+    A: serde::de::DeserializeOwned + Send + 'static,
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
     let job: A = serde_json::from_value(value)?;
     let worker = W::from_context(ctx);
     Ok(Box::new(BoundJob { worker, job }))
+}
+
+pub fn job_batch_factory<W, A, DT, ET>(
+    values: Vec<serde_json::Value>,
+    ctx: &DT,
+) -> Result<BatchBuild<ET>, OxanusError>
+where
+    W: Worker<A, Error = ET> + FromContext<DT> + 'static,
+    A: serde::de::DeserializeOwned + Send + 'static,
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let mut jobs = Vec::with_capacity(values.len());
+    let mut invalid = Vec::new();
+
+    for (index, value) in values.into_iter().enumerate() {
+        match serde_json::from_value(value) {
+            Ok(job) => jobs.push(job),
+            Err(error) => invalid.push(InvalidBatchJob {
+                index,
+                error: error.to_string(),
+            }),
+        }
+    }
+
+    if jobs.is_empty() {
+        return Ok(BatchBuild { job: None, invalid });
+    }
+
+    let worker = W::from_context(ctx);
+    Ok(BatchBuild {
+        job: Some(Box::new(BoundBatchJob { worker, jobs })),
+        invalid,
+    })
+}
+
+struct WorkerFactories<DT, ET> {
+    factory: JobFactory<DT, ET>,
+    batch_factory: JobBatchFactory<DT, ET>,
+    batch_config: Option<WorkerBatchConfig>,
 }
 
 impl<DT, ET> WorkerRegistry<DT, ET> {
@@ -58,16 +113,22 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
     }
 
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT, ET>) {
+        let factories = WorkerFactories {
+            factory: config.factory,
+            batch_factory: config.batch_factory,
+            batch_config: config.batch_config,
+        };
+
         match config.kind {
             WorkerConfigKind::Normal => {
-                self.jobs.insert(config.name, config.factory);
+                self.jobs.insert(config.name, factories);
             }
             WorkerConfigKind::Cron {
                 schedule,
                 queue_key,
                 resurrect,
             } => {
-                self.jobs.insert(config.name.clone(), config.factory);
+                self.jobs.insert(config.name.clone(), factories);
 
                 let schedule = cron::Schedule::from_str(&schedule).unwrap_or_else(|_| {
                     panic!("{}: Invalid cron schedule: {schedule}", config.name)
@@ -97,6 +158,12 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
         self.schedules.contains_key(name)
     }
 
+    pub(crate) fn batch_config(&self, name: &str) -> Option<WorkerBatchConfig> {
+        self.jobs
+            .get(name)
+            .and_then(|factories| factories.batch_config.clone())
+    }
+
     pub fn build(
         &self,
         name: &str,
@@ -107,10 +174,28 @@ impl<DT, ET> WorkerRegistry<DT, ET> {
             .jobs
             .get(name)
             .ok_or_else(|| OxanusError::GenericError(format!("Job type {name} not registered")))?;
-        match factory(json, ctx) {
+        match (factory.factory)(json, ctx) {
             Ok(job) => Ok(job),
             Err(e) => Err(OxanusError::JobFactoryError(format!(
                 "Failed to build job {name}: {e}"
+            ))),
+        }
+    }
+
+    pub(crate) fn build_batch(
+        &self,
+        name: &str,
+        json: Vec<serde_json::Value>,
+        ctx: &DT,
+    ) -> Result<BatchBuild<ET>, OxanusError> {
+        let factories = self
+            .jobs
+            .get(name)
+            .ok_or_else(|| OxanusError::GenericError(format!("Job type {name} not registered")))?;
+        match (factories.batch_factory)(json, ctx) {
+            Ok(job) => Ok(job),
+            Err(e) => Err(OxanusError::JobFactoryError(format!(
+                "Failed to build job batch {name}: {e}"
             ))),
         }
     }

--- a/oxanus/tests/compile_fail.rs
+++ b/oxanus/tests/compile_fail.rs
@@ -1,0 +1,8 @@
+#[test]
+fn batch_worker_requires_process_batch_hook() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/batch_missing_process_batch.rs");
+    t.compile_fail("tests/ui/batch_size_requires_timeout.rs");
+    t.compile_fail("tests/ui/batch_size_zero.rs");
+    t.compile_fail("tests/ui/batch_timeout_requires_size.rs");
+}

--- a/oxanus/tests/integration/batch.rs
+++ b/oxanus/tests/integration/batch.rs
@@ -1,0 +1,518 @@
+use crate::shared::*;
+use deadpool_redis::redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use testresult::TestResult;
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct FooBatchJob {
+    values_key: String,
+    calls_key: String,
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 3, batch_timeout_ms = 100)]
+struct FooBatchWorker {
+    state: WorkerState,
+}
+
+impl FooBatchWorker {
+    async fn process_batch(
+        &self,
+        jobs: Vec<oxanus::BatchItem<FooBatchJob>>,
+    ) -> Result<(), WorkerError> {
+        if let Some(first) = jobs.first() {
+            let mut redis = self.state.redis.get().await?;
+            let values = jobs
+                .iter()
+                .map(|item| item.job.value.clone())
+                .collect::<Vec<_>>();
+            let _: usize = redis.rpush(&first.job.values_key, values).await?;
+            let _: i64 = redis.incr(&first.job.calls_key, 1).await?;
+            let _: bool = redis.expire(&first.job.values_key, 3).await?;
+            let _: bool = redis.expire(&first.job.calls_key, 3).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = ContextBatchWorker)]
+struct ContextBatchJob {
+    seen_key: String,
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 2, batch_timeout_ms = 100)]
+struct ContextBatchWorker {
+    state: WorkerState,
+}
+
+impl ContextBatchWorker {
+    async fn process_batch(
+        &self,
+        jobs: Vec<oxanus::BatchItem<ContextBatchJob>>,
+    ) -> Result<(), WorkerError> {
+        let mut redis = self.state.redis.get().await?;
+        for oxanus::BatchItem { job, ctx } in jobs {
+            let _: usize = redis.hset(&job.seen_key, job.value, ctx.meta.id).await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = RetryBatchWorker)]
+struct RetryBatchJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError)]
+#[oxanus(registry = None)]
+#[oxanus(max_retries = 1, retry_delay = 0)]
+#[oxanus(batch_size = 2, batch_timeout_ms = 100)]
+struct RetryBatchWorker;
+
+impl RetryBatchWorker {
+    async fn process_batch(
+        &self,
+        jobs: Vec<oxanus::BatchItem<RetryBatchJob>>,
+    ) -> Result<(), WorkerError> {
+        if jobs.iter().any(|item| item.ctx.meta.retries == 0) {
+            return Err(WorkerError::Generic("retry batch once".to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = PanicBatchWorker)]
+struct PanicBatchJob {}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError)]
+#[oxanus(registry = None)]
+#[oxanus(max_retries = 0)]
+#[oxanus(batch_size = 2, batch_timeout_ms = 100)]
+struct PanicBatchWorker;
+
+impl PanicBatchWorker {
+    async fn process_batch(
+        &self,
+        _jobs: Vec<oxanus::BatchItem<PanicBatchJob>>,
+    ) -> Result<(), WorkerError> {
+        panic!("batch panic");
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+#[oxanus(worker = SizingBatchWorker)]
+struct SizingBatchJob {
+    sizes_key: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(context = WorkerState, error = WorkerError)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 2, batch_timeout_ms = 100)]
+struct SizingBatchWorker {
+    state: WorkerState,
+}
+
+impl SizingBatchWorker {
+    async fn process_batch(
+        &self,
+        jobs: Vec<oxanus::BatchItem<SizingBatchJob>>,
+    ) -> Result<(), WorkerError> {
+        if let Some(first) = jobs.first() {
+            let mut redis = self.state.redis.get().await?;
+            let _: usize = redis.rpush(&first.job.sizes_key, jobs.len()).await?;
+            let _: bool = redis.expire(&first.job.sizes_key, 3).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct QueueBatch;
+
+impl oxanus::Queue for QueueBatch {
+    fn to_config() -> oxanus::QueueConfig {
+        oxanus::QueueConfig::as_static("batch").concurrency(3)
+    }
+}
+
+#[derive(Serialize)]
+struct QueueBatchHighConcurrency;
+
+impl oxanus::Queue for QueueBatchHighConcurrency {
+    fn to_config() -> oxanus::QueueConfig {
+        oxanus::QueueConfig::as_static("batch_high_concurrency").concurrency(5)
+    }
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_processes_full_batch_once() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<FooBatchWorker, FooBatchJob>()
+        .exit_when_processed(3);
+
+    let values_key = uuid::Uuid::new_v4().to_string();
+    let calls_key = uuid::Uuid::new_v4().to_string();
+
+    for value in ["a", "b", "c"] {
+        storage
+            .enqueue(
+                QueueBatch,
+                FooBatchJob {
+                    values_key: values_key.clone(),
+                    calls_key: calls_key.clone(),
+                    value: value.to_string(),
+                },
+            )
+            .await?;
+    }
+
+    oxanus::run(config, ctx).await?;
+
+    let calls: Option<i64> = redis_conn.get(calls_key).await?;
+    let values: Vec<String> = redis_conn.lrange(values_key, 0, -1).await?;
+
+    assert_eq!(calls, Some(1));
+    assert_eq!(values.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_flushes_partial_batch_after_timeout() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<FooBatchWorker, FooBatchJob>()
+        .exit_when_processed(2);
+
+    let values_key = uuid::Uuid::new_v4().to_string();
+    let calls_key = uuid::Uuid::new_v4().to_string();
+
+    for value in ["a", "b"] {
+        storage
+            .enqueue(
+                QueueBatch,
+                FooBatchJob {
+                    values_key: values_key.clone(),
+                    calls_key: calls_key.clone(),
+                    value: value.to_string(),
+                },
+            )
+            .await?;
+    }
+
+    oxanus::run(config, ctx).await?;
+
+    let calls: Option<i64> = redis_conn.get(calls_key).await?;
+    let values: Vec<String> = redis_conn.lrange(values_key, 0, -1).await?;
+
+    assert_eq!(calls, Some(1));
+    assert_eq!(values.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_kills_only_invalid_jobs_in_mixed_batch() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<FooBatchWorker, FooBatchJob>()
+        .exit_when_processed(2);
+
+    let values_key = uuid::Uuid::new_v4().to_string();
+    let calls_key = uuid::Uuid::new_v4().to_string();
+
+    storage
+        .enqueue_envelope(invalid_batch_envelope(
+            values_key.clone(),
+            calls_key.clone(),
+        ))
+        .await?;
+
+    for value in ["a", "b"] {
+        storage
+            .enqueue(
+                QueueBatch,
+                FooBatchJob {
+                    values_key: values_key.clone(),
+                    calls_key: calls_key.clone(),
+                    value: value.to_string(),
+                },
+            )
+            .await?;
+    }
+
+    oxanus::run(config, ctx).await?;
+
+    let calls: Option<i64> = redis_conn.get(calls_key).await?;
+    let values: Vec<String> = redis_conn.lrange(values_key, 0, -1).await?;
+    let dead = storage
+        .list_dead(&oxanus::QueueListOpts {
+            count: 10,
+            offset: 0,
+        })
+        .await?;
+
+    assert_eq!(calls, Some(1));
+    assert_eq!(values.len(), 2);
+    assert_eq!(dead.len(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_retries_each_job_after_batch_error() -> TestResult {
+    let redis_pool = setup();
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<RetryBatchWorker, RetryBatchJob>()
+        .exit_when_processed(4);
+
+    storage.enqueue(QueueBatch, RetryBatchJob {}).await?;
+    storage.enqueue(QueueBatch, RetryBatchJob {}).await?;
+
+    let stats = oxanus::run(config, ctx).await?;
+
+    assert_eq!(stats.processed, 4);
+    assert_eq!(stats.failed, 2);
+    assert_eq!(stats.succeeded, 2);
+    assert_eq!(stats.panicked, 0);
+    assert_eq!(storage.dead_count().await?, 0);
+    assert_eq!(storage.retries_count().await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_panic_marks_each_job_panicked() -> TestResult {
+    let redis_pool = setup();
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<PanicBatchWorker, PanicBatchJob>()
+        .exit_when_processed(2);
+
+    storage.enqueue(QueueBatch, PanicBatchJob {}).await?;
+    storage.enqueue(QueueBatch, PanicBatchJob {}).await?;
+
+    let stats = oxanus::run(config, ctx).await?;
+
+    assert_eq!(stats.processed, 2);
+    assert_eq!(stats.failed, 2);
+    assert_eq!(stats.panicked, 2);
+    assert_eq!(stats.succeeded, 0);
+    assert_eq!(storage.dead_count().await?, 2);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_never_exceeds_batch_size_with_higher_queue_concurrency() -> TestResult
+{
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatchHighConcurrency>()
+        .register_worker::<SizingBatchWorker, SizingBatchJob>()
+        .exit_when_processed(5);
+
+    let sizes_key = uuid::Uuid::new_v4().to_string();
+    for _ in 0..5 {
+        storage
+            .enqueue(
+                QueueBatchHighConcurrency,
+                SizingBatchJob {
+                    sizes_key: sizes_key.clone(),
+                },
+            )
+            .await?;
+    }
+
+    oxanus::run(config, ctx).await?;
+
+    let sizes: Vec<usize> = redis_conn.lrange(sizes_key, 0, -1).await?;
+
+    assert!(sizes.len() > 1);
+    assert_eq!(sizes.iter().sum::<usize>(), 5);
+    assert!(sizes.iter().all(|size| *size <= 2));
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_kills_all_invalid_jobs_without_processing() -> TestResult {
+    let redis_pool = setup();
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<FooBatchWorker, FooBatchJob>()
+        .with_graceful_shutdown(async {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            Ok(())
+        });
+
+    let values_key = uuid::Uuid::new_v4().to_string();
+    let calls_key = uuid::Uuid::new_v4().to_string();
+
+    for _ in 0..3 {
+        storage
+            .enqueue_envelope(invalid_batch_envelope(
+                values_key.clone(),
+                calls_key.clone(),
+            ))
+            .await?;
+    }
+
+    let stats = oxanus::run(config, ctx).await?;
+
+    assert_eq!(stats.processed, 0);
+    assert_eq!(storage.dead_count().await?, 3);
+    assert_eq!(storage.enqueued_count(QueueBatch).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_batch_worker_receives_context_per_job() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxanus::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxanus::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxanus::Config::new(&storage)
+        .register_queue::<QueueBatch>()
+        .register_worker::<ContextBatchWorker, ContextBatchJob>()
+        .exit_when_processed(2);
+
+    let seen_key = uuid::Uuid::new_v4().to_string();
+    let first_id = storage
+        .enqueue(
+            QueueBatch,
+            ContextBatchJob {
+                seen_key: seen_key.clone(),
+                value: "first".to_string(),
+            },
+        )
+        .await?;
+    let second_id = storage
+        .enqueue(
+            QueueBatch,
+            ContextBatchJob {
+                seen_key: seen_key.clone(),
+                value: "second".to_string(),
+            },
+        )
+        .await?;
+
+    oxanus::run(config, ctx).await?;
+
+    let first_seen: Option<String> = redis_conn.hget(&seen_key, "first").await?;
+    let second_seen: Option<String> = redis_conn.hget(&seen_key, "second").await?;
+
+    assert_eq!(first_seen, Some(first_id));
+    assert_eq!(second_seen, Some(second_id));
+
+    Ok(())
+}
+
+fn invalid_batch_envelope(values_key: String, calls_key: String) -> oxanus::JobEnvelope {
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().timestamp_micros();
+
+    oxanus::JobEnvelope {
+        id: id.clone(),
+        queue: "batch".to_string(),
+        job: oxanus::JobData {
+            name: std::any::type_name::<FooBatchWorker>().to_string(),
+            args: serde_json::json!({
+                "values_key": values_key,
+                "calls_key": calls_key
+            }),
+        },
+        meta: oxanus::JobMeta {
+            id,
+            retries: 0,
+            unique: false,
+            on_conflict: None,
+            created_at: now,
+            scheduled_at: now,
+            started_at: None,
+            state: None,
+            resurrect: true,
+            error: None,
+            throttle_cost: None,
+        },
+    }
+}

--- a/oxanus/tests/integration/cron.rs
+++ b/oxanus/tests/integration/cron.rs
@@ -27,13 +27,14 @@ impl oxanus::FromContext<WorkerState> for CronWorkerRedisCounter {
 impl oxanus::Worker<CronWorkerRedisCounterJob> for CronWorkerRedisCounter {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        _job: &CronWorkerRedisCounterJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<CronWorkerRedisCounterJob>>,
     ) -> Result<(), WorkerError> {
         let mut redis = self.state.redis.get().await?;
-        let _: () = redis.incr("cron:counter", 1).await?;
+        for _item in jobs {
+            let _: () = redis.incr("cron:counter", 1).await?;
+        }
         Ok(())
     }
 

--- a/oxanus/tests/integration/dead.rs
+++ b/oxanus/tests/integration/dead.rs
@@ -24,10 +24,9 @@ impl oxanus::FromContext<()> for WorkerFail {
 impl oxanus::Worker<WorkerFailJob> for WorkerFail {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        _job: &WorkerFailJob,
-        _ctx: &oxanus::JobContext,
+        _jobs: Vec<oxanus::BatchItem<WorkerFailJob>>,
     ) -> Result<(), WorkerError> {
         Err(WorkerError::Generic(
             "I have nothing to live for...".to_string(),

--- a/oxanus/tests/integration/main.rs
+++ b/oxanus/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod batch;
 mod cron;
 mod dead;
 mod drain;

--- a/oxanus/tests/integration/panic.rs
+++ b/oxanus/tests/integration/panic.rs
@@ -23,10 +23,9 @@ impl oxanus::FromContext<()> for WorkerPanic {
 impl oxanus::Worker<WorkerPanicJob> for WorkerPanic {
     type Error = std::io::Error;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        _job: &WorkerPanicJob,
-        _ctx: &oxanus::JobContext,
+        _jobs: Vec<oxanus::BatchItem<WorkerPanicJob>>,
     ) -> Result<(), std::io::Error> {
         panic!("test panic");
     }

--- a/oxanus/tests/integration/registry.rs
+++ b/oxanus/tests/integration/registry.rs
@@ -24,7 +24,7 @@ pub struct WorkerCounter {
 impl WorkerCounter {
     async fn process(
         &self,
-        job: &WorkerCounterJob,
+        job: WorkerCounterJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         let mut redis = self.ctx.redis.get().await?;
@@ -46,7 +46,7 @@ pub struct CronWorkerCounter {
 impl CronWorkerCounter {
     async fn process(
         &self,
-        _job: &CronWorkerCounterJob,
+        _job: CronWorkerCounterJob,
         _ctx: &oxanus::JobContext,
     ) -> Result<(), WorkerError> {
         let mut redis = self.ctx.redis.get().await?;

--- a/oxanus/tests/integration/retry.rs
+++ b/oxanus/tests/integration/retry.rs
@@ -31,19 +31,22 @@ impl oxanus::FromContext<WorkerState> for WorkerRedisSetWithRetry {
 impl oxanus::Worker<WorkerRedisSetWithRetryJob> for WorkerRedisSetWithRetry {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        job: &WorkerRedisSetWithRetryJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<WorkerRedisSetWithRetryJob>>,
     ) -> Result<(), WorkerError> {
         let mut redis = self.state.redis.get().await?;
-        let value: Option<String> = redis.get(&job.key).await?;
-        if value.is_some() {
-            let _: () = redis.set_ex(&job.key, job.value_second.clone(), 3).await?;
-            return Ok(());
+        for item in jobs {
+            let job = item.job;
+            let value: Option<String> = redis.get(&job.key).await?;
+            if value.is_some() {
+                let _: () = redis.set_ex(&job.key, job.value_second, 3).await?;
+                continue;
+            }
+            let _: () = redis.set_ex(&job.key, job.value_first, 3).await?;
+            return Err(WorkerError::Generic("Key not set".to_string()));
         }
-        let _: () = redis.set_ex(&job.key, job.value_first.clone(), 3).await?;
-        Err(WorkerError::Generic("Key not set".to_string()))
+        Ok(())
     }
 
     fn retry_delay(&self, _job: &WorkerRedisSetWithRetryJob, _retries: u32) -> u64 {

--- a/oxanus/tests/integration/shared.rs
+++ b/oxanus/tests/integration/shared.rs
@@ -27,10 +27,9 @@ pub struct WorkerNoop;
 impl oxanus::Worker<WorkerNoopJob> for WorkerNoop {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        _job: &WorkerNoopJob,
-        _ctx: &oxanus::JobContext,
+        _jobs: Vec<oxanus::BatchItem<WorkerNoopJob>>,
     ) -> Result<(), WorkerError> {
         Ok(())
     }
@@ -62,13 +61,15 @@ pub struct WorkerRedisSet {
 impl oxanus::Worker<WorkerRedisSetJob> for WorkerRedisSet {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        job: &WorkerRedisSetJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<WorkerRedisSetJob>>,
     ) -> Result<(), WorkerError> {
         let mut redis = self.state.redis.get().await?;
-        let _: () = redis.set_ex(&job.key, job.value.clone(), 3).await?;
+        for item in jobs {
+            let job = item.job;
+            let _: () = redis.set_ex(&job.key, job.value, 3).await?;
+        }
         Ok(())
     }
 }

--- a/oxanus/tests/integration/unique.rs
+++ b/oxanus/tests/integration/unique.rs
@@ -37,13 +37,15 @@ impl oxanus::FromContext<WorkerState> for WorkerUniqueSkip {
 impl oxanus::Worker<WorkerUniqueSkipJob> for WorkerUniqueSkip {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        job: &WorkerUniqueSkipJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<WorkerUniqueSkipJob>>,
     ) -> Result<(), WorkerError> {
         let mut redis = self.state.redis.get().await?;
-        let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
+        for item in jobs {
+            let job = item.job;
+            let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
+        }
         Ok(())
     }
 
@@ -88,13 +90,15 @@ impl oxanus::FromContext<WorkerState> for WorkerUniqueReplace {
 impl oxanus::Worker<WorkerUniqueReplaceJob> for WorkerUniqueReplace {
     type Error = WorkerError;
 
-    async fn process(
+    async fn run_batch(
         &self,
-        job: &WorkerUniqueReplaceJob,
-        _ctx: &oxanus::JobContext,
+        jobs: Vec<oxanus::BatchItem<WorkerUniqueReplaceJob>>,
     ) -> Result<(), WorkerError> {
         let mut redis = self.state.redis.get().await?;
-        let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
+        for item in jobs {
+            let job = item.job;
+            let _: () = redis.set_ex(&job.key, job.value.to_string(), 3).await?;
+        }
         Ok(())
     }
 

--- a/oxanus/tests/ui/batch_missing_process_batch.rs
+++ b/oxanus/tests/ui/batch_missing_process_batch.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct WorkerContext;
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct MissingProcessBatchJob {
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 2, batch_timeout_ms = 100)]
+struct MissingProcessBatchWorker;
+
+fn main() {}

--- a/oxanus/tests/ui/batch_missing_process_batch.stderr
+++ b/oxanus/tests/ui/batch_missing_process_batch.stderr
@@ -1,0 +1,7 @@
+error[E0599]: no method named `process_batch` found for reference `&MissingProcessBatchWorker` in the current scope
+  --> tests/ui/batch_missing_process_batch.rs:14:10
+   |
+14 | #[derive(oxanus::Worker)]
+   |          ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `oxanus::Worker` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/oxanus/tests/ui/batch_size_requires_timeout.rs
+++ b/oxanus/tests/ui/batch_size_requires_timeout.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct WorkerContext;
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct MissingTimeoutJob {
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 2)]
+struct MissingTimeoutWorker;
+
+impl MissingTimeoutWorker {
+    async fn process_batch(
+        &self,
+        _jobs: Vec<oxanus::BatchItem<MissingTimeoutJob>>,
+    ) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/oxanus/tests/ui/batch_size_requires_timeout.stderr
+++ b/oxanus/tests/ui/batch_size_requires_timeout.stderr
@@ -1,0 +1,5 @@
+error: batch_size requires batch_timeout_ms
+  --> tests/ui/batch_size_requires_timeout.rs:17:8
+   |
+17 | struct MissingTimeoutWorker;
+   |        ^^^^^^^^^^^^^^^^^^^^

--- a/oxanus/tests/ui/batch_size_zero.rs
+++ b/oxanus/tests/ui/batch_size_zero.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct WorkerContext;
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct ZeroBatchSizeJob {
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(registry = None)]
+#[oxanus(batch_size = 0, batch_timeout_ms = 100)]
+struct ZeroBatchSizeWorker;
+
+impl ZeroBatchSizeWorker {
+    async fn process_batch(
+        &self,
+        _jobs: Vec<oxanus::BatchItem<ZeroBatchSizeJob>>,
+    ) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/oxanus/tests/ui/batch_size_zero.stderr
+++ b/oxanus/tests/ui/batch_size_zero.stderr
@@ -1,0 +1,5 @@
+error: batch_size must be greater than zero
+  --> tests/ui/batch_size_zero.rs:17:8
+   |
+17 | struct ZeroBatchSizeWorker;
+   |        ^^^^^^^^^^^^^^^^^^^

--- a/oxanus/tests/ui/batch_timeout_requires_size.rs
+++ b/oxanus/tests/ui/batch_timeout_requires_size.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct WorkerContext;
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+struct MissingBatchSizeJob {
+    value: String,
+}
+
+#[derive(oxanus::Worker)]
+#[oxanus(registry = None)]
+#[oxanus(batch_timeout_ms = 100)]
+struct MissingBatchSizeWorker;
+
+impl MissingBatchSizeWorker {
+    async fn process_batch(
+        &self,
+        _jobs: Vec<oxanus::BatchItem<MissingBatchSizeJob>>,
+    ) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/oxanus/tests/ui/batch_timeout_requires_size.stderr
+++ b/oxanus/tests/ui/batch_timeout_requires_size.stderr
@@ -1,0 +1,5 @@
+error: batch_timeout_ms requires batch_size
+  --> tests/ui/batch_timeout_requires_size.rs:17:8
+   |
+17 | struct MissingBatchSizeWorker;
+   |        ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Adds optional batch workers via `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]`.

- Introduces `BatchItem<Job>` so each job payload stays paired with its own `JobContext`.
- Routes worker execution through the batch path while keeping ergonomic macro hooks: `process(job, ctx)` for single-job workers and `process_batch(items)` for batch workers.
- Adds queue batchers that flush on size, timeout, cancellation, or channel close.
- Adds batched Redis started-at and success cleanup helpers.
- Handles mixed valid/invalid batch payloads by killing malformed jobs while processing valid ones.

## Notes

This is a breaking Rust API change: workers now own job values, and the runtime trait method is `run_batch`.

Batch results are all-or-nothing from Oxanus's perspective: `Ok(())` succeeds every job in the batch; errors or panics retry/fail every job in that batch.

## Tests

- `cargo fmt --all`
- `cargo check --all`
- `cargo test --workspace`
- `cargo clippy --all-features --workspace --all-targets -- -D warnings`
- `cargo check -p oxanus --examples --features registry`
- `cargo check -p oxanus-web --example web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a breaking public API change (`Worker` now runs via `run_batch` and owns job values) and rewires the core execution/coordinator/storage paths to support batched processing, impacting retries, shutdown, and job lifecycle semantics.
> 
> **Overview**
> Adds first-class *batch worker* support via `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]`, new `BatchItem`/`WorkerBatchConfig`, and a `process_batch` hook, while keeping single-job workers working via a generated per-item loop.
> 
> Refactors core runtime plumbing to route all execution through the batched `Processable` path: `Worker` now exposes `run_batch`, jobs are passed by value (dropping the `Sync` bound), and the coordinator batches dequeued jobs per `(queue, worker)` with flush-on-size/timeout/cancel semantics and per-job result propagation.
> 
> Extends registry/config/storage to support batch factories/config and batched persistence updates (`set_started_at_batch`, `finish_with_success_batch`), and adds compile-fail + integration tests plus a new `examples/batch.rs` demonstrating end-to-end behavior (including mixed valid/invalid payload handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8900c7aeb554c17b563a079cee9b9f76bbf862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->