### PR TITLE
feat: add queue rate and ETA stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add `#[derive(oxanus::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
 - Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
 - Add queue length history metrics and a Queue Lengths chart to the web metrics dashboard.
+- Add per-queue processing rate, growth rate, and ETA stats with web dashboard display.
 
 ### Changed
 

--- a/oxanus-web/src/filters.rs
+++ b/oxanus-web/src/filters.rs
@@ -72,6 +72,36 @@ pub fn format_duration_ms_f64(val: f64, _env: &dyn askama::Values) -> askama::Re
     Ok(format_duration_from_ms(val))
 }
 
+fn format_duration_from_secs(secs: f64) -> String {
+    if secs >= 3600.0 {
+        format!("{:.1}h", secs / 3600.0)
+    } else if secs >= 60.0 {
+        format!("{:.1}m", secs / 60.0)
+    } else {
+        format!("{secs:.1}s")
+    }
+}
+
+#[askama::filter_fn]
+pub fn format_rate_per_minute(val: &f64, _env: &dyn askama::Values) -> askama::Result<String> {
+    Ok(format!("{val:.1}/min"))
+}
+
+#[askama::filter_fn]
+pub fn format_signed_rate_per_minute(
+    val: &f64,
+    _env: &dyn askama::Values,
+) -> askama::Result<String> {
+    Ok(format!("{val:+.1}/min"))
+}
+
+#[askama::filter_fn]
+pub fn format_eta_s(val: &Option<f64>, _env: &dyn askama::Values) -> askama::Result<String> {
+    Ok(val
+        .map(format_duration_from_secs)
+        .unwrap_or_else(|| "—".to_string()))
+}
+
 #[askama::filter_fn]
 pub fn pretty_json(val: &serde_json::Value, _env: &dyn askama::Values) -> askama::Result<String> {
     Ok(serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string()))

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -212,6 +212,7 @@ pub(crate) async fn queue_detail(
                 panicked: dq.panicked,
                 failed: dq.failed,
                 latency_s: dq.latency_s,
+                rate: dq.rate,
                 queues: Vec::new(),
             })
         });
@@ -386,25 +387,46 @@ fn sort_queues(
     desc: bool,
 ) {
     queues.sort_by(|a, b| {
-        let cmp = match sort {
-            "enqueued" => a.enqueued.cmp(&b.enqueued),
-            "processed" => a.processed.cmp(&b.processed),
-            "succeeded" => a.succeeded.cmp(&b.succeeded),
-            "failed" => a.failed.cmp(&b.failed),
-            "panicked" => a.panicked.cmp(&b.panicked),
-            "concurrency" => {
-                let ca = concurrency_map.get(&a.key).copied().unwrap_or(0);
-                let cb = concurrency_map.get(&b.key).copied().unwrap_or(0);
-                ca.cmp(&cb)
-            }
-            "latency" => a
-                .latency_s
-                .partial_cmp(&b.latency_s)
-                .unwrap_or(std::cmp::Ordering::Equal),
-            _ => a.key.cmp(&b.key),
-        };
-        if desc { cmp.reverse() } else { cmp }
+        if sort == "eta" {
+            compare_eta(a.rate.eta_s, b.rate.eta_s, desc)
+        } else {
+            let cmp = match sort {
+                "enqueued" => a.enqueued.cmp(&b.enqueued),
+                "processed" => a.processed.cmp(&b.processed),
+                "succeeded" => a.succeeded.cmp(&b.succeeded),
+                "failed" => a.failed.cmp(&b.failed),
+                "panicked" => a.panicked.cmp(&b.panicked),
+                "rate" => a
+                    .rate
+                    .processed_per_minute
+                    .partial_cmp(&b.rate.processed_per_minute)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                "concurrency" => {
+                    let ca = concurrency_map.get(&a.key).copied().unwrap_or(0);
+                    let cb = concurrency_map.get(&b.key).copied().unwrap_or(0);
+                    ca.cmp(&cb)
+                }
+                "latency" => a
+                    .latency_s
+                    .partial_cmp(&b.latency_s)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                _ => a.key.cmp(&b.key),
+            };
+            if desc { cmp.reverse() } else { cmp }
+        }
     });
+}
+
+fn compare_eta(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let cmp = a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal);
+            if desc { cmp.reverse() } else { cmp }
+        }
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
 }
 
 fn build_cron_rows(

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -418,15 +418,14 @@ fn sort_queues(
 }
 
 fn compare_eta(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering {
-    match (a, b) {
-        (Some(a), Some(b)) => {
-            let cmp = a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal);
-            if desc { cmp.reverse() } else { cmp }
-        }
+    let cmp = match (a, b) {
+        (Some(a), Some(b)) => a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal),
         (Some(_), None) => std::cmp::Ordering::Less,
         (None, Some(_)) => std::cmp::Ordering::Greater,
         (None, None) => std::cmp::Ordering::Equal,
-    }
+    };
+
+    if desc { cmp.reverse() } else { cmp }
 }
 
 fn build_cron_rows(
@@ -497,4 +496,61 @@ fn build_cron_rows(
     let mut rows = Vec::new();
     flatten(&root, 0, &mut rows);
     rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_queues;
+    use std::collections::HashMap;
+
+    fn queue_with_eta(key: &str, eta_s: Option<f64>) -> oxanus::QueueStats {
+        oxanus::QueueStats {
+            key: key.to_string(),
+            enqueued: 0,
+            processed: 0,
+            succeeded: 0,
+            panicked: 0,
+            failed: 0,
+            latency_s: 0.0,
+            rate: oxanus::QueueRateStats {
+                eta_s,
+                ..oxanus::QueueRateStats::default()
+            },
+            queues: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn eta_sort_ascending_places_unknown_last() {
+        let mut queues = vec![
+            queue_with_eta("never", None),
+            queue_with_eta("slow", Some(30.0)),
+            queue_with_eta("fast", Some(10.0)),
+        ];
+
+        sort_queues(&mut queues, &HashMap::new(), "eta", false);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["fast", "slow", "never"]);
+    }
+
+    #[test]
+    fn eta_sort_descending_places_unknown_first() {
+        let mut queues = vec![
+            queue_with_eta("fast", Some(10.0)),
+            queue_with_eta("never", None),
+            queue_with_eta("slow", Some(30.0)),
+        ];
+
+        sort_queues(&mut queues, &HashMap::new(), "eta", true);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["never", "slow", "fast"]);
+    }
 }

--- a/oxanus-web/templates/queue_detail.html
+++ b/oxanus-web/templates/queue_detail.html
@@ -25,7 +25,7 @@
 
         {% match queue_stats %}
         {% when Some with (qs) %}
-        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4 mb-8">
+        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4 mb-8">
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Enqueued</div>
                 <div class="text-2xl font-semibold text-blue-400">{{ qs.enqueued|format_number }}</div>
@@ -53,6 +53,26 @@
             <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Latency</div>
                 <div class="text-2xl font-semibold text-yellow-400">{{ qs.latency_s|format_latency }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed/min</div>
+                <div class="text-2xl font-semibold text-cyan-400">{{ qs.rate.processed_per_minute|format_rate_per_minute }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Succeeded/min</div>
+                <div class="text-2xl font-semibold text-emerald-400">{{ qs.rate.succeeded_per_minute|format_rate_per_minute }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed/min</div>
+                <div class="text-2xl font-semibold text-red-400">{{ qs.rate.failed_per_minute|format_rate_per_minute }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Growth/min</div>
+                <div class="text-2xl font-semibold text-orange-400">{{ qs.rate.growth_per_minute|format_signed_rate_per_minute }}</div>
+            </div>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">ETA</div>
+                <div class="text-2xl font-semibold text-yellow-400">{{ qs.rate.eta_s|format_eta_s }}</div>
             </div>
         </div>
         {% when None %}

--- a/oxanus-web/templates/queues.html
+++ b/oxanus-web/templates/queues.html
@@ -30,6 +30,8 @@
                         <th class="pb-3 pr-4"><a href="{{ base_path }}/queues?sort=key&dir={{ self.next_dir("key") }}" class="hover:text-gray-200">Queue{{ self.sort_arrow("key") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=concurrency&dir={{ self.next_dir("concurrency") }}" class="hover:text-gray-200">Concurrency{{ self.sort_arrow("concurrency") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=enqueued&dir={{ self.next_dir("enqueued") }}" class="hover:text-gray-200">Enqueued{{ self.sort_arrow("enqueued") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=rate&dir={{ self.next_dir("rate") }}" class="hover:text-gray-200">Rate{{ self.sort_arrow("rate") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=eta&dir={{ self.next_dir("eta") }}" class="hover:text-gray-200">ETA{{ self.sort_arrow("eta") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=processed&dir={{ self.next_dir("processed") }}" class="hover:text-gray-200">Processed{{ self.sort_arrow("processed") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=succeeded&dir={{ self.next_dir("succeeded") }}" class="hover:text-gray-200">Succeeded{{ self.sort_arrow("succeeded") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=failed&dir={{ self.next_dir("failed") }}" class="hover:text-gray-200">Failed{{ self.sort_arrow("failed") }}</a></th>
@@ -43,6 +45,8 @@
                         <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
                         <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
                         <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
+                        <td class="py-3 pr-4 text-right text-cyan-400">{{ queue.rate.processed_per_minute|format_rate_per_minute }}</td>
+                        <td class="py-3 pr-4 text-right text-yellow-400">{{ queue.rate.eta_s|format_eta_s }}</td>
                         <td class="py-3 pr-4 text-right text-green-400">{{ queue.processed }}</td>
                         <td class="py-3 pr-4 text-right text-green-300">{{ queue.succeeded }}</td>
                         <td class="py-3 pr-4 text-right text-red-400">{{ queue.failed }}</td>
@@ -54,6 +58,8 @@
                         <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
                         <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.enqueued }}</td>
+                        <td class="py-2 pr-4 text-right text-xs text-cyan-400">{{ dq.rate.processed_per_minute|format_rate_per_minute }}</td>
+                        <td class="py-2 pr-4 text-right text-xs text-yellow-400">{{ dq.rate.eta_s|format_eta_s }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.processed }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.succeeded }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.failed }}</td>

--- a/oxanus/src/metrics.rs
+++ b/oxanus/src/metrics.rs
@@ -8,6 +8,7 @@ use crate::result_collector::{WorkerResult, WorkerResultKind};
 pub(crate) const METRICS_RETENTION_SECS: i64 = 8 * 60 * 60;
 pub(crate) const DEFAULT_METRIC_MINUTES: usize = 60;
 pub(crate) const MAX_METRIC_MINUTES: usize = 8 * 60;
+pub(crate) const QUEUE_RATE_WINDOW_MINUTES: usize = 10;
 pub(crate) const HISTOGRAM_BUCKET_COUNT: usize = 14;
 
 /// Maximum execution time represented by each histogram bucket.
@@ -41,6 +42,9 @@ pub(crate) const METRIC_SUCCESSFUL_EXECUTIONS: &str = "xs";
 pub(crate) const METRIC_FAILED_EXECUTIONS: &str = "xf";
 pub(crate) const METRIC_PANICKED_EXECUTIONS: &str = "xpn";
 pub(crate) const METRIC_EXECUTION_MS: &str = "ms";
+pub(crate) const QUEUE_METRIC_PROCESSED_JOBS: &str = "p";
+pub(crate) const QUEUE_METRIC_SUCCEEDED_JOBS: &str = "s";
+pub(crate) const QUEUE_METRIC_FAILED_JOBS: &str = "f";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MetricIdentity {
@@ -322,31 +326,63 @@ pub struct QueueLengthMetricsSnapshot {
     pub queues: Vec<QueueLengthMetricsSeries>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct QueueCounterTotals {
+    pub(crate) processed: u64,
+    pub(crate) succeeded: u64,
+    pub(crate) failed: u64,
+}
+
+impl QueueCounterTotals {
+    fn add_metric(&mut self, metric: &str, value: u64) {
+        match metric {
+            QUEUE_METRIC_PROCESSED_JOBS => {
+                self.processed = self.processed.saturating_add(value);
+            }
+            QUEUE_METRIC_SUCCEEDED_JOBS => {
+                self.succeeded = self.succeeded.saturating_add(value);
+            }
+            QUEUE_METRIC_FAILED_JOBS => {
+                self.failed = self.failed.saturating_add(value);
+            }
+            _ => {}
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct JobMetricsBuffer {
     entries: HashMap<(i64, MetricIdentity), PendingJobMetrics>,
+    queue_entries: HashMap<(i64, String), QueueCounterTotals>,
 }
 
 impl JobMetricsBuffer {
     pub(crate) fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.entries.is_empty() && self.queue_entries.is_empty()
     }
 
     pub(crate) fn clear(&mut self) {
         self.entries.clear();
+        self.queue_entries.clear();
     }
 
     pub(crate) fn record(&mut self, result: &WorkerResult) {
         let minute = chrono::Utc::now().timestamp().div_euclid(60);
         let identity = MetricIdentity::from_worker_result(result);
         let metrics = self.entries.entry((minute, identity)).or_default();
+        let queue_metrics = self
+            .queue_entries
+            .entry((minute, result.queue.clone()))
+            .or_default();
 
         metrics.processed = metrics.processed.saturating_add(result.job_count);
+        queue_metrics.processed = queue_metrics.processed.saturating_add(result.job_count);
 
         match result.kind {
             WorkerResultKind::Success => {
                 metrics.successful_executions = metrics.successful_executions.saturating_add(1);
                 metrics.execution_ms = metrics.execution_ms.saturating_add(result.execution_ms);
+                queue_metrics.succeeded = queue_metrics.succeeded.saturating_add(result.job_count);
                 let bucket = histogram_bucket_index(result.execution_ms);
                 if let Some(count) = metrics.histogram.get_mut(bucket) {
                     *count = count.saturating_add(1);
@@ -357,10 +393,12 @@ impl JobMetricsBuffer {
                 metrics.panicked = metrics.panicked.saturating_add(result.job_count);
                 metrics.failed_executions = metrics.failed_executions.saturating_add(1);
                 metrics.panicked_executions = metrics.panicked_executions.saturating_add(1);
+                queue_metrics.failed = queue_metrics.failed.saturating_add(result.job_count);
             }
             WorkerResultKind::Failed => {
                 metrics.failed = metrics.failed.saturating_add(result.job_count);
                 metrics.failed_executions = metrics.failed_executions.saturating_add(1);
+                queue_metrics.failed = queue_metrics.failed.saturating_add(result.job_count);
             }
         }
     }
@@ -371,6 +409,12 @@ impl JobMetricsBuffer {
         self.entries
             .iter()
             .map(|((minute, identity), metrics)| (*minute, identity, metrics))
+    }
+
+    pub(crate) fn queue_records(&self) -> impl Iterator<Item = (i64, &str, &QueueCounterTotals)> {
+        self.queue_entries
+            .iter()
+            .map(|((minute, queue), metrics)| (*minute, queue.as_str(), metrics))
     }
 }
 
@@ -490,6 +534,33 @@ pub(crate) fn aggregate_counter_hashes(
 }
 
 #[must_use]
+pub(crate) fn queue_metric_field(queue: &str, metric: &str) -> String {
+    format!("{}:{queue}|{metric}", queue.len())
+}
+
+#[must_use]
+pub(crate) fn aggregate_queue_counter_hashes(
+    hashes: Vec<HashMap<String, i64>>,
+) -> HashMap<String, QueueCounterTotals> {
+    let mut queues = HashMap::new();
+
+    for hash in hashes {
+        for (field, raw_value) in hash {
+            let Some((queue, metric)) = split_queue_metric_field(&field) else {
+                continue;
+            };
+            let value = u64::try_from(raw_value).unwrap_or_default();
+            queues
+                .entry(queue)
+                .or_insert_with(QueueCounterTotals::default)
+                .add_metric(metric, value);
+        }
+    }
+
+    queues
+}
+
+#[must_use]
 pub(crate) fn queue_length_series_from_hashes(
     minutes: &[i64],
     hashes: Vec<HashMap<String, i64>>,
@@ -605,6 +676,23 @@ fn split_metric_field(field: &str) -> Option<(MetricIdentity, &str)> {
         | METRIC_PANICKED_EXECUTIONS
         | METRIC_EXECUTION_MS => {
             MetricIdentity::from_field_key(identity_key).map(|id| (id, metric))
+        }
+        _ => None,
+    }
+}
+
+fn split_queue_metric_field(field: &str) -> Option<(String, &str)> {
+    let (queue_key, metric) = field.rsplit_once('|')?;
+    match metric {
+        QUEUE_METRIC_PROCESSED_JOBS | QUEUE_METRIC_SUCCEEDED_JOBS | QUEUE_METRIC_FAILED_JOBS => {
+            let (queue_len, queue) = queue_key.split_once(':')?;
+            let queue_len = queue_len.parse::<usize>().ok()?;
+
+            if queue.len() != queue_len || !queue.is_char_boundary(queue_len) {
+                return None;
+            }
+
+            Some((queue.to_string(), metric))
         }
         _ => None,
     }
@@ -742,6 +830,56 @@ mod tests {
             MetricIdentity::from_field_key(&identity.field_key()),
             Some(identity)
         );
+    }
+
+    #[test]
+    fn queue_counter_hashes_aggregate_with_missing_fields_as_zero() {
+        let queue = "critical:tenant|fast";
+        let mut hashes = vec![HashMap::new(), HashMap::new()];
+        let second_hash = hashes
+            .get_mut(1)
+            .expect("query should include a second minute bucket");
+        second_hash.insert(queue_metric_field(queue, QUEUE_METRIC_PROCESSED_JOBS), 5);
+        second_hash.insert(queue_metric_field(queue, QUEUE_METRIC_FAILED_JOBS), 2);
+
+        let counters = aggregate_queue_counter_hashes(hashes);
+        let totals = counters
+            .get(queue)
+            .expect("queue counters should be aggregated");
+
+        assert_eq!(totals.processed, 5);
+        assert_eq!(totals.succeeded, 0);
+        assert_eq!(totals.failed, 2);
+    }
+
+    #[test]
+    fn job_metrics_buffer_records_queue_counters() {
+        let mut buffer = JobMetricsBuffer::default();
+
+        buffer.record(&WorkerResult {
+            kind: WorkerResultKind::Success,
+            worker_name: "Worker".to_string(),
+            queue: "default".to_string(),
+            execution_ms: 10,
+            job_count: 3,
+        });
+        buffer.record(&WorkerResult {
+            kind: WorkerResultKind::Panicked,
+            worker_name: "Worker".to_string(),
+            queue: "default".to_string(),
+            execution_ms: 10,
+            job_count: 1,
+        });
+
+        let queue_records = buffer.queue_records().collect::<Vec<_>>();
+        assert_eq!(queue_records.len(), 1);
+        let (_, queue, counters) = queue_records
+            .first()
+            .expect("queue counter record should exist");
+        assert_eq!(*queue, "default");
+        assert_eq!(counters.processed, 4);
+        assert_eq!(counters.succeeded, 3);
+        assert_eq!(counters.failed, 1);
     }
 
     #[test]

--- a/oxanus/src/prometheus.rs
+++ b/oxanus/src/prometheus.rs
@@ -334,7 +334,9 @@ impl PrometheusMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stats::{DynamicQueueStats, Process, QueueStats, Stats, StatsGlobal};
+    use crate::stats::{
+        DynamicQueueStats, Process, QueueRateStats, QueueStats, Stats, StatsGlobal,
+    };
 
     fn create_test_stats() -> Stats {
         Stats {
@@ -364,6 +366,7 @@ mod tests {
                     panicked: 2,
                     failed: 8,
                     latency_s: 1.5,
+                    rate: QueueRateStats::default(),
                     queues: vec![],
                 },
                 QueueStats {
@@ -374,6 +377,7 @@ mod tests {
                     panicked: 0,
                     failed: 2,
                     latency_s: 0.5,
+                    rate: QueueRateStats::default(),
                     queues: vec![DynamicQueueStats {
                         suffix: "user_123".to_string(),
                         enqueued: 5,
@@ -382,6 +386,7 @@ mod tests {
                         panicked: 0,
                         failed: 1,
                         latency_s: 0.3,
+                        rate: QueueRateStats::default(),
                     }],
                 },
             ],

--- a/oxanus/src/stats.rs
+++ b/oxanus/src/stats.rs
@@ -47,6 +47,95 @@ pub struct StatsProcessing {
     pub job_envelope: JobEnvelope,
 }
 
+/// Historical per-queue rate estimates.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct QueueRateStats {
+    /// Number of minutes used to calculate these rates.
+    pub window_minutes: usize,
+    /// Jobs processed per minute over the window.
+    pub processed_per_minute: f64,
+    /// Jobs succeeded per minute over the window.
+    pub succeeded_per_minute: f64,
+    /// Jobs failed per minute over the window.
+    pub failed_per_minute: f64,
+    /// Net queue growth per minute over the window.
+    pub growth_per_minute: f64,
+    /// Processing capacity remaining after incoming growth.
+    pub effective_drain_per_minute: f64,
+    /// Estimated seconds until the waiting queue drains.
+    pub eta_s: Option<f64>,
+}
+
+impl QueueRateStats {
+    pub(crate) fn calculate(
+        window_minutes: usize,
+        enqueued: usize,
+        window_start_enqueued: usize,
+        processed: u64,
+        succeeded: u64,
+        failed: u64,
+    ) -> Self {
+        let window_minutes = window_minutes.max(1);
+        let window = window_minutes as f64;
+        let processed_per_minute = processed as f64 / window;
+        let succeeded_per_minute = succeeded as f64 / window;
+        let failed_per_minute = failed as f64 / window;
+        let growth_per_minute = (enqueued as f64 - window_start_enqueued as f64) / window;
+        let effective_drain_per_minute = processed_per_minute - growth_per_minute.max(0.0);
+
+        Self {
+            window_minutes,
+            processed_per_minute,
+            succeeded_per_minute,
+            failed_per_minute,
+            growth_per_minute,
+            effective_drain_per_minute,
+            eta_s: Self::eta(enqueued, effective_drain_per_minute),
+        }
+    }
+
+    pub(crate) fn aggregate(
+        window_minutes: usize,
+        enqueued: usize,
+        rates: impl IntoIterator<Item = Self>,
+    ) -> Self {
+        let window_minutes = window_minutes.max(1);
+        let mut processed_per_minute = 0.0;
+        let mut succeeded_per_minute = 0.0;
+        let mut failed_per_minute = 0.0;
+        let mut growth_per_minute = 0.0;
+
+        for rate in rates {
+            processed_per_minute += rate.processed_per_minute;
+            succeeded_per_minute += rate.succeeded_per_minute;
+            failed_per_minute += rate.failed_per_minute;
+            growth_per_minute += rate.growth_per_minute;
+        }
+
+        let effective_drain_per_minute = processed_per_minute - growth_per_minute.max(0.0);
+
+        Self {
+            window_minutes,
+            processed_per_minute,
+            succeeded_per_minute,
+            failed_per_minute,
+            growth_per_minute,
+            effective_drain_per_minute,
+            eta_s: Self::eta(enqueued, effective_drain_per_minute),
+        }
+    }
+
+    fn eta(enqueued: usize, effective_drain_per_minute: f64) -> Option<f64> {
+        if enqueued == 0 {
+            Some(0.0)
+        } else if effective_drain_per_minute > 0.0 {
+            Some(enqueued as f64 / (effective_drain_per_minute / 60.0))
+        } else {
+            None
+        }
+    }
+}
+
 /// Statistics for a specific queue.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueueStats {
@@ -65,6 +154,9 @@ pub struct QueueStats {
     pub failed: i64,
     /// Current latency in seconds.
     pub latency_s: f64,
+    /// Historical rate estimates for this queue.
+    #[serde(default)]
+    pub rate: QueueRateStats,
 
     /// Dynamic sub-queue statistics (if any).
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -89,6 +181,9 @@ pub struct DynamicQueueStats {
     pub failed: i64,
     /// Current latency in seconds.
     pub latency_s: f64,
+    /// Historical rate estimates for this dynamic sub-queue.
+    #[serde(default)]
+    pub rate: QueueRateStats,
 }
 
 /// Information about an Oxanus worker process.
@@ -109,5 +204,62 @@ impl Process {
     #[must_use]
     pub fn id(&self) -> String {
         format!("{}-{}", self.hostname, self.pid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueueRateStats;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn queue_rate_calculates_eta_when_effective_drain_is_positive() {
+        let rate = QueueRateStats::calculate(10, 30, 10, 50, 40, 10);
+
+        assert_close(rate.processed_per_minute, 5.0);
+        assert_close(rate.succeeded_per_minute, 4.0);
+        assert_close(rate.failed_per_minute, 1.0);
+        assert_close(rate.growth_per_minute, 2.0);
+        assert_close(rate.effective_drain_per_minute, 3.0);
+        assert_close(rate.eta_s.expect("eta should be finite"), 600.0);
+    }
+
+    #[test]
+    fn queue_rate_eta_is_unknown_when_growth_exceeds_processing() {
+        let rate = QueueRateStats::calculate(10, 50, 0, 20, 20, 0);
+
+        assert_close(rate.processed_per_minute, 2.0);
+        assert_close(rate.growth_per_minute, 5.0);
+        assert_close(rate.effective_drain_per_minute, -3.0);
+        assert!(rate.eta_s.is_none());
+    }
+
+    #[test]
+    fn queue_rate_eta_is_zero_for_empty_queue() {
+        let rate = QueueRateStats::calculate(10, 0, 10, 0, 0, 0);
+
+        assert_close(rate.growth_per_minute, -1.0);
+        assert_eq!(rate.eta_s, Some(0.0));
+    }
+
+    #[test]
+    fn queue_rate_aggregates_dynamic_children() {
+        let first = QueueRateStats::calculate(10, 10, 0, 30, 25, 5);
+        let second = QueueRateStats::calculate(10, 20, 10, 40, 35, 5);
+
+        let rate = QueueRateStats::aggregate(10, 30, [first, second]);
+
+        assert_close(rate.processed_per_minute, 7.0);
+        assert_close(rate.succeeded_per_minute, 6.0);
+        assert_close(rate.failed_per_minute, 1.0);
+        assert_close(rate.growth_per_minute, 2.0);
+        assert_close(rate.effective_drain_per_minute, 5.0);
+        assert_close(rate.eta_s.expect("eta should be finite"), 360.0);
     }
 }

--- a/oxanus/src/stats.rs
+++ b/oxanus/src/stats.rs
@@ -60,7 +60,7 @@ pub struct QueueRateStats {
     pub failed_per_minute: f64,
     /// Net queue growth per minute over the window.
     pub growth_per_minute: f64,
-    /// Processing capacity remaining after incoming growth.
+    /// Observed queue drain after incoming growth is accounted for.
     pub effective_drain_per_minute: f64,
     /// Estimated seconds until the waiting queue drains.
     pub eta_s: Option<f64>,
@@ -81,7 +81,8 @@ impl QueueRateStats {
         let succeeded_per_minute = succeeded as f64 / window;
         let failed_per_minute = failed as f64 / window;
         let growth_per_minute = (enqueued as f64 - window_start_enqueued as f64) / window;
-        let effective_drain_per_minute = processed_per_minute - growth_per_minute.max(0.0);
+        let effective_drain_per_minute =
+            Self::effective_drain(processed_per_minute, growth_per_minute);
 
         Self {
             window_minutes,
@@ -112,7 +113,8 @@ impl QueueRateStats {
             growth_per_minute += rate.growth_per_minute;
         }
 
-        let effective_drain_per_minute = processed_per_minute - growth_per_minute.max(0.0);
+        let effective_drain_per_minute =
+            Self::effective_drain(processed_per_minute, growth_per_minute);
 
         Self {
             window_minutes,
@@ -132,6 +134,14 @@ impl QueueRateStats {
             Some(enqueued as f64 / (effective_drain_per_minute / 60.0))
         } else {
             None
+        }
+    }
+
+    fn effective_drain(processed_per_minute: f64, growth_per_minute: f64) -> f64 {
+        if processed_per_minute > 0.0 {
+            (-growth_per_minute).max(0.0)
+        } else {
+            0.0
         }
     }
 }
@@ -220,23 +230,23 @@ mod tests {
 
     #[test]
     fn queue_rate_calculates_eta_when_effective_drain_is_positive() {
-        let rate = QueueRateStats::calculate(10, 30, 10, 50, 40, 10);
+        let rate = QueueRateStats::calculate(10, 10, 30, 50, 40, 10);
 
         assert_close(rate.processed_per_minute, 5.0);
         assert_close(rate.succeeded_per_minute, 4.0);
         assert_close(rate.failed_per_minute, 1.0);
-        assert_close(rate.growth_per_minute, 2.0);
-        assert_close(rate.effective_drain_per_minute, 3.0);
-        assert_close(rate.eta_s.expect("eta should be finite"), 600.0);
+        assert_close(rate.growth_per_minute, -2.0);
+        assert_close(rate.effective_drain_per_minute, 2.0);
+        assert_close(rate.eta_s.expect("eta should be finite"), 300.0);
     }
 
     #[test]
-    fn queue_rate_eta_is_unknown_when_growth_exceeds_processing() {
-        let rate = QueueRateStats::calculate(10, 50, 0, 20, 20, 0);
+    fn queue_rate_eta_is_unknown_when_queue_grows_despite_processing() {
+        let rate = QueueRateStats::calculate(10, 20, 0, 100, 100, 0);
 
-        assert_close(rate.processed_per_minute, 2.0);
-        assert_close(rate.growth_per_minute, 5.0);
-        assert_close(rate.effective_drain_per_minute, -3.0);
+        assert_close(rate.processed_per_minute, 10.0);
+        assert_close(rate.growth_per_minute, 2.0);
+        assert_close(rate.effective_drain_per_minute, 0.0);
         assert!(rate.eta_s.is_none());
     }
 
@@ -249,17 +259,26 @@ mod tests {
     }
 
     #[test]
+    fn queue_rate_eta_is_unknown_without_processing_rate() {
+        let rate = QueueRateStats::calculate(10, 10, 20, 0, 0, 0);
+
+        assert_close(rate.growth_per_minute, -1.0);
+        assert_close(rate.effective_drain_per_minute, 0.0);
+        assert!(rate.eta_s.is_none());
+    }
+
+    #[test]
     fn queue_rate_aggregates_dynamic_children() {
-        let first = QueueRateStats::calculate(10, 10, 0, 30, 25, 5);
-        let second = QueueRateStats::calculate(10, 20, 10, 40, 35, 5);
+        let first = QueueRateStats::calculate(10, 10, 20, 30, 25, 5);
+        let second = QueueRateStats::calculate(10, 20, 30, 40, 35, 5);
 
         let rate = QueueRateStats::aggregate(10, 30, [first, second]);
 
         assert_close(rate.processed_per_minute, 7.0);
         assert_close(rate.succeeded_per_minute, 6.0);
         assert_close(rate.failed_per_minute, 1.0);
-        assert_close(rate.growth_per_minute, 2.0);
-        assert_close(rate.effective_drain_per_minute, 5.0);
-        assert_close(rate.eta_s.expect("eta should be finite"), 360.0);
+        assert_close(rate.growth_per_minute, -2.0);
+        assert_close(rate.effective_drain_per_minute, 2.0);
+        assert_close(rate.eta_s.expect("eta should be finite"), 900.0);
     }
 }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -16,12 +16,16 @@ use crate::{
         JobMetricsSnapshot, METRIC_EXECUTION_MS, METRIC_FAILED_EXECUTIONS, METRIC_FAILED_JOBS,
         METRIC_PANICKED_EXECUTIONS, METRIC_PANICKED_JOBS, METRIC_PROCESSED_JOBS,
         METRIC_SUCCESSFUL_EXECUTIONS, METRICS_RETENTION_SECS, MetricIdentity,
-        QueueLengthMetricsSnapshot, aggregate_counter_hashes, histogram_bitfield_fetch_args,
+        QUEUE_METRIC_FAILED_JOBS, QUEUE_METRIC_PROCESSED_JOBS, QUEUE_METRIC_SUCCEEDED_JOBS,
+        QUEUE_RATE_WINDOW_MINUTES, QueueCounterTotals, QueueLengthMetricsSnapshot,
+        aggregate_counter_hashes, aggregate_queue_counter_hashes, histogram_bitfield_fetch_args,
         histogram_bitfield_increment_args, histogram_buckets_from_counts, metric_minutes,
-        queue_length_series_from_hashes,
+        queue_length_series_from_hashes, queue_metric_field,
     },
     result_collector::QueueResultStats,
-    stats::{DynamicQueueStats, Process, QueueStats, Stats, StatsGlobal, StatsProcessing},
+    stats::{
+        DynamicQueueStats, Process, QueueRateStats, QueueStats, Stats, StatsGlobal, StatsProcessing,
+    },
     storage_keys::StorageKeys,
     storage_types::QueueListOpts,
     worker_registry::CronJob,
@@ -807,6 +811,14 @@ impl StorageInternal {
     ) -> Result<Vec<QueueStats>, OxanusError> {
         let list: HashMap<String, i64> = (*redis).hgetall(&self.keys.stats).await?;
         let now = chrono::Utc::now().timestamp();
+        let rate_minutes = metric_minutes(now, JobMetricsQuery::new(QUEUE_RATE_WINDOW_MINUTES));
+        let queue_length_rate_hashes = self
+            .queue_length_metric_hashes(redis, &rate_minutes)
+            .await?;
+        let queue_counter_rate_hashes = self
+            .queue_counter_metric_hashes(redis, &rate_minutes)
+            .await?;
+        let queue_counter_totals = aggregate_queue_counter_hashes(queue_counter_rate_hashes);
 
         let mut map = HashMap::new();
         let mut queue_values: Vec<(String, String, i64)> = Vec::new();
@@ -861,6 +873,7 @@ impl StorageInternal {
                     panicked: 0,
                     failed: 0,
                     latency_s: 0.0,
+                    rate: QueueRateStats::default(),
                     queues: vec![],
                 });
 
@@ -878,6 +891,7 @@ impl StorageInternal {
                         panicked: 0,
                         failed: 0,
                         latency_s: 0.0,
+                        rate: QueueRateStats::default(),
                     });
                 }
 
@@ -926,6 +940,12 @@ impl StorageInternal {
                     None => self.enqueued_count_w_conn(redis, &value.key).await?,
                 };
                 value.latency_s = self.latency_s_w_conn(redis, &value.key).await?;
+                value.rate = Self::queue_rate_stats(
+                    &value.key,
+                    value.enqueued,
+                    &queue_length_rate_hashes,
+                    &queue_counter_totals,
+                );
             } else {
                 for dynamic_queue in value.queues.iter_mut() {
                     let dynamic_queue_key = format!("{}#{}", value.key, dynamic_queue.suffix);
@@ -944,12 +964,23 @@ impl StorageInternal {
 
                     dynamic_queue.enqueued = enqueued;
                     dynamic_queue.latency_s = latency_s;
+                    dynamic_queue.rate = Self::queue_rate_stats(
+                        &dynamic_queue_key,
+                        dynamic_queue.enqueued,
+                        &queue_length_rate_hashes,
+                        &queue_counter_totals,
+                    );
 
                     if value.latency_s < latency_s {
                         value.latency_s = latency_s;
                     }
                     value.enqueued += enqueued;
                 }
+                value.rate = QueueRateStats::aggregate(
+                    QUEUE_RATE_WINDOW_MINUTES,
+                    value.enqueued,
+                    value.queues.iter().map(|queue| queue.rate),
+                );
             }
 
             value.queues.sort_by(|a, b| a.suffix.cmp(&b.suffix));
@@ -986,6 +1017,7 @@ impl StorageInternal {
                 panicked: 0,
                 failed: 0,
                 latency_s: 0.0,
+                rate: QueueRateStats::default(),
                 queues: vec![],
             });
 
@@ -1003,6 +1035,7 @@ impl StorageInternal {
                 panicked: 0,
                 failed: 0,
                 latency_s: 0.0,
+                rate: QueueRateStats::default(),
             });
         }
     }
@@ -1032,6 +1065,29 @@ impl StorageInternal {
         }
 
         usize::try_from(snapshot.enqueued?).ok()
+    }
+
+    fn queue_rate_stats(
+        queue: &str,
+        enqueued: usize,
+        queue_length_hashes: &[HashMap<String, i64>],
+        queue_counter_totals: &HashMap<String, QueueCounterTotals>,
+    ) -> QueueRateStats {
+        let window_start_enqueued = queue_length_hashes
+            .first()
+            .and_then(|hash| hash.get(queue))
+            .and_then(|value| usize::try_from(*value).ok())
+            .unwrap_or_default();
+        let counters = queue_counter_totals.get(queue).copied().unwrap_or_default();
+
+        QueueRateStats::calculate(
+            QUEUE_RATE_WINDOW_MINUTES,
+            enqueued,
+            window_start_enqueued,
+            counters.processed,
+            counters.succeeded,
+            counters.failed,
+        )
     }
 
     pub(crate) async fn flush_result_stats(
@@ -1207,6 +1263,33 @@ impl StorageInternal {
                 pipe.add_command(cmd).ignore();
                 pipe.expire(histogram_key, METRICS_RETENTION_SECS);
             }
+        }
+
+        for (minute, queue, metrics) in buffer.queue_records() {
+            let counter_key = self.metrics_queue_counter_key(minute);
+
+            if metrics.processed > 0 {
+                pipe.hincr(
+                    &counter_key,
+                    queue_metric_field(queue, QUEUE_METRIC_PROCESSED_JOBS),
+                    redis_metric_increment(metrics.processed),
+                );
+            }
+            if metrics.succeeded > 0 {
+                pipe.hincr(
+                    &counter_key,
+                    queue_metric_field(queue, QUEUE_METRIC_SUCCEEDED_JOBS),
+                    redis_metric_increment(metrics.succeeded),
+                );
+            }
+            if metrics.failed > 0 {
+                pipe.hincr(
+                    &counter_key,
+                    queue_metric_field(queue, QUEUE_METRIC_FAILED_JOBS),
+                    redis_metric_increment(metrics.failed),
+                );
+            }
+            pipe.expire(&counter_key, METRICS_RETENTION_SECS);
         }
 
         let _: () = pipe.query_async(&mut redis).await?;
@@ -1639,6 +1722,10 @@ impl StorageInternal {
         format!("{}:q:{minute}", self.keys.metrics_prefix)
     }
 
+    fn metrics_queue_counter_key(&self, minute: i64) -> String {
+        format!("{}:qc:{minute}", self.keys.metrics_prefix)
+    }
+
     fn metrics_histogram_key(&self, identity: &MetricIdentity, minute: i64) -> String {
         format!(
             "{}:h:{}:{minute}",
@@ -1675,6 +1762,22 @@ impl StorageInternal {
         let mut pipe = redis::pipe();
         for minute in minutes {
             pipe.hgetall(self.metrics_queue_length_key(*minute));
+        }
+        Ok(pipe.query_async(redis).await?)
+    }
+
+    async fn queue_counter_metric_hashes(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        minutes: &[i64],
+    ) -> Result<Vec<HashMap<String, i64>>, OxanusError> {
+        if minutes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut pipe = redis::pipe();
+        for minute in minutes {
+            pipe.hgetall(self.metrics_queue_counter_key(*minute));
         }
         Ok(pipe.query_async(redis).await?)
     }
@@ -1817,6 +1920,13 @@ mod tests {
         fn worker_name() -> &'static str {
             "TestJob"
         }
+    }
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
     }
 
     #[tokio::test]
@@ -2158,6 +2268,141 @@ mod tests {
         assert_eq!(dynamic_queue_stats.suffix, "fast");
         assert_eq!(dynamic_queue_stats.processed, 2);
         assert_eq!(dynamic_queue_stats.succeeded, 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stats_include_queue_rates_from_historical_counters() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let static_queue = random_string();
+        let dynamic_prefix = random_string();
+        let dynamic_queue_a = format!("{dynamic_prefix}#a");
+        let dynamic_queue_b = format!("{dynamic_prefix}#b");
+
+        let mut metrics = JobMetricsBuffer::default();
+        metrics.record(&crate::result_collector::WorkerResult {
+            kind: crate::result_collector::WorkerResultKind::Success,
+            worker_name: "Worker".to_string(),
+            queue: static_queue.clone(),
+            execution_ms: 10,
+            job_count: 4,
+        });
+        metrics.record(&crate::result_collector::WorkerResult {
+            kind: crate::result_collector::WorkerResultKind::Failed,
+            worker_name: "Worker".to_string(),
+            queue: static_queue.clone(),
+            execution_ms: 10,
+            job_count: 2,
+        });
+        metrics.record(&crate::result_collector::WorkerResult {
+            kind: crate::result_collector::WorkerResultKind::Success,
+            worker_name: "Worker".to_string(),
+            queue: dynamic_queue_a.clone(),
+            execution_ms: 10,
+            job_count: 4,
+        });
+        metrics.record(&crate::result_collector::WorkerResult {
+            kind: crate::result_collector::WorkerResultKind::Panicked,
+            worker_name: "Worker".to_string(),
+            queue: dynamic_queue_b.clone(),
+            execution_ms: 10,
+            job_count: 2,
+        });
+        storage.flush_job_metrics(&metrics).await?;
+
+        let mut updates = HashMap::new();
+        updates.insert(
+            static_queue.clone(),
+            QueueResultStats {
+                processed: 6,
+                succeeded: 4,
+                panicked: 0,
+                failed: 2,
+            },
+        );
+        updates.insert(
+            dynamic_queue_a.clone(),
+            QueueResultStats {
+                processed: 4,
+                succeeded: 4,
+                panicked: 0,
+                failed: 0,
+            },
+        );
+        updates.insert(
+            dynamic_queue_b.clone(),
+            QueueResultStats {
+                processed: 2,
+                succeeded: 0,
+                panicked: 2,
+                failed: 2,
+            },
+        );
+        storage.flush_result_stats(&updates).await?;
+
+        for _ in 0..3 {
+            storage
+                .enqueue(JobEnvelope::new(static_queue.clone(), TestJob {})?)
+                .await?;
+        }
+        for _ in 0..2 {
+            storage
+                .enqueue(JobEnvelope::new(dynamic_queue_a.clone(), TestJob {})?)
+                .await?;
+        }
+        storage
+            .enqueue(JobEnvelope::new(dynamic_queue_b.clone(), TestJob {})?)
+            .await?;
+
+        let stats = storage.stats().await?;
+        let static_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == static_queue)
+            .expect("static queue stats should exist");
+        assert_close(static_stats.rate.processed_per_minute, 0.6);
+        assert_close(static_stats.rate.succeeded_per_minute, 0.4);
+        assert_close(static_stats.rate.failed_per_minute, 0.2);
+        assert_close(static_stats.rate.growth_per_minute, 0.3);
+        assert_close(static_stats.rate.effective_drain_per_minute, 0.3);
+        assert_close(
+            static_stats.rate.eta_s.expect("eta should be finite"),
+            600.0,
+        );
+
+        let dynamic_stats = stats
+            .queues
+            .iter()
+            .find(|queue| queue.key == dynamic_prefix)
+            .expect("dynamic queue stats should exist");
+        assert_close(dynamic_stats.rate.processed_per_minute, 0.6);
+        assert_close(dynamic_stats.rate.succeeded_per_minute, 0.4);
+        assert_close(dynamic_stats.rate.failed_per_minute, 0.2);
+        assert_close(dynamic_stats.rate.growth_per_minute, 0.3);
+        assert_close(dynamic_stats.rate.effective_drain_per_minute, 0.3);
+        assert_close(
+            dynamic_stats.rate.eta_s.expect("eta should be finite"),
+            600.0,
+        );
+
+        let dynamic_queue_stats = dynamic_stats
+            .queues
+            .iter()
+            .find(|queue| queue.suffix == "b")
+            .expect("dynamic sub-queue stats should exist");
+        assert_close(dynamic_queue_stats.rate.processed_per_minute, 0.2);
+        assert_close(dynamic_queue_stats.rate.succeeded_per_minute, 0.0);
+        assert_close(dynamic_queue_stats.rate.failed_per_minute, 0.2);
+        assert_close(dynamic_queue_stats.rate.growth_per_minute, 0.1);
+        assert_close(dynamic_queue_stats.rate.effective_drain_per_minute, 0.1);
+        assert_close(
+            dynamic_queue_stats
+                .rate
+                .eta_s
+                .expect("eta should be finite"),
+            600.0,
+        );
 
         Ok(())
     }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -2365,11 +2365,8 @@ mod tests {
         assert_close(static_stats.rate.succeeded_per_minute, 0.4);
         assert_close(static_stats.rate.failed_per_minute, 0.2);
         assert_close(static_stats.rate.growth_per_minute, 0.3);
-        assert_close(static_stats.rate.effective_drain_per_minute, 0.3);
-        assert_close(
-            static_stats.rate.eta_s.expect("eta should be finite"),
-            600.0,
-        );
+        assert_close(static_stats.rate.effective_drain_per_minute, 0.0);
+        assert!(static_stats.rate.eta_s.is_none());
 
         let dynamic_stats = stats
             .queues
@@ -2380,11 +2377,8 @@ mod tests {
         assert_close(dynamic_stats.rate.succeeded_per_minute, 0.4);
         assert_close(dynamic_stats.rate.failed_per_minute, 0.2);
         assert_close(dynamic_stats.rate.growth_per_minute, 0.3);
-        assert_close(dynamic_stats.rate.effective_drain_per_minute, 0.3);
-        assert_close(
-            dynamic_stats.rate.eta_s.expect("eta should be finite"),
-            600.0,
-        );
+        assert_close(dynamic_stats.rate.effective_drain_per_minute, 0.0);
+        assert!(dynamic_stats.rate.eta_s.is_none());
 
         let dynamic_queue_stats = dynamic_stats
             .queues
@@ -2395,14 +2389,8 @@ mod tests {
         assert_close(dynamic_queue_stats.rate.succeeded_per_minute, 0.0);
         assert_close(dynamic_queue_stats.rate.failed_per_minute, 0.2);
         assert_close(dynamic_queue_stats.rate.growth_per_minute, 0.1);
-        assert_close(dynamic_queue_stats.rate.effective_drain_per_minute, 0.1);
-        assert_close(
-            dynamic_queue_stats
-                .rate
-                .eta_s
-                .expect("eta should be finite"),
-            600.0,
-        );
+        assert_close(dynamic_queue_stats.rate.effective_drain_per_minute, 0.0);
+        assert!(dynamic_queue_stats.rate.eta_s.is_none());
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add public queue rate stats for processed, succeeded, failed, growth, effective drain, and ETA
- record per-minute per-queue processed/succeeded/failed counters in Redis with 8h retention
- calculate queue and dynamic sub-queue rates from the 10-minute history window, treating missing queue-length fields as zero
- show rate and ETA on `/queues` and queue detail pages

## Test plan
- `cargo check --all`
- `cargo test`
- `cargo clippy --all-targets --all-features --workspace`

## Review
- Pre-landing review: no issues found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Redis-backed per-queue counter metrics and extends the public `Stats` API with rate/ETA fields, which could affect dashboard/stat consumers and increase Redis write/read paths. Logic is covered by unit/integration tests but changes touch core stats aggregation.
> 
> **Overview**
> Adds **per-queue rate/ETA statistics** by recording per-minute per-queue processed/succeeded/failed counters in Redis (new `:qc:` hashes) and aggregating them over a 10-minute window to compute processed/succeeded/failed rates, growth, effective drain, and `eta_s` for both static and dynamic queues.
> 
> Extends `QueueStats`/`DynamicQueueStats` with a new `rate: QueueRateStats` field and wires this through `storage.stats()`, plus updates the web dashboard to display/sort by rate and ETA (new Askama filters + UI columns/tiles) and includes regression tests for rate calculation and ETA sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732c5ba77b7761db7ce50b89a440e12e5f912445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->