### PR TITLE
feat: allow separate Redis stats URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Add queue length history metrics and a Queue Lengths chart to the web queues dashboard.
 - Add per-queue processing rate, growth rate, and ETA stats with web dashboard display.
 - Add `#[oxanus(on_demand = true)]` and an On-Demand dashboard tab for manually enqueueing registered jobs.
+- Add separate Redis configuration for stats via `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools`.
 
 ### Changed
 

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -164,6 +164,7 @@ The component registry automatically discovers and registers all workers and que
 `Storage` provides the interface for job persistence - enqueueing, scheduling, state management, and queue monitoring.
 
 Build it with `Storage::builder().build_from_env()` which reads the `REDIS_URL` environment variable.
+Set `REDIS_STATS_URL` to store counters and metrics in a separate Redis instance; when it is not set, stats use `REDIS_URL`.
 
 ### Context
 

--- a/oxanus/src/storage_builder.rs
+++ b/oxanus/src/storage_builder.rs
@@ -10,6 +10,7 @@ pub struct StorageBuilder {
     timeouts: Option<StorageBuilderTimeouts>,
 }
 
+#[derive(Clone, Copy)]
 pub struct StorageBuilderTimeouts {
     pub wait: Option<std::time::Duration>,
     pub create: Option<std::time::Duration>,
@@ -77,14 +78,45 @@ impl StorageBuilder {
     }
 
     pub fn build_from_redis_url(self, url: impl Into<String>) -> Result<Storage, OxanusError> {
+        let pool = Self::build_redis_pool(
+            url,
+            self.max_pool_size.unwrap_or(50),
+            self.timeouts.unwrap_or_default(),
+        )?;
+
+        Ok(Storage {
+            internal: StorageInternal::new(pool, self.namespace),
+        })
+    }
+
+    pub fn build_from_redis_urls(
+        self,
+        url: impl Into<String>,
+        stats_url: impl Into<String>,
+    ) -> Result<Storage, OxanusError> {
+        let max_pool_size = self.max_pool_size.unwrap_or(50);
+        let timeouts = self.timeouts.unwrap_or_default();
+        let pool = Self::build_redis_pool(url, max_pool_size, timeouts)?;
+        let stats_pool = Self::build_redis_pool(stats_url, max_pool_size, timeouts)?;
+
+        Ok(Storage {
+            internal: StorageInternal::with_stats_pool(pool, stats_pool, self.namespace),
+        })
+    }
+
+    fn build_redis_pool(
+        url: impl Into<String>,
+        max_pool_size: usize,
+        timeouts: StorageBuilderTimeouts,
+    ) -> Result<deadpool_redis::Pool, OxanusError> {
         let mut cfg = deadpool_redis::Config::from_url(url);
         cfg.pool = Some(deadpool_redis::PoolConfig {
-            max_size: self.max_pool_size.unwrap_or(50),
-            timeouts: self.timeouts.unwrap_or_default().into(),
+            max_size: max_pool_size,
+            timeouts: timeouts.into(),
             queue_mode: Default::default(),
         });
 
-        let pool = cfg
+        Ok(cfg
             .builder()?
             .post_create(Hook::sync_fn(|conn, _| {
                 // redis 1.0 introduced a default 500ms response_timeout on
@@ -95,11 +127,7 @@ impl StorageBuilder {
                 Ok(())
             }))
             .runtime(deadpool_redis::Runtime::Tokio1)
-            .build()?;
-
-        Ok(Storage {
-            internal: StorageInternal::new(pool, self.namespace),
-        })
+            .build()?)
     }
 
     pub fn build_from_env(self) -> Result<Storage, OxanusError> {
@@ -108,11 +136,46 @@ impl StorageBuilder {
 
     pub fn build_from_env_var(self, var_name: &str) -> Result<Storage, OxanusError> {
         let url = std::env::var(var_name).unwrap_or_else(|_| panic!("{var_name} is not set"));
-        self.build_from_redis_url(url)
+        match std::env::var("REDIS_STATS_URL") {
+            Ok(stats_url) => self.build_from_redis_urls(url, stats_url),
+            Err(_) => self.build_from_redis_url(url),
+        }
     }
 
     pub fn build_from_pool(self, pool: deadpool_redis::Pool) -> Result<Storage, OxanusError> {
         let internal = StorageInternal::new(pool, self.namespace);
         Ok(Storage { internal })
+    }
+
+    pub fn build_from_pools(
+        self,
+        pool: deadpool_redis::Pool,
+        stats_pool: deadpool_redis::Pool,
+    ) -> Result<Storage, OxanusError> {
+        let internal = StorageInternal::with_stats_pool(pool, stats_pool, self.namespace);
+        Ok(Storage { internal })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StorageBuilder;
+
+    #[test]
+    fn build_from_redis_url_uses_primary_pool_for_stats() {
+        let storage = StorageBuilder::new()
+            .build_from_redis_url("redis://127.0.0.1/0")
+            .expect("storage should build");
+
+        assert!(!storage.internal.has_dedicated_stats_pool());
+    }
+
+    #[test]
+    fn build_from_redis_urls_uses_dedicated_stats_pool() {
+        let storage = StorageBuilder::new()
+            .build_from_redis_urls("redis://127.0.0.1/0", "redis://127.0.0.1/1")
+            .expect("storage should build");
+
+        assert!(storage.internal.has_dedicated_stats_pool());
     }
 }

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -40,6 +40,7 @@ const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
 #[derive(Clone)]
 pub(crate) struct StorageInternal {
     pool: deadpool_redis::Pool,
+    stats_pool: Option<deadpool_redis::Pool>,
     keys: StorageKeys,
     started_at: i64,
     consecutive_redis_failures: Arc<AtomicU32>,
@@ -57,11 +58,34 @@ struct QueueLengthSnapshot {
     refreshed_at: Option<i64>,
 }
 
+struct QueueStatsInputs {
+    stats: HashMap<String, i64>,
+    queue_length_rate_hashes: Vec<HashMap<String, i64>>,
+    queue_counter_totals: HashMap<String, QueueCounterTotals>,
+}
+
 impl StorageInternal {
     pub fn new(pool: deadpool_redis::Pool, namespace: Option<String>) -> Self {
+        Self::with_optional_stats_pool(pool, None, namespace)
+    }
+
+    pub fn with_stats_pool(
+        pool: deadpool_redis::Pool,
+        stats_pool: deadpool_redis::Pool,
+        namespace: Option<String>,
+    ) -> Self {
+        Self::with_optional_stats_pool(pool, Some(stats_pool), namespace)
+    }
+
+    fn with_optional_stats_pool(
+        pool: deadpool_redis::Pool,
+        stats_pool: Option<deadpool_redis::Pool>,
+        namespace: Option<String>,
+    ) -> Self {
         let keys = StorageKeys::new(namespace.unwrap_or_default());
         Self {
             pool,
+            stats_pool,
             keys,
             started_at: chrono::Utc::now().timestamp(),
             consecutive_redis_failures: Arc::new(AtomicU32::new(0)),
@@ -109,13 +133,28 @@ impl StorageInternal {
         &self.keys.namespace
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_dedicated_stats_pool(&self) -> bool {
+        self.stats_pool.is_some()
+    }
+
     pub async fn pool(&self) -> Result<deadpool_redis::Pool, OxanusError> {
         Ok(self.pool.clone())
     }
 
     pub async fn connection(&self) -> Result<deadpool_redis::Connection, OxanusError> {
-        self.pool
-            .get()
+        Self::connection_from_pool(&self.pool).await
+    }
+
+    async fn stats_connection(&self) -> Result<deadpool_redis::Connection, OxanusError> {
+        let pool = self.stats_pool.as_ref().unwrap_or(&self.pool);
+        Self::connection_from_pool(pool).await
+    }
+
+    async fn connection_from_pool(
+        pool: &deadpool_redis::Pool,
+    ) -> Result<deadpool_redis::Connection, OxanusError> {
+        pool.get()
             .await
             .map_err(OxanusError::DeadpoolRedisPoolError)
     }
@@ -809,16 +848,9 @@ impl StorageInternal {
         queues: &[String],
         filter: bool,
     ) -> Result<Vec<QueueStats>, OxanusError> {
-        let list: HashMap<String, i64> = (*redis).hgetall(&self.keys.stats).await?;
         let now = chrono::Utc::now().timestamp();
         let rate_minutes = metric_minutes(now, JobMetricsQuery::new(QUEUE_RATE_WINDOW_MINUTES));
-        let queue_length_rate_hashes = self
-            .queue_length_metric_hashes(redis, &rate_minutes)
-            .await?;
-        let queue_counter_rate_hashes = self
-            .queue_counter_metric_hashes(redis, &rate_minutes)
-            .await?;
-        let queue_counter_totals = aggregate_queue_counter_hashes(queue_counter_rate_hashes);
+        let inputs = self.queue_stats_inputs(redis, &rate_minutes).await?;
 
         let mut map = HashMap::new();
         let mut queue_values: Vec<(String, String, i64)> = Vec::new();
@@ -828,7 +860,7 @@ impl StorageInternal {
             queue_values.push((queue.clone(), "processed".to_string(), 0));
         }
 
-        for (key, value) in list {
+        for (key, value) in inputs.stats {
             let (queue_full_key, stat_key) = match Self::stats_key_parts(&key) {
                 Some(parts) => parts,
                 None => continue,
@@ -943,8 +975,8 @@ impl StorageInternal {
                 value.rate = Self::queue_rate_stats(
                     &value.key,
                     value.enqueued,
-                    &queue_length_rate_hashes,
-                    &queue_counter_totals,
+                    &inputs.queue_length_rate_hashes,
+                    &inputs.queue_counter_totals,
                 );
             } else {
                 for dynamic_queue in value.queues.iter_mut() {
@@ -967,8 +999,8 @@ impl StorageInternal {
                     dynamic_queue.rate = Self::queue_rate_stats(
                         &dynamic_queue_key,
                         dynamic_queue.enqueued,
-                        &queue_length_rate_hashes,
-                        &queue_counter_totals,
+                        &inputs.queue_length_rate_hashes,
+                        &inputs.queue_counter_totals,
                     );
 
                     if value.latency_s < latency_s {
@@ -989,6 +1021,39 @@ impl StorageInternal {
         values.sort_by(|a, b| a.key.cmp(&b.key));
 
         Ok(values)
+    }
+
+    async fn queue_stats_inputs(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        rate_minutes: &[i64],
+    ) -> Result<QueueStatsInputs, OxanusError> {
+        if self.stats_pool.is_some() {
+            let mut stats_redis = self.stats_connection().await?;
+            self.queue_stats_inputs_w_conn(&mut stats_redis, rate_minutes)
+                .await
+        } else {
+            self.queue_stats_inputs_w_conn(redis, rate_minutes).await
+        }
+    }
+
+    async fn queue_stats_inputs_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        rate_minutes: &[i64],
+    ) -> Result<QueueStatsInputs, OxanusError> {
+        let stats: HashMap<String, i64> = (*redis).hgetall(&self.keys.stats).await?;
+        let queue_length_rate_hashes = self.queue_length_metric_hashes(redis, rate_minutes).await?;
+        let queue_counter_rate_hashes = self
+            .queue_counter_metric_hashes(redis, rate_minutes)
+            .await?;
+        let queue_counter_totals = aggregate_queue_counter_hashes(queue_counter_rate_hashes);
+
+        Ok(QueueStatsInputs {
+            stats,
+            queue_length_rate_hashes,
+            queue_counter_totals,
+        })
     }
 
     fn stats_key_parts(key: &str) -> Option<(&str, &str)> {
@@ -1098,7 +1163,7 @@ impl StorageInternal {
             return Ok(());
         }
 
-        let mut redis = self.connection().await?;
+        let mut redis = self.stats_connection().await?;
         let mut pipe = redis::pipe();
         let mut has_commands = false;
 
@@ -1164,10 +1229,29 @@ impl StorageInternal {
         }
 
         let refreshed_at = chrono::Utc::now().timestamp();
+
+        if self.stats_pool.is_some() {
+            let mut stats_redis = self.stats_connection().await?;
+            self.write_queue_length_stats(&mut stats_redis, &lengths, refreshed_at)
+                .await?;
+        } else {
+            self.write_queue_length_stats(&mut redis, &lengths, refreshed_at)
+                .await?;
+        }
+
+        Ok(lengths)
+    }
+
+    async fn write_queue_length_stats(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        lengths: &HashMap<String, i64>,
+        refreshed_at: i64,
+    ) -> Result<(), OxanusError> {
         let queue_length_key = self.metrics_queue_length_key(refreshed_at.div_euclid(60));
         let mut pipe = redis::pipe();
 
-        for (queue, count) in &lengths {
+        for (queue, count) in lengths {
             pipe.hset(&self.keys.stats, format!("{queue}:enqueued"), *count)
                 .hset(
                     &self.keys.stats,
@@ -1178,9 +1262,9 @@ impl StorageInternal {
         }
         pipe.expire(queue_length_key, METRICS_RETENTION_SECS);
 
-        let _: () = pipe.query_async(&mut redis).await?;
+        let _: () = pipe.query_async(redis).await?;
 
-        Ok(lengths)
+        Ok(())
     }
 
     pub async fn flush_job_metrics(&self, buffer: &JobMetricsBuffer) -> Result<(), OxanusError> {
@@ -1188,7 +1272,7 @@ impl StorageInternal {
             return Ok(());
         }
 
-        let mut redis = self.connection().await?;
+        let mut redis = self.stats_connection().await?;
         let mut pipe = redis::pipe();
 
         for (minute, identity, metrics) in buffer.records() {
@@ -1301,7 +1385,7 @@ impl StorageInternal {
         &self,
         query: JobMetricsQuery,
     ) -> Result<JobMetricsSnapshot, OxanusError> {
-        let mut redis = self.connection().await?;
+        let mut redis = self.stats_connection().await?;
         let minutes = metric_minutes(chrono::Utc::now().timestamp(), query);
         let hashes = self.metrics_counter_hashes(&mut redis, &minutes).await?;
         let aggregation = aggregate_counter_hashes(&minutes, hashes, None);
@@ -1323,7 +1407,7 @@ impl StorageInternal {
         identity: &MetricIdentity,
         query: JobMetricsQuery,
     ) -> Result<JobMetricsDetail, OxanusError> {
-        let mut redis = self.connection().await?;
+        let mut redis = self.stats_connection().await?;
         let minutes = metric_minutes(chrono::Utc::now().timestamp(), query);
         let hashes = self
             .metrics_counter_hashes_for(&mut redis, &minutes, identity)
@@ -1350,7 +1434,7 @@ impl StorageInternal {
         &self,
         query: JobMetricsQuery,
     ) -> Result<QueueLengthMetricsSnapshot, OxanusError> {
-        let mut redis = self.connection().await?;
+        let mut redis = self.stats_connection().await?;
         let minutes = metric_minutes(chrono::Utc::now().timestamp(), query);
         let hashes = self
             .queue_length_metric_hashes(&mut redis, &minutes)


### PR DESCRIPTION
## Summary
- Add optional stats Redis pool support to `StorageBuilder` via `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools`
- Route stats counters, queue length history, and metrics through the stats pool while keeping job state on the primary pool
- Document the `REDIS_STATS_URL` fallback behavior and update the changelog

## Verification
- `cargo fmt --all`
- `cargo clippy --all-features --workspace`

## Review
- Pre-landing review: no issues found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core storage/Redis code paths by introducing an optional second pool and rerouting metrics/stat writes/reads, which could affect dashboard/metrics correctness if misconfigured. Job data operations remain on the primary pool, limiting blast radius to observability and queue stats.
> 
> **Overview**
> Adds optional support for storing *stats/metrics* in a separate Redis instance via `REDIS_STATS_URL` and new `StorageBuilder` APIs (`build_from_redis_urls`, `build_from_pools`), while keeping job state in the primary Redis.
> 
> Updates `StorageInternal` to maintain an optional `stats_pool` and route queue stats aggregation, result counters, queue length snapshots, and metrics read/write operations through a `stats_connection()` when configured (fallbacks to the primary pool otherwise), with accompanying tests and documentation/changelog updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f104758b044d8e04079485cb4ac598f5710767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->