### PR TITLE
feat: move queue length chart to queues tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `#[derive(oxanus::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
 - Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
-- Add queue length history metrics and a Queue Lengths chart to the web metrics dashboard.
+- Add queue length history metrics and a Queue Lengths chart to the web queues dashboard.
 - Add per-queue processing rate, growth rate, and ETA stats with web dashboard display.
 
 ### Changed

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -45,6 +45,8 @@ pub(crate) async fn queues_list(
     Query(params): Query<QueuesParams>,
 ) -> Result<QueuesTemplate, OxanusWebError> {
     let mut stats = state.storage.stats().await?;
+    let query = oxanus::JobMetricsQuery::new(params.minutes.unwrap_or(0));
+    let queue_lengths = state.storage.queue_length_metrics(query).await?;
 
     let sort = params.sort.as_deref().unwrap_or("key");
     let dir = params.dir.as_deref().unwrap_or("asc");
@@ -57,6 +59,7 @@ pub(crate) async fn queues_list(
         active_tab: "/queues",
         stats,
         concurrency_map: state.concurrency_map,
+        queue_lengths,
         sort: sort.to_string(),
         dir: dir.to_string(),
     })
@@ -68,13 +71,11 @@ pub(crate) async fn metrics(
 ) -> Result<MetricsTemplate, OxanusWebError> {
     let query = oxanus::JobMetricsQuery::new(params.minutes.unwrap_or(0));
     let metrics = state.storage.job_metrics(query).await?;
-    let queue_lengths = state.storage.queue_length_metrics(query).await?;
 
     Ok(MetricsTemplate {
         base_path: state.base_path,
         active_tab: "/metrics",
         metrics,
-        queue_lengths,
     })
 }
 
@@ -347,6 +348,8 @@ pub(crate) struct QueuesParams {
     sort: Option<String>,
     #[serde(default)]
     dir: Option<String>,
+    #[serde(default)]
+    minutes: Option<usize>,
 }
 
 #[derive(Deserialize)]

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -81,6 +81,7 @@ pub(crate) struct QueuesTemplate {
     pub active_tab: &'static str,
     pub stats: oxanus::Stats,
     pub concurrency_map: HashMap<String, usize>,
+    pub queue_lengths: oxanus::QueueLengthMetricsSnapshot,
     pub sort: String,
     pub dir: String,
 }
@@ -106,31 +107,18 @@ impl QueuesTemplate {
         }
     }
 
+    pub fn sort_href(&self, col: &str) -> String {
+        format!(
+            "{}/queues?sort={}&dir={}&minutes={}",
+            self.base_path,
+            col,
+            self.next_dir(col),
+            self.queue_lengths.minutes
+        )
+    }
+
     pub fn concurrency_for(&self, key: &str) -> String {
         concurrency_for(&self.concurrency_map, key)
-    }
-}
-
-#[derive(Template, WebTemplate)]
-#[template(path = "metrics.html")]
-pub(crate) struct MetricsTemplate {
-    pub base_path: String,
-    pub active_tab: &'static str,
-    pub metrics: oxanus::JobMetricsSnapshot,
-    pub queue_lengths: oxanus::QueueLengthMetricsSnapshot,
-}
-
-impl MetricsTemplate {
-    pub fn metric_identity_label(&self, identity: &oxanus::MetricIdentity) -> String {
-        metric_identity_label(identity)
-    }
-
-    pub fn execution_chart_data_json(&self) -> String {
-        self.summary_chart_data_json(|point| point.execution_ms as f64 / 1000.0)
-    }
-
-    pub fn processed_chart_data_json(&self) -> String {
-        self.summary_chart_data_json(|point| point.processed as f64)
     }
 
     pub fn queue_length_chart_data_json(&self) -> String {
@@ -160,6 +148,120 @@ impl MetricsTemplate {
             "series": series,
         })
         .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueuesTemplate;
+    use std::collections::HashMap;
+
+    fn queues_template(queue_lengths: oxanus::QueueLengthMetricsSnapshot) -> QueuesTemplate {
+        QueuesTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/queues",
+            stats: oxanus::Stats {
+                global: oxanus::StatsGlobal {
+                    jobs: 0,
+                    enqueued: 0,
+                    processed: 0,
+                    failed: 0,
+                    dead: 0,
+                    scheduled: 0,
+                    retries: 0,
+                    latency_s_max: 0.0,
+                },
+                processes: Vec::new(),
+                processing: Vec::new(),
+                queues: Vec::new(),
+            },
+            concurrency_map: HashMap::new(),
+            queue_lengths,
+            sort: "key".to_string(),
+            dir: "asc".to_string(),
+        }
+    }
+
+    #[test]
+    fn queue_sort_href_preserves_chart_window() {
+        let template = queues_template(oxanus::QueueLengthMetricsSnapshot {
+            starts_at: 0,
+            ends_at: 0,
+            minutes: 120,
+            queues: Vec::new(),
+        });
+
+        assert_eq!(
+            template.sort_href("enqueued"),
+            "/admin/queues?sort=enqueued&dir=desc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn queue_length_chart_data_json_uses_window_when_no_queues_exist() {
+        let template = queues_template(oxanus::QueueLengthMetricsSnapshot {
+            starts_at: 60,
+            ends_at: 120,
+            minutes: 2,
+            queues: Vec::new(),
+        });
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.queue_length_chart_data_json()).unwrap();
+
+        assert_eq!(payload["timestamps"], serde_json::json!([60, 120]));
+        assert_eq!(payload["series"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn queue_length_chart_data_json_serializes_queue_series() {
+        let template = queues_template(oxanus::QueueLengthMetricsSnapshot {
+            starts_at: 60,
+            ends_at: 120,
+            minutes: 2,
+            queues: vec![oxanus::QueueLengthMetricsSeries {
+                queue: "default".to_string(),
+                series: vec![
+                    oxanus::QueueLengthMetricsPoint {
+                        timestamp: 60,
+                        enqueued: 2,
+                    },
+                    oxanus::QueueLengthMetricsPoint {
+                        timestamp: 120,
+                        enqueued: 5,
+                    },
+                ],
+            }],
+        });
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.queue_length_chart_data_json()).unwrap();
+
+        assert_eq!(payload["timestamps"], serde_json::json!([60, 120]));
+        assert_eq!(
+            payload["series"],
+            serde_json::json!([{ "label": "default", "data": [2, 5] }])
+        );
+    }
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "metrics.html")]
+pub(crate) struct MetricsTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub metrics: oxanus::JobMetricsSnapshot,
+}
+
+impl MetricsTemplate {
+    pub fn metric_identity_label(&self, identity: &oxanus::MetricIdentity) -> String {
+        metric_identity_label(identity)
+    }
+
+    pub fn execution_chart_data_json(&self) -> String {
+        self.summary_chart_data_json(|point| point.execution_ms as f64 / 1000.0)
+    }
+
+    pub fn processed_chart_data_json(&self) -> String {
+        self.summary_chart_data_json(|point| point.processed as f64)
     }
 
     fn summary_chart_data_json(&self, value: impl Fn(&oxanus::JobMetricsPoint) -> f64) -> String {

--- a/oxanus-web/templates/metrics.html
+++ b/oxanus-web/templates/metrics.html
@@ -83,14 +83,6 @@
         <section class="space-y-6 mb-10">
             <div>
                 <div class="flex items-center justify-between mb-4">
-                    <h2 class="text-lg font-semibold">Queue Lengths</h2>
-                </div>
-                <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
-                    <div id="queue-length-chart" class="w-full h-[300px]"></div>
-                </div>
-            </div>
-            <div>
-                <div class="flex items-center justify-between mb-4">
                     <h2 class="text-lg font-semibold">Total Time</h2>
                 </div>
                 <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
@@ -472,12 +464,6 @@
                 });
             }
 
-            renderChart(
-                'queue-length-chart',
-                {{ self.queue_length_chart_data_json()|safe }},
-                formatCount,
-                { includeZeroValues: false }
-            );
             renderChart(
                 'execution-chart',
                 {{ self.execution_chart_data_json()|safe }},

--- a/oxanus-web/templates/queues.html
+++ b/oxanus-web/templates/queues.html
@@ -5,6 +5,36 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Queues - Oxanus</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"></script>
+    <style>
+        .uplot {
+            color: #d1d5db;
+            background: transparent;
+        }
+        .chart-tooltip {
+            position: absolute;
+            z-index: 10;
+            min-width: 9rem;
+            pointer-events: none;
+            border: 1px solid #374151;
+            border-radius: 0.375rem;
+            background: rgba(17, 24, 39, 0.96);
+            color: #f9fafb;
+            padding: 0.5rem 0.625rem;
+            font-size: 0.75rem;
+            line-height: 1.25rem;
+            white-space: nowrap;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
+            transform: translate(-50%, -100%);
+        }
+        .chart-tooltip.hidden {
+            display: none;
+        }
+        .chart-tooltip-label {
+            color: #9ca3af;
+        }
+    </style>
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
     <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -15,6 +45,26 @@
         {% include "_tabs.html" %}
 
         {% include "_stats_cards.html" %}
+
+        <section class="mb-10">
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+                <h2 class="text-lg font-semibold">Queue Lengths</h2>
+                <form method="GET" action="{{ base_path }}/queues" class="flex items-center gap-2 text-sm">
+                    <input type="hidden" name="sort" value="{{ sort }}">
+                    <input type="hidden" name="dir" value="{{ dir }}">
+                    <label for="minutes" class="text-gray-400">Window</label>
+                    <select id="minutes" name="minutes" class="bg-gray-900 border border-gray-800 rounded px-3 py-1.5 text-gray-200" onchange="this.form.submit()">
+                        <option value="60" {% if queue_lengths.minutes == 60 %}selected{% endif %}>60 minutes</option>
+                        <option value="120" {% if queue_lengths.minutes == 120 %}selected{% endif %}>2 hours</option>
+                        <option value="240" {% if queue_lengths.minutes == 240 %}selected{% endif %}>4 hours</option>
+                        <option value="480" {% if queue_lengths.minutes == 480 %}selected{% endif %}>8 hours</option>
+                    </select>
+                </form>
+            </div>
+            <div class="relative bg-gray-900 border border-gray-800 rounded-lg p-4">
+                <div id="queue-length-chart" class="w-full h-[300px]"></div>
+            </div>
+        </section>
 
         <h2 class="text-lg font-semibold mb-4">Queues ({{ stats.queues.len() }})</h2>
 
@@ -27,16 +77,16 @@
             <table class="w-full text-sm">
                 <thead>
                     <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
-                        <th class="pb-3 pr-4"><a href="{{ base_path }}/queues?sort=key&dir={{ self.next_dir("key") }}" class="hover:text-gray-200">Queue{{ self.sort_arrow("key") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=concurrency&dir={{ self.next_dir("concurrency") }}" class="hover:text-gray-200">Concurrency{{ self.sort_arrow("concurrency") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=enqueued&dir={{ self.next_dir("enqueued") }}" class="hover:text-gray-200">Enqueued{{ self.sort_arrow("enqueued") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=rate&dir={{ self.next_dir("rate") }}" class="hover:text-gray-200">Rate{{ self.sort_arrow("rate") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=eta&dir={{ self.next_dir("eta") }}" class="hover:text-gray-200">ETA{{ self.sort_arrow("eta") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=processed&dir={{ self.next_dir("processed") }}" class="hover:text-gray-200">Processed{{ self.sort_arrow("processed") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=succeeded&dir={{ self.next_dir("succeeded") }}" class="hover:text-gray-200">Succeeded{{ self.sort_arrow("succeeded") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=failed&dir={{ self.next_dir("failed") }}" class="hover:text-gray-200">Failed{{ self.sort_arrow("failed") }}</a></th>
-                        <th class="pb-3 pr-4 text-right"><a href="{{ base_path }}/queues?sort=panicked&dir={{ self.next_dir("panicked") }}" class="hover:text-gray-200">Panicked{{ self.sort_arrow("panicked") }}</a></th>
-                        <th class="pb-3 text-right"><a href="{{ base_path }}/queues?sort=latency&dir={{ self.next_dir("latency") }}" class="hover:text-gray-200">Latency{{ self.sort_arrow("latency") }}</a></th>
+                        <th class="pb-3 pr-4"><a href="{{ self.sort_href("key") }}" class="hover:text-gray-200">Queue{{ self.sort_arrow("key") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("concurrency") }}" class="hover:text-gray-200">Concurrency{{ self.sort_arrow("concurrency") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("enqueued") }}" class="hover:text-gray-200">Enqueued{{ self.sort_arrow("enqueued") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("rate") }}" class="hover:text-gray-200">Rate{{ self.sort_arrow("rate") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("eta") }}" class="hover:text-gray-200">ETA{{ self.sort_arrow("eta") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("processed") }}" class="hover:text-gray-200">Processed{{ self.sort_arrow("processed") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("succeeded") }}" class="hover:text-gray-200">Succeeded{{ self.sort_arrow("succeeded") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("failed") }}" class="hover:text-gray-200">Failed{{ self.sort_arrow("failed") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("panicked") }}" class="hover:text-gray-200">Panicked{{ self.sort_arrow("panicked") }}</a></th>
+                        <th class="pb-3 text-right"><a href="{{ self.sort_href("latency") }}" class="hover:text-gray-200">Latency{{ self.sort_arrow("latency") }}</a></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -73,5 +123,162 @@
         </div>
         {% endif %}
     </div>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            if (typeof uPlot === 'undefined') {
+                return;
+            }
+
+            function formatTime(ts) {
+                return new Date(ts * 1000).toLocaleString(undefined, {
+                    month: 'numeric',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit'
+                });
+            }
+
+            function formatCount(value) {
+                return Math.round(value).toLocaleString();
+            }
+
+            var palette = [
+                '#60a5fa',
+                '#4ade80',
+                '#f472b6',
+                '#facc15',
+                '#a78bfa',
+                '#2dd4bf',
+                '#fb923c',
+                '#94a3b8'
+            ];
+
+            function seriesColor(index) {
+                return palette[index % palette.length];
+            }
+
+            function sortedSeriesRows(payload, idx) {
+                return payload.series.map(function (series, seriesIdx) {
+                    return {
+                        series: series,
+                        seriesIdx: seriesIdx,
+                        value: series.data[idx] || 0
+                    };
+                }).sort(function (a, b) {
+                    return (b.value - a.value) || (a.seriesIdx - b.seriesIdx);
+                });
+            }
+
+            function buildTooltip(chartEl, payload, formatter, options) {
+                options = options || {};
+                var tooltip = document.createElement('div');
+                tooltip.className = 'chart-tooltip hidden';
+                chartEl.appendChild(tooltip);
+
+                chartEl.addEventListener('mouseleave', function () {
+                    tooltip.classList.add('hidden');
+                });
+
+                return function (u) {
+                    var idx = u.cursor.idx;
+                    if (idx == null || idx < 0 || idx >= payload.timestamps.length) {
+                        tooltip.classList.add('hidden');
+                        return;
+                    }
+
+                    tooltip.replaceChildren();
+
+                    var time = document.createElement('div');
+                    var timeLabel = document.createElement('span');
+                    timeLabel.className = 'chart-tooltip-label';
+                    timeLabel.textContent = 'Time: ';
+                    time.appendChild(timeLabel);
+                    time.append(formatTime(payload.timestamps[idx]));
+                    tooltip.appendChild(time);
+
+                    sortedSeriesRows(payload, idx).filter(function (entry) {
+                        return options.includeZeroValues !== false || entry.value !== 0;
+                    }).forEach(function (entry) {
+                        var row = document.createElement('div');
+                        var label = document.createElement('span');
+                        label.className = 'chart-tooltip-label';
+                        label.textContent = entry.series.label + ': ';
+                        label.style.color = seriesColor(entry.seriesIdx);
+                        row.appendChild(label);
+                        row.append(formatter(entry.value));
+                        tooltip.appendChild(row);
+                    });
+
+                    tooltip.classList.remove('hidden');
+
+                    var x = u.over.offsetLeft + u.cursor.left;
+                    var y = u.over.offsetTop + u.cursor.top;
+                    var halfWidth = tooltip.offsetWidth / 2;
+                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
+                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
+
+                    tooltip.style.left = left + 'px';
+                    tooltip.style.top = top + 'px';
+                };
+            }
+
+            function renderChart(chartId, payload, valueFormatter, options) {
+                var chartEl = document.getElementById(chartId);
+                if (!chartEl) {
+                    return;
+                }
+
+                var data = [payload.timestamps].concat(payload.series.map(function (series) {
+                    return series.data;
+                }));
+
+                new uPlot({
+                    width: Math.max(chartEl.clientWidth, 320),
+                    height: 300,
+                    legend: { show: false },
+                    tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
+                    scales: {
+                        x: { time: true },
+                        y: { range: [0, null] }
+                    },
+                    axes: [
+                        {
+                            stroke: '#9ca3af',
+                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                            ticks: { stroke: '#374151' }
+                        },
+                        {
+                            size: 72,
+                            stroke: '#9ca3af',
+                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                            ticks: { stroke: '#374151' },
+                            values: function (_u, vals) {
+                                return vals.map(valueFormatter);
+                            }
+                        }
+                    ],
+                    series: [
+                        {}
+                    ].concat(payload.series.map(function (series, index) {
+                        return {
+                            label: series.label,
+                            stroke: seriesColor(index),
+                            width: 2
+                        };
+                    })),
+                    hooks: {
+                        setCursor: [buildTooltip(chartEl, payload, valueFormatter, options)]
+                    }
+                }, data, chartEl);
+            }
+
+            renderChart(
+                'queue-length-chart',
+                {{ self.queue_length_chart_data_json()|safe }},
+                formatCount,
+                { includeZeroValues: false }
+            );
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Move the Queue Lengths chart from the Metrics tab to the Queues tab, directly after the dashboard stat badges and before the Queues table header.
- Load queue length metrics from the queues handler and remove that data dependency from the metrics handler.
- Preserve the Queue Lengths window selector on the queues page and keep the selected window when sorting queue columns.
- Add unit coverage for queue-length chart JSON serialization and sort-link window preservation.
- Update the unreleased changelog entry to point at the queues dashboard.

## Test Coverage
- Added 3 unit tests in `oxanus-web/src/templates.rs` for the moved queue chart helper behavior.
- Coverage audit: moved UI/data helper paths covered for JSON payload generation and sort URL window preservation. Browser rendering is covered by Askama compile-time template checks via `cargo check`.

## Pre-Landing Review
No issues found in the inline pre-landing review.

## Design Review
Frontend template change reviewed inline. No layout overlap or obvious responsive issue found in the static markup; existing dashboard card and chart styling is reused.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN
Intent: move Queue Lengths from Metrics to Queues after the badges.
Delivered: chart moved to the requested location, with supporting handler/template data and tests.

## Plan Completion
No plan file detected.

## Verification Results
No browser dev server verification was run. This is an Askama/Rust dashboard template change verified through compile and unit tests.

## Test plan
- [x] `cargo fmt`
- [x] `cargo check --all`
- [x] `cargo test -p oxanus-web` (5 passed, 0 failed)

Generated with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/handler refactor in the web dashboard: moves existing queue-length metrics fetching/rendering between pages and adds query param handling/tests, with no core queue processing changes.
> 
> **Overview**
> Moves the **Queue Lengths** time-series chart off the `Metrics` tab and into the `Queues` tab (rendered above the queues table) with a selectable time window.
> 
> Shifts queue-length metrics fetching to the `queues_list` handler (adds `minutes` query param) and removes the metrics page dependency, while updating queue sort links to preserve the selected window.
> 
> Adds unit tests for `QueuesTemplate` chart JSON serialization and for ensuring sort URLs retain the chart window; updates the changelog entry to reference the queues dashboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d1bfd0f634e618f9beaf1d31ea23d9d06fd771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->