### PR TITLE
fix: hide zero values in metrics tooltips

### DIFF
--- a/oxanus-web/templates/metrics.html
+++ b/oxanus-web/templates/metrics.html
@@ -199,7 +199,8 @@
                 });
             }
 
-            function buildTooltip(chartEl, payload, formatter) {
+            function buildTooltip(chartEl, payload, formatter, options) {
+                options = options || {};
                 var tooltip = document.createElement('div');
                 tooltip.className = 'chart-tooltip hidden';
                 chartEl.appendChild(tooltip);
@@ -225,7 +226,9 @@
                     time.append(formatTime(payload.timestamps[idx]));
                     tooltip.appendChild(time);
 
-                    sortedSeriesRows(payload, idx).forEach(function (entry) {
+                    sortedSeriesRows(payload, idx).filter(function (entry) {
+                        return options.includeZeroValues !== false || entry.value !== 0;
+                    }).forEach(function (entry) {
                         var row = document.createElement('div');
                         var label = document.createElement('span');
                         label.className = 'chart-tooltip-label';
@@ -249,7 +252,7 @@
                 };
             }
 
-            function renderChart(chartId, payload, valueFormatter) {
+            function renderChart(chartId, payload, valueFormatter, options) {
                 var chartEl = document.getElementById(chartId);
                 if (!chartEl) {
                     return;
@@ -294,7 +297,7 @@
                         };
                     })),
                     hooks: {
-                        setCursor: [buildTooltip(chartEl, payload, valueFormatter)]
+                        setCursor: [buildTooltip(chartEl, payload, valueFormatter, options)]
                     }
                 }, data, chartEl);
             }
@@ -430,7 +433,9 @@
                     time.append(formatTime(timestamps[idx]));
                     tooltip.appendChild(time);
 
-                    sortedSeriesRows(payload, idx).forEach(function (entry) {
+                    sortedSeriesRows(payload, idx).filter(function (entry) {
+                        return entry.value !== 0;
+                    }).forEach(function (entry) {
                         var row = document.createElement('div');
                         var label = document.createElement('span');
                         label.className = 'chart-tooltip-label';
@@ -441,13 +446,15 @@
                         tooltip.appendChild(row);
                     });
 
-                    var total = document.createElement('div');
-                    var totalLabel = document.createElement('span');
-                    totalLabel.className = 'chart-tooltip-label';
-                    totalLabel.textContent = 'Total: ';
-                    total.appendChild(totalLabel);
-                    total.append(formatCount(totals[idx] || 0));
-                    tooltip.appendChild(total);
+                    if ((totals[idx] || 0) !== 0) {
+                        var total = document.createElement('div');
+                        var totalLabel = document.createElement('span');
+                        totalLabel.className = 'chart-tooltip-label';
+                        totalLabel.textContent = 'Total: ';
+                        total.appendChild(totalLabel);
+                        total.append(formatCount(totals[idx] || 0));
+                        tooltip.appendChild(total);
+                    }
                     tooltip.classList.remove('hidden');
 
                     var x = event.clientX - rect.left;
@@ -468,12 +475,14 @@
             renderChart(
                 'queue-length-chart',
                 {{ self.queue_length_chart_data_json()|safe }},
-                formatCount
+                formatCount,
+                { includeZeroValues: false }
             );
             renderChart(
                 'execution-chart',
                 {{ self.execution_chart_data_json()|safe }},
-                formatSeconds
+                formatSeconds,
+                { includeZeroValues: false }
             );
             renderStackedProcessedChart(
                 'processed-chart',


### PR DESCRIPTION
## Summary
- Hide zero-value series from Queue Lengths and Total Time chart hover tooltips.
- Hide zero worker rows and the `Total: 0` summary row from the Total Processed hover tooltip.

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --all-features --workspace
- [x] cargo test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change in `metrics.html` that tweaks tooltip rendering logic and adds an optional flag to omit zero values; no backend/data-path changes.
> 
> **Overview**
> Improves metrics chart hover tooltips by **hiding zero-value series rows** for the Queue Length and Total Time uPlot charts via a new `includeZeroValues` option passed through `renderChart`/`buildTooltip`.
> 
> Also updates the Total Processed (stacked) chart tooltip to **omit per-worker rows with `0`** and to hide the `Total` row when it would display `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce1d321396887f11df5a4e11b55822df4a936a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->