### PR TITLE
feat: batch result stats and queue length metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - Add `#[derive(oxanus::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
 - Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
+- Add queue length history metrics and a Queue Lengths chart to the web metrics dashboard.
 
 ### Changed
 
+- Batch result stats writes and active queue length snapshots to reduce Redis calls during job completion and dashboard stats reads.
 - Replace runtime Redis `KEYS` calls with cursor-based `SCAN` for queue discovery and orphaned processing queue recovery.
 - Move job-specific derive attributes (`unique_id`, `on_conflict`, `resurrect`, and `throttle_cost`) from `#[derive(oxanus::Worker)]` to `#[derive(oxanus::Job)]`; `Self::...` in job hooks now resolves to the job type.
 - Change worker execution to own job values and route all worker execution through the batched runtime path; job types no longer need `Sync`.

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -66,15 +66,15 @@ pub(crate) async fn metrics(
     Extension(state): Extension<OxanusWebState>,
     Query(params): Query<MetricsParams>,
 ) -> Result<MetricsTemplate, OxanusWebError> {
-    let metrics = state
-        .storage
-        .job_metrics(oxanus::JobMetricsQuery::new(params.minutes.unwrap_or(0)))
-        .await?;
+    let query = oxanus::JobMetricsQuery::new(params.minutes.unwrap_or(0));
+    let metrics = state.storage.job_metrics(query).await?;
+    let queue_lengths = state.storage.queue_length_metrics(query).await?;
 
     Ok(MetricsTemplate {
         base_path: state.base_path,
         active_tab: "/metrics",
         metrics,
+        queue_lengths,
     })
 }
 

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -117,6 +117,7 @@ pub(crate) struct MetricsTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub metrics: oxanus::JobMetricsSnapshot,
+    pub queue_lengths: oxanus::QueueLengthMetricsSnapshot,
 }
 
 impl MetricsTemplate {
@@ -130,6 +131,35 @@ impl MetricsTemplate {
 
     pub fn processed_chart_data_json(&self) -> String {
         self.summary_chart_data_json(|point| point.processed as f64)
+    }
+
+    pub fn queue_length_chart_data_json(&self) -> String {
+        let timestamps: Vec<i64> = self.queue_lengths.queues.first().map_or_else(
+            || {
+                (0..self.queue_lengths.minutes)
+                    .map(|idx| self.queue_lengths.starts_at + i64::try_from(idx).unwrap_or(0) * 60)
+                    .collect()
+            },
+            |queue| queue.series.iter().map(|point| point.timestamp).collect(),
+        );
+        let series: Vec<serde_json::Value> = self
+            .queue_lengths
+            .queues
+            .iter()
+            .map(|queue| {
+                let data: Vec<u64> = queue.series.iter().map(|point| point.enqueued).collect();
+                serde_json::json!({
+                    "label": queue.queue.clone(),
+                    "data": data,
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "timestamps": timestamps,
+            "series": series,
+        })
+        .to_string()
     }
 
     fn summary_chart_data_json(&self, value: impl Fn(&oxanus::JobMetricsPoint) -> f64) -> String {

--- a/oxanus-web/templates/metrics.html
+++ b/oxanus-web/templates/metrics.html
@@ -83,6 +83,15 @@
         <section class="space-y-6 mb-10">
             <div>
                 <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-lg font-semibold">Queue Lengths</h2>
+                </div>
+                <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
+                    <div id="queue-length-chart-key" class="mb-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-400"></div>
+                    <div id="queue-length-chart" class="w-full h-[300px]"></div>
+                </div>
+            </div>
+            <div>
+                <div class="flex items-center justify-between mb-4">
                     <h2 class="text-lg font-semibold">Total Time</h2>
                 </div>
                 <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
@@ -474,6 +483,12 @@
                 });
             }
 
+            renderChart(
+                'queue-length-chart',
+                'queue-length-chart-key',
+                {{ self.queue_length_chart_data_json()|safe }},
+                formatCount
+            );
             renderChart(
                 'execution-chart',
                 'execution-chart-key',

--- a/oxanus/src/coordinator.rs
+++ b/oxanus/src/coordinator.rs
@@ -219,7 +219,6 @@ where
 
     let result = executor::run(Arc::clone(&config), job, &mut envelope).await?;
     drop(pending.permit);
-
     process_result(result_tx, result, envelope).await;
 
     Ok(())
@@ -532,7 +531,6 @@ where
 
     let outcome = executor::run_batch(Arc::clone(&config), job, &mut envelopes).await?;
     drop(permits);
-
     process_batch_result(result_tx, outcome, envelopes).await;
 
     Ok(())

--- a/oxanus/src/metrics.rs
+++ b/oxanus/src/metrics.rs
@@ -294,6 +294,34 @@ pub struct JobMetricsDetail {
     pub histogram: Vec<JobMetricsHistogramBucket>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct QueueLengthMetricsPoint {
+    /// Start timestamp for this minute bucket.
+    pub timestamp: i64,
+    /// Jobs enqueued in this queue when the sample was recorded.
+    pub enqueued: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueLengthMetricsSeries {
+    /// Queue name.
+    pub queue: String,
+    /// Per-minute queue length samples.
+    pub series: Vec<QueueLengthMetricsPoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueLengthMetricsSnapshot {
+    /// Inclusive start timestamp for the queried window.
+    pub starts_at: i64,
+    /// Inclusive end timestamp for the queried window.
+    pub ends_at: i64,
+    /// Number of minute buckets returned.
+    pub minutes: usize,
+    /// Per-queue length samples sorted by peak queue length descending.
+    pub queues: Vec<QueueLengthMetricsSeries>,
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct JobMetricsBuffer {
     entries: HashMap<(i64, MetricIdentity), PendingJobMetrics>,
@@ -462,6 +490,57 @@ pub(crate) fn aggregate_counter_hashes(
 }
 
 #[must_use]
+pub(crate) fn queue_length_series_from_hashes(
+    minutes: &[i64],
+    hashes: Vec<HashMap<String, i64>>,
+) -> Vec<QueueLengthMetricsSeries> {
+    let series_template: Vec<QueueLengthMetricsPoint> = minutes
+        .iter()
+        .map(|minute| QueueLengthMetricsPoint {
+            timestamp: minute * 60,
+            enqueued: 0,
+        })
+        .collect();
+    let mut queues: HashMap<String, Vec<QueueLengthMetricsPoint>> = HashMap::new();
+
+    for (idx, hash) in hashes.into_iter().enumerate() {
+        for (queue, raw_value) in hash {
+            let value = u64::try_from(raw_value).unwrap_or_default();
+            let series = queues
+                .entry(queue)
+                .or_insert_with(|| series_template.clone());
+            if let Some(point) = series.get_mut(idx) {
+                point.enqueued = value;
+            }
+        }
+    }
+
+    let mut queues: Vec<QueueLengthMetricsSeries> = queues
+        .into_iter()
+        .map(|(queue, series)| QueueLengthMetricsSeries { queue, series })
+        .collect();
+
+    queues.sort_by(|a, b| {
+        let a_peak = a
+            .series
+            .iter()
+            .map(|point| point.enqueued)
+            .max()
+            .unwrap_or_default();
+        let b_peak = b
+            .series
+            .iter()
+            .map(|point| point.enqueued)
+            .max()
+            .unwrap_or_default();
+
+        b_peak.cmp(&a_peak).then_with(|| a.queue.cmp(&b.queue))
+    });
+
+    queues
+}
+
+#[must_use]
 pub(crate) fn histogram_bucket_index(duration_ms: u64) -> usize {
     HISTOGRAM_BUCKET_INTERVALS_MS
         .iter()
@@ -551,8 +630,12 @@ mod tests {
     #[test]
     fn bitfield_increment_args_use_saturated_u16_counters() {
         let mut buckets = [0_u64; HISTOGRAM_BUCKET_COUNT];
-        buckets[0] = 2;
-        buckets[13] = 70_000;
+        *buckets
+            .first_mut()
+            .expect("histogram should include the first bucket") = 2;
+        *buckets
+            .get_mut(13)
+            .expect("histogram should include the last bucket") = 70_000;
 
         let args = histogram_bitfield_increment_args(&buckets);
 
@@ -658,6 +741,62 @@ mod tests {
         assert_eq!(
             MetricIdentity::from_field_key(&identity.field_key()),
             Some(identity)
+        );
+    }
+
+    #[test]
+    fn queue_length_series_aggregates_and_sorts_by_peak_length() {
+        let minutes = vec![10, 11, 12];
+        let mut hashes = vec![HashMap::new(); minutes.len()];
+        hashes
+            .first_mut()
+            .expect("query should include a first minute bucket")
+            .insert("default".to_string(), 2);
+        hashes
+            .get_mut(1)
+            .expect("query should include a second minute bucket")
+            .insert("critical".to_string(), 7);
+        let third_hash = hashes
+            .get_mut(2)
+            .expect("query should include a third minute bucket");
+        third_hash.insert("default".to_string(), 4);
+        third_hash.insert("critical".to_string(), 0);
+
+        let queues = queue_length_series_from_hashes(&minutes, hashes);
+
+        assert_eq!(queues.len(), 2);
+        let critical = queues
+            .first()
+            .expect("critical queue length series should exist");
+        assert_eq!(critical.queue, "critical");
+        assert_eq!(
+            critical
+                .series
+                .first()
+                .expect("critical series should include the first point")
+                .timestamp,
+            600
+        );
+        assert_eq!(
+            critical
+                .series
+                .iter()
+                .map(|point| point.enqueued)
+                .collect::<Vec<_>>(),
+            vec![0, 7, 0]
+        );
+
+        let default = queues
+            .get(1)
+            .expect("default queue length series should exist");
+        assert_eq!(default.queue, "default");
+        assert_eq!(
+            default
+                .series
+                .iter()
+                .map(|point| point.enqueued)
+                .collect::<Vec<_>>(),
+            vec![2, 0, 4]
         );
     }
 

--- a/oxanus/src/result_collector.rs
+++ b/oxanus/src/result_collector.rs
@@ -1,9 +1,16 @@
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use tokio::sync::{Mutex, mpsc};
 use tokio::time::{Duration, Instant, MissedTickBehavior};
 
 use crate::{OxanusError, config::Config, metrics::JobMetricsBuffer};
+
+const METRICS_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const STATS_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const QUEUE_LENGTH_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Default, Debug)]
 pub struct Stats {
@@ -30,6 +37,33 @@ pub(crate) enum WorkerResultKind {
     Failed,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct QueueResultStats {
+    pub(crate) processed: i64,
+    pub(crate) succeeded: i64,
+    pub(crate) panicked: i64,
+    pub(crate) failed: i64,
+}
+
+impl QueueResultStats {
+    fn record(&mut self, result: &WorkerResult) {
+        let count = i64::try_from(result.job_count).unwrap_or(i64::MAX);
+        self.processed = self.processed.saturating_add(count);
+        match result.kind {
+            WorkerResultKind::Success => {
+                self.succeeded = self.succeeded.saturating_add(count);
+            }
+            WorkerResultKind::Panicked => {
+                self.panicked = self.panicked.saturating_add(count);
+                self.failed = self.failed.saturating_add(count);
+            }
+            WorkerResultKind::Failed => {
+                self.failed = self.failed.saturating_add(count);
+            }
+        }
+    }
+}
+
 pub async fn run<DT, ET>(
     mut rx: mpsc::Receiver<WorkerResult>,
     config: Arc<Config<DT, ET>>,
@@ -40,11 +74,21 @@ where
     ET: std::error::Error + Send + Sync + 'static,
 {
     let mut metrics = JobMetricsBuffer::default();
-    let mut flush_interval = tokio::time::interval_at(
-        Instant::now() + Duration::from_secs(5),
-        Duration::from_secs(5),
+    let mut pending_stats = HashMap::new();
+    let mut active_queues = HashSet::new();
+    let mut metrics_flush_interval = tokio::time::interval_at(
+        Instant::now() + METRICS_FLUSH_INTERVAL,
+        METRICS_FLUSH_INTERVAL,
     );
-    flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut stats_flush_interval =
+        tokio::time::interval_at(Instant::now() + STATS_FLUSH_INTERVAL, STATS_FLUSH_INTERVAL);
+    let mut queue_length_refresh_interval = tokio::time::interval_at(
+        Instant::now() + QUEUE_LENGTH_REFRESH_INTERVAL,
+        QUEUE_LENGTH_REFRESH_INTERVAL,
+    );
+    metrics_flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    stats_flush_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    queue_length_refresh_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     loop {
         tokio::select! {
@@ -52,26 +96,32 @@ where
                 match result {
                     Some(result) => {
                         metrics.record(&result);
-                        config.storage.internal.track_redis_result(
-                            update_stats(Arc::clone(&config), Arc::clone(&stats), &result).await
-                        )?;
+                        update_stats(&config, Arc::clone(&stats), &mut pending_stats, &mut active_queues, &result).await?;
                     }
                     None => {
-                        flush_metrics(Arc::clone(&config), &mut metrics).await?;
+                        flush_before_exit(&config, &mut metrics, &mut pending_stats, &mut active_queues).await?;
                         return Ok(());
                     }
                 }
             }
-            _ = flush_interval.tick() => {
-                flush_metrics(Arc::clone(&config), &mut metrics).await?;
+            _ = metrics_flush_interval.tick() => {
+                flush_metrics(&config, &mut metrics).await?;
+            }
+            _ = stats_flush_interval.tick() => {
+                flush_pending_stats(&config, &mut pending_stats).await?;
+            }
+            _ = queue_length_refresh_interval.tick() => {
+                refresh_active_queue_lengths(&config, &mut active_queues).await?;
             }
         }
     }
 }
 
 async fn update_stats<DT, ET>(
-    config: Arc<Config<DT, ET>>,
+    config: &Config<DT, ET>,
     stats: Arc<Mutex<Stats>>,
+    pending_stats: &mut HashMap<String, QueueResultStats>,
+    active_queues: &mut HashSet<String>,
     result: &WorkerResult,
 ) -> Result<(), OxanusError>
 where
@@ -97,7 +147,11 @@ where
         stats.processed
     };
 
-    config.storage.internal.update_stats(result).await?;
+    pending_stats
+        .entry(result.queue.clone())
+        .or_default()
+        .record(result);
+    active_queues.insert(result.queue.clone());
 
     if let Some(exit_when_processed) = config.exit_when_processed
         && processed >= exit_when_processed
@@ -108,8 +162,23 @@ where
     Ok(())
 }
 
+async fn flush_before_exit<DT, ET>(
+    config: &Config<DT, ET>,
+    metrics: &mut JobMetricsBuffer,
+    pending_stats: &mut HashMap<String, QueueResultStats>,
+    active_queues: &mut HashSet<String>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    flush_metrics(config, metrics).await?;
+    flush_pending_stats(config, pending_stats).await?;
+    refresh_active_queue_lengths(config, active_queues).await
+}
+
 async fn flush_metrics<DT, ET>(
-    config: Arc<Config<DT, ET>>,
+    config: &Config<DT, ET>,
     metrics: &mut JobMetricsBuffer,
 ) -> Result<(), OxanusError>
 where
@@ -130,6 +199,72 @@ where
     }
 
     Ok(())
+}
+
+async fn flush_pending_stats<DT, ET>(
+    config: &Config<DT, ET>,
+    pending_stats: &mut HashMap<String, QueueResultStats>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if pending_stats.is_empty() {
+        return Ok(());
+    }
+
+    if config
+        .storage
+        .internal
+        .track_redis_result(
+            config
+                .storage
+                .internal
+                .flush_result_stats(pending_stats)
+                .await,
+        )?
+        .is_some()
+    {
+        pending_stats.clear();
+    }
+
+    Ok(())
+}
+
+async fn refresh_active_queue_lengths<DT, ET>(
+    config: &Config<DT, ET>,
+    active_queues: &mut HashSet<String>,
+) -> Result<(), OxanusError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if active_queues.is_empty() {
+        return Ok(());
+    }
+
+    let queues: Vec<String> = active_queues.iter().cloned().collect();
+    let lengths = config.storage.internal.track_redis_result(
+        config
+            .storage
+            .internal
+            .refresh_queue_length_stats(&queues)
+            .await,
+    )?;
+    prune_active_queues(active_queues, lengths.as_ref());
+
+    Ok(())
+}
+
+fn prune_active_queues(
+    active_queues: &mut HashSet<String>,
+    lengths: Option<&HashMap<String, i64>>,
+) {
+    let Some(lengths) = lengths else {
+        return;
+    };
+
+    active_queues.retain(|queue| lengths.get(queue).is_some_and(|count| *count > 0));
 }
 
 #[cfg(test)]
@@ -197,5 +332,37 @@ mod tests {
         assert_eq!(metrics.totals.execution_ms, 75);
 
         Ok(())
+    }
+
+    #[test]
+    fn active_queue_pruning_drops_zero_length_queue() {
+        let queue = "empty".to_string();
+        let mut active_queues = HashSet::from([queue.clone()]);
+        let lengths = HashMap::from([(queue.clone(), 0)]);
+
+        prune_active_queues(&mut active_queues, Some(&lengths));
+
+        assert!(!active_queues.contains(&queue));
+    }
+
+    #[test]
+    fn active_queue_pruning_keeps_nonzero_queue() {
+        let queue = "busy".to_string();
+        let mut active_queues = HashSet::from([queue.clone()]);
+        let lengths = HashMap::from([(queue.clone(), 1)]);
+
+        prune_active_queues(&mut active_queues, Some(&lengths));
+
+        assert!(active_queues.contains(&queue));
+    }
+
+    #[test]
+    fn active_queue_pruning_skips_pruning_when_refresh_failed() {
+        let queue = "unknown".to_string();
+        let mut active_queues = HashSet::from([queue.clone()]);
+
+        prune_active_queues(&mut active_queues, None);
+
+        assert!(active_queues.contains(&queue));
     }
 }

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -3,7 +3,10 @@ use chrono::{DateTime, Utc};
 use crate::{
     error::OxanusError,
     job_envelope::{JobEnvelope, JobId},
-    metrics::{JobMetricsDetail, JobMetricsQuery, JobMetricsSnapshot, MetricIdentity},
+    metrics::{
+        JobMetricsDetail, JobMetricsQuery, JobMetricsSnapshot, MetricIdentity,
+        QueueLengthMetricsSnapshot,
+    },
     queue::Queue,
     stats::{Process, QueueStats, Stats},
     storage_builder::StorageBuilder,
@@ -295,6 +298,17 @@ impl Storage {
         query: JobMetricsQuery,
     ) -> Result<JobMetricsDetail, OxanusError> {
         self.internal.job_metrics_for(identity, query).await
+    }
+
+    /// Returns per-minute queue length samples for active queues.
+    ///
+    /// Samples are recorded by workers during their periodic queue length refresh
+    /// and retained for the same window as job execution metrics.
+    pub async fn queue_length_metrics(
+        &self,
+        query: JobMetricsQuery,
+    ) -> Result<QueueLengthMetricsSnapshot, OxanusError> {
+        self.internal.queue_length_metrics(query).await
     }
 
     /// Returns the list of processes that are currently running.

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -16,10 +16,11 @@ use crate::{
         JobMetricsSnapshot, METRIC_EXECUTION_MS, METRIC_FAILED_EXECUTIONS, METRIC_FAILED_JOBS,
         METRIC_PANICKED_EXECUTIONS, METRIC_PANICKED_JOBS, METRIC_PROCESSED_JOBS,
         METRIC_SUCCESSFUL_EXECUTIONS, METRICS_RETENTION_SECS, MetricIdentity,
-        aggregate_counter_hashes, histogram_bitfield_fetch_args, histogram_bitfield_increment_args,
-        histogram_buckets_from_counts, metric_minutes,
+        QueueLengthMetricsSnapshot, aggregate_counter_hashes, histogram_bitfield_fetch_args,
+        histogram_bitfield_increment_args, histogram_buckets_from_counts, metric_minutes,
+        queue_length_series_from_hashes,
     },
-    result_collector::{WorkerResult, WorkerResultKind},
+    result_collector::QueueResultStats,
     stats::{DynamicQueueStats, Process, QueueStats, Stats, StatsGlobal, StatsProcessing},
     storage_keys::StorageKeys,
     storage_types::QueueListOpts,
@@ -30,6 +31,7 @@ const JOB_EXPIRE_TIME: i64 = 7 * 24 * 3600; // 7 days
 const RESURRECT_THRESHOLD_SECS: i64 = 5;
 const MAX_CONSECUTIVE_REDIS_FAILURES: u32 = 30;
 const SCAN_BATCH_SIZE: usize = 500;
+const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
 
 #[derive(Clone)]
 pub(crate) struct StorageInternal {
@@ -43,6 +45,12 @@ enum JobEnqueueAction {
     Default,
     Skip,
     Replace,
+}
+
+#[derive(Default)]
+struct QueueLengthSnapshot {
+    enqueued: Option<i64>,
+    refreshed_at: Option<i64>,
 }
 
 impl StorageInternal {
@@ -798,52 +806,50 @@ impl StorageInternal {
         filter: bool,
     ) -> Result<Vec<QueueStats>, OxanusError> {
         let list: HashMap<String, i64> = (*redis).hgetall(&self.keys.stats).await?;
+        let now = chrono::Utc::now().timestamp();
 
         let mut map = HashMap::new();
         let mut queue_values: Vec<(String, String, i64)> = Vec::new();
+        let mut queue_length_snapshots: HashMap<String, QueueLengthSnapshot> = HashMap::new();
 
         for queue in queues {
             queue_values.push((queue.clone(), "processed".to_string(), 0));
         }
 
         for (key, value) in list {
-            let parts: Vec<&str> = key.rsplitn(2, ':').collect();
-            let mut parts_iter = parts.into_iter();
-            let stat_key = match parts_iter.next() {
-                Some(stat_key) => stat_key,
-                None => continue,
-            };
-            let queue_full_key = match parts_iter.next() {
-                Some(queue_key) => queue_key,
+            let (queue_full_key, stat_key) = match Self::stats_key_parts(&key) {
+                Some(parts) => parts,
                 None => continue,
             };
 
-            if filter {
-                let base_key = queue_full_key
-                    .split_once('#')
-                    .map_or(queue_full_key, |(base, _)| base);
-                let matches = queues.iter().any(|q| {
-                    let q_base = q.split_once('#').map_or(q.as_str(), |(base, _)| base);
-                    q_base == base_key || q == queue_full_key
-                });
-                if !matches {
-                    continue;
-                }
+            if filter && !Self::stats_key_matches_filter(queue_full_key, queues) {
+                continue;
             }
 
-            queue_values.push((queue_full_key.to_string(), stat_key.to_string(), value));
+            match stat_key {
+                "enqueued" => {
+                    queue_length_snapshots
+                        .entry(queue_full_key.to_string())
+                        .or_default()
+                        .enqueued = Some(value);
+                }
+                "enqueued_at" => {
+                    queue_length_snapshots
+                        .entry(queue_full_key.to_string())
+                        .or_default()
+                        .refreshed_at = Some(value);
+                }
+                _ => {
+                    queue_values.push((queue_full_key.to_string(), stat_key.to_string(), value));
+                }
+            }
         }
 
         for (queue_full_key, stat_key, value) in queue_values {
-            let queue_key_parts: Vec<&str> = queue_full_key.splitn(2, '#').collect();
-            let mut queue_key_parts_iter = queue_key_parts.into_iter();
-
-            let queue_key = match queue_key_parts_iter.next() {
-                Some(queue_key) => queue_key,
-                None => continue,
+            let Some((queue_key, queue_dynamic_key)) = Self::split_queue_stats_key(&queue_full_key)
+            else {
+                continue;
             };
-
-            let queue_dynamic_key = queue_key_parts_iter.next();
 
             let queue_stats = map
                 .entry(queue_key.to_string())
@@ -899,18 +905,41 @@ impl StorageInternal {
             }
         }
 
+        for queue_full_key in queue_length_snapshots.keys() {
+            if Self::fresh_queue_length_snapshot(&queue_length_snapshots, queue_full_key, now)
+                .is_some_and(|enqueued| enqueued > 0)
+            {
+                Self::ensure_queue_stats_entry(&mut map, queue_full_key);
+            }
+        }
+
         let mut values: Vec<QueueStats> = map.into_values().collect();
 
         for value in values.iter_mut() {
             if value.queues.is_empty() {
-                value.enqueued = self.enqueued_count_w_conn(redis, &value.key).await?;
+                value.enqueued = match Self::fresh_queue_length_snapshot(
+                    &queue_length_snapshots,
+                    &value.key,
+                    now,
+                ) {
+                    Some(enqueued) => enqueued,
+                    None => self.enqueued_count_w_conn(redis, &value.key).await?,
+                };
                 value.latency_s = self.latency_s_w_conn(redis, &value.key).await?;
             } else {
                 for dynamic_queue in value.queues.iter_mut() {
                     let dynamic_queue_key = format!("{}#{}", value.key, dynamic_queue.suffix);
-                    let enqueued = self
-                        .enqueued_count_w_conn(redis, &dynamic_queue_key)
-                        .await?;
+                    let enqueued = match Self::fresh_queue_length_snapshot(
+                        &queue_length_snapshots,
+                        &dynamic_queue_key,
+                        now,
+                    ) {
+                        Some(enqueued) => enqueued,
+                        None => {
+                            self.enqueued_count_w_conn(redis, &dynamic_queue_key)
+                                .await?
+                        }
+                    };
                     let latency_s = self.latency_s_w_conn(redis, &dynamic_queue_key).await?;
 
                     dynamic_queue.enqueued = enqueued;
@@ -931,34 +960,171 @@ impl StorageInternal {
         Ok(values)
     }
 
-    pub async fn update_stats(&self, result: &WorkerResult) -> Result<(), OxanusError> {
+    fn stats_key_parts(key: &str) -> Option<(&str, &str)> {
+        key.rsplit_once(':')
+    }
+
+    fn split_queue_stats_key(queue_full_key: &str) -> Option<(&str, Option<&str>)> {
+        let mut queue_key_parts = queue_full_key.splitn(2, '#');
+        let queue_key = queue_key_parts.next()?;
+        Some((queue_key, queue_key_parts.next()))
+    }
+
+    fn ensure_queue_stats_entry(map: &mut HashMap<String, QueueStats>, queue_full_key: &str) {
+        let Some((queue_key, queue_dynamic_key)) = Self::split_queue_stats_key(queue_full_key)
+        else {
+            return;
+        };
+
+        let queue_stats = map
+            .entry(queue_key.to_string())
+            .or_insert_with(|| QueueStats {
+                key: queue_key.to_string(),
+                enqueued: 0,
+                processed: 0,
+                succeeded: 0,
+                panicked: 0,
+                failed: 0,
+                latency_s: 0.0,
+                queues: vec![],
+            });
+
+        if let Some(queue_dynamic_key) = queue_dynamic_key
+            && !queue_stats
+                .queues
+                .iter()
+                .any(|q| q.suffix == queue_dynamic_key)
+        {
+            queue_stats.queues.push(DynamicQueueStats {
+                suffix: queue_dynamic_key.to_string(),
+                enqueued: 0,
+                processed: 0,
+                succeeded: 0,
+                panicked: 0,
+                failed: 0,
+                latency_s: 0.0,
+            });
+        }
+    }
+
+    fn stats_key_matches_filter(queue_full_key: &str, queues: &[String]) -> bool {
+        let base_key = queue_full_key
+            .split_once('#')
+            .map_or(queue_full_key, |(base, _)| base);
+
+        queues.iter().any(|queue| {
+            let queue_base = queue
+                .split_once('#')
+                .map_or(queue.as_str(), |(base, _)| base);
+            queue_base == base_key || queue.as_str() == queue_full_key
+        })
+    }
+
+    fn fresh_queue_length_snapshot(
+        queue_length_snapshots: &HashMap<String, QueueLengthSnapshot>,
+        queue: &str,
+        now: i64,
+    ) -> Option<usize> {
+        let snapshot = queue_length_snapshots.get(queue)?;
+        let refreshed_at = snapshot.refreshed_at?;
+        if now.saturating_sub(refreshed_at) > QUEUE_LENGTH_SNAPSHOT_TTL_SECS {
+            return None;
+        }
+
+        usize::try_from(snapshot.enqueued?).ok()
+    }
+
+    pub(crate) async fn flush_result_stats(
+        &self,
+        stats: &HashMap<String, QueueResultStats>,
+    ) -> Result<(), OxanusError> {
+        if stats.is_empty() {
+            return Ok(());
+        }
+
         let mut redis = self.connection().await?;
-        let queue = result.queue.clone();
-
-        let count = redis_metric_increment(result.job_count);
-        let processed_key = format!("{queue}:processed");
-        let succeeded_key = format!("{queue}:succeeded");
-        let failed_key = format!("{queue}:failed");
-        let panicked_key = format!("{queue}:panicked");
-
         let mut pipe = redis::pipe();
-        pipe.hincr(&self.keys.stats, processed_key, count);
-        match result.kind {
-            WorkerResultKind::Success => {
-                pipe.hincr(&self.keys.stats, succeeded_key, count);
+        let mut has_commands = false;
+
+        for (queue, queue_stats) in stats {
+            if queue_stats.processed > 0 {
+                pipe.hincr(
+                    &self.keys.stats,
+                    format!("{queue}:processed"),
+                    queue_stats.processed,
+                );
+                has_commands = true;
             }
-            WorkerResultKind::Panicked => {
-                pipe.hincr(&self.keys.stats, failed_key, count);
-                pipe.hincr(&self.keys.stats, panicked_key, count);
+            if queue_stats.succeeded > 0 {
+                pipe.hincr(
+                    &self.keys.stats,
+                    format!("{queue}:succeeded"),
+                    queue_stats.succeeded,
+                );
+                has_commands = true;
             }
-            WorkerResultKind::Failed => {
-                pipe.hincr(&self.keys.stats, failed_key, count);
+            if queue_stats.panicked > 0 {
+                pipe.hincr(
+                    &self.keys.stats,
+                    format!("{queue}:panicked"),
+                    queue_stats.panicked,
+                );
+                has_commands = true;
+            }
+            if queue_stats.failed > 0 {
+                pipe.hincr(
+                    &self.keys.stats,
+                    format!("{queue}:failed"),
+                    queue_stats.failed,
+                );
+                has_commands = true;
             }
         }
 
-        let _: () = pipe.query_async(&mut redis).await?;
+        if has_commands {
+            let _: () = pipe.query_async(&mut redis).await?;
+        }
 
         Ok(())
+    }
+
+    pub(crate) async fn refresh_queue_length_stats(
+        &self,
+        queues: &[String],
+    ) -> Result<HashMap<String, i64>, OxanusError> {
+        if queues.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut redis = self.connection().await?;
+        let mut queues = queues.to_vec();
+        queues.sort();
+        queues.dedup();
+        let mut lengths = HashMap::with_capacity(queues.len());
+
+        for queue in &queues {
+            let count: i64 = (*redis).llen(self.namespace_queue(queue)).await?;
+            lengths.insert(queue.clone(), count);
+        }
+
+        let refreshed_at = chrono::Utc::now().timestamp();
+        let queue_length_key = self.metrics_queue_length_key(refreshed_at.div_euclid(60));
+        let mut pipe = redis::pipe();
+
+        for (queue, count) in &lengths {
+            pipe.hset(&self.keys.stats, format!("{queue}:enqueued"), *count)
+                .hset(
+                    &self.keys.stats,
+                    format!("{queue}:enqueued_at"),
+                    refreshed_at,
+                )
+                .hset(&queue_length_key, queue, *count);
+        }
+        pipe.expire(queue_length_key, METRICS_RETENTION_SECS);
+
+        let _: () = pipe.query_async(&mut redis).await?;
+
+        Ok(lengths)
     }
 
     pub async fn flush_job_metrics(&self, buffer: &JobMetricsBuffer) -> Result<(), OxanusError> {
@@ -1094,6 +1260,26 @@ impl StorageInternal {
             totals: aggregation.totals,
             series: aggregation.series,
             histogram: histogram_buckets_from_counts(&histogram),
+        })
+    }
+
+    pub async fn queue_length_metrics(
+        &self,
+        query: JobMetricsQuery,
+    ) -> Result<QueueLengthMetricsSnapshot, OxanusError> {
+        let mut redis = self.connection().await?;
+        let minutes = metric_minutes(chrono::Utc::now().timestamp(), query);
+        let hashes = self
+            .queue_length_metric_hashes(&mut redis, &minutes)
+            .await?;
+        let starts_at = minutes.first().copied().unwrap_or_default() * 60;
+        let ends_at = minutes.last().copied().unwrap_or_default() * 60;
+
+        Ok(QueueLengthMetricsSnapshot {
+            starts_at,
+            ends_at,
+            minutes: minutes.len(),
+            queues: queue_length_series_from_hashes(&minutes, hashes),
         })
     }
 
@@ -1449,6 +1635,10 @@ impl StorageInternal {
         format!("{}:j:{minute}", self.keys.metrics_prefix)
     }
 
+    fn metrics_queue_length_key(&self, minute: i64) -> String {
+        format!("{}:q:{minute}", self.keys.metrics_prefix)
+    }
+
     fn metrics_histogram_key(&self, identity: &MetricIdentity, minute: i64) -> String {
         format!(
             "{}:h:{}:{minute}",
@@ -1469,6 +1659,22 @@ impl StorageInternal {
         let mut pipe = redis::pipe();
         for minute in minutes {
             pipe.hgetall(self.metrics_counter_key(*minute));
+        }
+        Ok(pipe.query_async(redis).await?)
+    }
+
+    async fn queue_length_metric_hashes(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        minutes: &[i64],
+    ) -> Result<Vec<HashMap<String, i64>>, OxanusError> {
+        if minutes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut pipe = redis::pipe();
+        for minute in minutes {
+            pipe.hgetall(self.metrics_queue_length_key(*minute));
         }
         Ok(pipe.query_async(redis).await?)
     }
@@ -1891,6 +2097,314 @@ mod tests {
                 "prefix-a".to_string(),
             ]
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_flush_result_stats_batches_counts() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let static_queue = random_string();
+        let dynamic_prefix = random_string();
+        let dynamic_queue = format!("{dynamic_prefix}#fast");
+
+        let mut updates = HashMap::new();
+        updates.insert(
+            static_queue.clone(),
+            QueueResultStats {
+                processed: 3,
+                succeeded: 1,
+                panicked: 1,
+                failed: 2,
+            },
+        );
+        updates.insert(
+            dynamic_queue,
+            QueueResultStats {
+                processed: 2,
+                succeeded: 2,
+                panicked: 0,
+                failed: 0,
+            },
+        );
+
+        storage.flush_result_stats(&updates).await?;
+
+        let stats = storage.stats().await?;
+        let static_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == static_queue)
+            .expect("static queue stats should exist");
+        assert_eq!(static_stats.processed, 3);
+        assert_eq!(static_stats.succeeded, 1);
+        assert_eq!(static_stats.panicked, 1);
+        assert_eq!(static_stats.failed, 2);
+
+        let dynamic_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == dynamic_prefix)
+            .expect("dynamic queue stats should exist");
+        assert_eq!(dynamic_stats.processed, 2);
+        assert_eq!(dynamic_stats.succeeded, 2);
+        assert_eq!(dynamic_stats.panicked, 0);
+        assert_eq!(dynamic_stats.failed, 0);
+        assert_eq!(dynamic_stats.queues.len(), 1);
+        let dynamic_queue_stats = dynamic_stats
+            .queues
+            .first()
+            .expect("fast dynamic queue stats should exist");
+        assert_eq!(dynamic_queue_stats.suffix, "fast");
+        assert_eq!(dynamic_queue_stats.processed, 2);
+        assert_eq!(dynamic_queue_stats.succeeded, 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_refresh_queue_length_stats_reports_llen() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let static_queue = random_string();
+        let dynamic_prefix = random_string();
+        let dynamic_queue = format!("{dynamic_prefix}#fast");
+
+        storage
+            .enqueue(JobEnvelope::new(static_queue.clone(), TestJob {})?)
+            .await?;
+        storage
+            .enqueue(JobEnvelope::new(static_queue.clone(), TestJob {})?)
+            .await?;
+        storage
+            .enqueue(JobEnvelope::new(dynamic_queue.clone(), TestJob {})?)
+            .await?;
+        storage
+            .enqueue(JobEnvelope::new(dynamic_queue.clone(), TestJob {})?)
+            .await?;
+        storage
+            .enqueue(JobEnvelope::new(dynamic_queue.clone(), TestJob {})?)
+            .await?;
+
+        let reported_lengths = storage
+            .refresh_queue_length_stats(&[static_queue.clone(), dynamic_queue.clone()])
+            .await?;
+        assert_eq!(reported_lengths.get(&static_queue), Some(&2));
+        assert_eq!(reported_lengths.get(&dynamic_queue), Some(&3));
+
+        let mut redis = storage.connection().await?;
+        let static_enqueued: i64 = (*redis)
+            .hget(&storage.keys.stats, format!("{static_queue}:enqueued"))
+            .await?;
+        let static_refreshed_at: i64 = (*redis)
+            .hget(&storage.keys.stats, format!("{static_queue}:enqueued_at"))
+            .await?;
+        assert_eq!(static_enqueued, 2);
+        assert!(static_refreshed_at >= chrono::Utc::now().timestamp() - 3);
+
+        let stats = storage.stats().await?;
+        let static_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == static_queue)
+            .expect("static queue stats should exist");
+        assert_eq!(static_stats.enqueued, 2);
+
+        let dynamic_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == dynamic_prefix)
+            .expect("dynamic queue stats should exist");
+        assert_eq!(dynamic_stats.enqueued, 3);
+        assert_eq!(dynamic_stats.queues.len(), 1);
+        let dynamic_queue_stats = dynamic_stats
+            .queues
+            .first()
+            .expect("fast dynamic queue stats should exist");
+        assert_eq!(dynamic_queue_stats.suffix, "fast");
+        assert_eq!(dynamic_queue_stats.enqueued, 3);
+
+        let queue_lengths = storage
+            .queue_length_metrics(JobMetricsQuery::new(2))
+            .await?;
+        let static_series = queue_lengths
+            .queues
+            .iter()
+            .find(|series| series.queue == static_queue)
+            .expect("static queue length series should exist");
+        assert_eq!(
+            static_series
+                .series
+                .iter()
+                .map(|point| point.enqueued)
+                .max(),
+            Some(2)
+        );
+        let dynamic_series = queue_lengths
+            .queues
+            .iter()
+            .find(|series| series.queue == dynamic_queue)
+            .expect("dynamic queue length series should exist");
+        assert_eq!(
+            dynamic_series
+                .series
+                .iter()
+                .map(|point| point.enqueued)
+                .max(),
+            Some(3)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stats_use_fresh_queue_length_snapshots() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let static_queue = random_string();
+        let dynamic_prefix = random_string();
+        let dynamic_queue_a = format!("{dynamic_prefix}#a");
+        let dynamic_queue_b = format!("{dynamic_prefix}#b");
+        let refreshed_at = chrono::Utc::now().timestamp();
+
+        let mut redis = storage.connection().await?;
+        let _: () = redis::pipe()
+            .hset(&storage.keys.stats, format!("{static_queue}:enqueued"), 42)
+            .hset(
+                &storage.keys.stats,
+                format!("{static_queue}:enqueued_at"),
+                refreshed_at,
+            )
+            .hset(
+                &storage.keys.stats,
+                format!("{dynamic_queue_a}:enqueued"),
+                3,
+            )
+            .hset(
+                &storage.keys.stats,
+                format!("{dynamic_queue_a}:enqueued_at"),
+                refreshed_at,
+            )
+            .hset(
+                &storage.keys.stats,
+                format!("{dynamic_queue_b}:enqueued"),
+                4,
+            )
+            .hset(
+                &storage.keys.stats,
+                format!("{dynamic_queue_b}:enqueued_at"),
+                refreshed_at,
+            )
+            .query_async(&mut redis)
+            .await?;
+
+        let stats = storage.stats().await?;
+        assert_eq!(stats.global.enqueued, 49);
+
+        let static_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == static_queue)
+            .expect("static queue stats should exist");
+        assert_eq!(static_stats.enqueued, 42);
+
+        let dynamic_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == dynamic_prefix)
+            .expect("dynamic queue stats should exist");
+        assert_eq!(dynamic_stats.enqueued, 7);
+        assert_eq!(dynamic_stats.queues.len(), 2);
+        let first_dynamic_queue = dynamic_stats
+            .queues
+            .first()
+            .expect("first dynamic queue stats should exist");
+        assert_eq!(first_dynamic_queue.suffix, "a");
+        assert_eq!(first_dynamic_queue.enqueued, 3);
+        let second_dynamic_queue = dynamic_stats
+            .queues
+            .get(1)
+            .expect("second dynamic queue stats should exist");
+        assert_eq!(second_dynamic_queue.suffix, "b");
+        assert_eq!(second_dynamic_queue.enqueued, 4);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stats_ignore_zero_queue_length_snapshots_without_other_stats() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let static_queue = random_string();
+        let dynamic_prefix = random_string();
+        let dynamic_queue = format!("{dynamic_prefix}#empty");
+        let refreshed_at = chrono::Utc::now().timestamp();
+
+        let mut redis = storage.connection().await?;
+        let _: () = redis::pipe()
+            .hset(&storage.keys.stats, format!("{static_queue}:enqueued"), 0)
+            .hset(
+                &storage.keys.stats,
+                format!("{static_queue}:enqueued_at"),
+                refreshed_at,
+            )
+            .hset(&storage.keys.stats, format!("{dynamic_queue}:enqueued"), 0)
+            .hset(
+                &storage.keys.stats,
+                format!("{dynamic_queue}:enqueued_at"),
+                refreshed_at,
+            )
+            .query_async(&mut redis)
+            .await?;
+
+        let stats = storage.stats().await?;
+
+        assert_eq!(stats.global.enqueued, 0);
+        assert!(
+            !stats
+                .queues
+                .iter()
+                .any(|queue_stats| queue_stats.key == static_queue)
+        );
+        assert!(
+            !stats
+                .queues
+                .iter()
+                .any(|queue_stats| queue_stats.key == dynamic_prefix)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stats_use_live_llen_when_queue_length_snapshot_is_stale() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        storage
+            .enqueue(JobEnvelope::new(queue.clone(), TestJob {})?)
+            .await?;
+        storage
+            .enqueue(JobEnvelope::new(queue.clone(), TestJob {})?)
+            .await?;
+
+        let stale_refreshed_at =
+            chrono::Utc::now().timestamp() - QUEUE_LENGTH_SNAPSHOT_TTL_SECS - 1;
+        let mut redis = storage.connection().await?;
+        let _: () = redis::pipe()
+            .hset(&storage.keys.stats, format!("{queue}:enqueued"), 42)
+            .hset(
+                &storage.keys.stats,
+                format!("{queue}:enqueued_at"),
+                stale_refreshed_at,
+            )
+            .query_async(&mut redis)
+            .await?;
+
+        let stats = storage.stats().await?;
+        let queue_stats = stats
+            .queues
+            .iter()
+            .find(|queue_stats| queue_stats.key == queue)
+            .expect("queue stats should exist");
+        assert_eq!(queue_stats.enqueued, 2);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Batch result stats writes so completed jobs update local stats immediately while Redis counters flush in periodic pipelines.
- Track active queues from completed job results, refresh their queue lengths periodically, store fresh queue length snapshots, and prune queues when a successful refresh reports `LLEN == 0`.
- Add queue length history metrics and a Queue Lengths chart to the web metrics dashboard.
- Preserve dynamic queue aggregation and fall back to live `LLEN` when queue length snapshots are stale or absent.
