### PR TITLE
Improve metrics worker labels

### DIFF
--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -120,6 +120,10 @@ pub(crate) struct MetricsTemplate {
 }
 
 impl MetricsTemplate {
+    pub fn metric_identity_label(&self, identity: &oxanus::MetricIdentity) -> String {
+        metric_identity_label(identity)
+    }
+
     pub fn execution_chart_data_json(&self) -> String {
         self.summary_chart_data_json(|point| point.execution_ms as f64 / 1000.0)
     }
@@ -143,6 +147,7 @@ impl MetricsTemplate {
                 let data: Vec<f64> = worker.series.iter().map(&value).collect();
                 serde_json::json!({
                     "label": metric_identity_label(&worker.identity),
+                    "fullLabel": worker.identity.worker,
                     "data": data,
                 })
             })

--- a/oxanus-web/templates/metric_detail.html
+++ b/oxanus-web/templates/metric_detail.html
@@ -63,30 +63,30 @@
 
         <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
                 <div class="text-2xl font-semibold text-green-400">{{ metrics.totals.processed|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
                 <div class="text-2xl font-semibold text-red-400">{{ metrics.totals.failed|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded</div>
                 <div class="text-2xl font-semibold text-emerald-400">{{ metrics.totals.succeeded|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Total Execution Time</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Total Time</div>
                 <div class="text-2xl font-semibold text-blue-400">{{ metrics.totals.execution_ms|format_duration_ms }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Avg Execution Time</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Avg Time</div>
                 <div class="text-2xl font-semibold text-purple-400">{{ metrics.totals.average_execution_ms()|format_duration_ms_f64 }}</div>
             </div>
         </div>
 
         <section class="space-y-6 mb-10">
             <div>
-                <h2 class="text-lg font-semibold mb-4">Average Execution Time</h2>
+                <h2 class="text-lg font-semibold mb-4">Average Time</h2>
                 <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
                     <div id="average-chart" class="w-full h-[300px]"></div>
                 </div>

--- a/oxanus-web/templates/metrics.html
+++ b/oxanus-web/templates/metrics.html
@@ -59,23 +59,23 @@
 
         <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
                 <div class="text-2xl font-semibold text-green-400">{{ metrics.totals.processed|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
                 <div class="text-2xl font-semibold text-red-400">{{ metrics.totals.failed|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded Jobs</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded</div>
                 <div class="text-2xl font-semibold text-emerald-400">{{ metrics.totals.succeeded|format_number_u64 }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Total Execution Time</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Total Time</div>
                 <div class="text-2xl font-semibold text-blue-400">{{ metrics.totals.execution_ms|format_duration_ms }}</div>
             </div>
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Avg Execution Time</div>
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Avg Time</div>
                 <div class="text-2xl font-semibold text-purple-400">{{ metrics.totals.average_execution_ms()|format_duration_ms_f64 }}</div>
             </div>
         </div>
@@ -83,7 +83,7 @@
         <section class="space-y-6 mb-10">
             <div>
                 <div class="flex items-center justify-between mb-4">
-                    <h2 class="text-lg font-semibold">Total Execution Time</h2>
+                    <h2 class="text-lg font-semibold">Total Time</h2>
                 </div>
                 <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
                     <div id="execution-chart-key" class="mb-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-400"></div>
@@ -92,7 +92,7 @@
             </div>
             <div>
                 <div class="flex items-center justify-between mb-4">
-                    <h2 class="text-lg font-semibold">Total Processed Jobs</h2>
+                    <h2 class="text-lg font-semibold">Total Processed</h2>
                 </div>
                 <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
                     <div id="processed-chart-key" class="mb-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-400"></div>
@@ -113,18 +113,18 @@
                     <thead>
                         <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
                             <th class="pb-3 pr-4">Worker</th>
-                            <th class="pb-3 pr-4 text-right">Processed Jobs</th>
-                            <th class="pb-3 pr-4 text-right">Succeeded Jobs</th>
-                            <th class="pb-3 pr-4 text-right">Failed Jobs</th>
-                            <th class="pb-3 pr-4 text-right">Total Execution Time</th>
-                            <th class="pb-3 text-right">Avg Execution Time</th>
+                            <th class="pb-3 pr-4 text-right">Processed</th>
+                            <th class="pb-3 pr-4 text-right">Succeeded</th>
+                            <th class="pb-3 pr-4 text-right">Failed</th>
+                            <th class="pb-3 pr-4 text-right">Total Time</th>
+                            <th class="pb-3 text-right">Avg Time</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for row in &metrics.workers %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">
-                                <a href="{{ base_path }}/metrics/job?worker={{ row.identity.worker|urlencode }}&amp;minutes={{ metrics.minutes }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ row.identity.worker }}</a>
+                                <a href="{{ base_path }}/metrics/job?worker={{ row.identity.worker|urlencode }}&amp;minutes={{ metrics.minutes }}" title="{{ row.identity.worker }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ self.metric_identity_label(&row.identity) }}</a>
                             </td>
                             <td class="py-3 pr-4 text-right text-green-400">{{ row.totals.processed|format_number_u64 }}</td>
                             <td class="py-3 pr-4 text-right text-emerald-400">{{ row.totals.succeeded|format_number_u64 }}</td>
@@ -190,6 +190,7 @@
                 payload.series.forEach(function (series, index) {
                     var item = document.createElement('span');
                     item.className = 'inline-flex min-w-0 items-center gap-2';
+                    item.title = series.fullLabel || series.label;
 
                     var swatch = document.createElement('span');
                     swatch.className = 'h-2 w-2 shrink-0 rounded-full';
@@ -235,7 +236,7 @@
                         var row = document.createElement('div');
                         var label = document.createElement('span');
                         label.className = 'chart-tooltip-label';
-                        label.textContent = series.label + ': ';
+                        label.textContent = (series.fullLabel || series.label) + ': ';
                         label.style.color = seriesColor(seriesIdx);
                         row.appendChild(label);
                         row.append(formatter(series.data[idx] || 0));
@@ -351,7 +352,7 @@
                 svg.setAttribute('width', '100%');
                 svg.setAttribute('height', height.toString());
                 svg.setAttribute('role', 'img');
-                svg.setAttribute('aria-label', 'Total processed jobs by worker');
+                svg.setAttribute('aria-label', 'Total processed by worker');
                 chartEl.appendChild(svg);
 
                 for (var tick = 0; tick <= 4; tick += 1) {
@@ -442,7 +443,7 @@
                         var row = document.createElement('div');
                         var label = document.createElement('span');
                         label.className = 'chart-tooltip-label';
-                        label.textContent = series.label + ': ';
+                        label.textContent = (series.fullLabel || series.label) + ': ';
                         label.style.color = seriesColor(seriesIdx);
                         row.appendChild(label);
                         row.append(formatCount(series.data[idx] || 0));


### PR DESCRIPTION
## Summary
- Show short worker names on the metrics workers table, with full paths available on hover.
- Preserve full worker paths in chart hover tooltips and legend titles.
- Shorten repeated metrics labels, for example Processed Jobs -> Processed.

## Verification
- cargo fmt --all
- cargo check -p oxanus-web
- cargo test -p oxanus-web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to metrics templates and chart rendering; no changes to metrics collection or backend logic.
> 
> **Overview**
> Improves the metrics UI by displaying shortened worker names (last `::` segment) in the workers table while preserving the full worker path via link `title` hover text.
> 
> Chart payloads now include both a short `label` and a `fullLabel`, and the legend/tooltip logic prefers `fullLabel` for hover/tooltip display. Also shortens repeated headings/ARIA labels (e.g., “Processed Jobs” → “Processed”, “Execution Time” → “Time”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421aaff77281be870a33b7bbf1e65fa97e11449b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->