### PR TITLE
Improve on-demand job registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxanus(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
 - Add queue length history metrics and a Queue Lengths chart to the web queues dashboard.
 - Add per-queue processing rate, growth rate, and ETA stats with web dashboard display.
-- Add `#[oxanus(on_demand = true)]` and an On-Demand dashboard tab for manually enqueueing registered jobs.
+- Add `#[oxanus(on_demand)]` and an On-Demand dashboard tab for manually enqueueing registered jobs.
 - Add separate Redis configuration for stats via `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools`.
 
 ### Changed

--- a/oxanus-macros/src/job.rs
+++ b/oxanus-macros/src/job.rs
@@ -1,4 +1,4 @@
-use darling::{Error, FromDeriveInput, FromMeta};
+use darling::{Error, FromDeriveInput, FromMeta, util::Flag};
 use heck::{
     ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
     ToUpperCamelCase,
@@ -19,7 +19,7 @@ struct OxanusJobArgs {
     on_conflict: Option<Ident>,
     resurrect: Option<bool>,
     throttle_cost: Option<ThrottleCost>,
-    on_demand: Option<bool>,
+    on_demand: Flag,
 }
 
 #[derive(Debug)]
@@ -174,7 +174,7 @@ pub fn expand_derive_job(input: DeriveInput) -> TokenStream {
     };
 
     let on_demand_args_template =
-        expand_on_demand_args_template(&input, args.on_demand.unwrap_or(false));
+        expand_on_demand_args_template(&input, args.on_demand.is_present());
 
     quote! {
         #[automatically_derived]
@@ -439,6 +439,7 @@ fn json_template_for_path(path: &syn::TypePath) -> TokenStream {
         "f32" | "f64" => quote!(0.0),
         "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128"
         | "usize" => quote!(0),
+        _ if looks_like_numeric_id_newtype(&ident) => quote!(0),
         "Vec" | "VecDeque" | "LinkedList" | "HashSet" | "BTreeSet" => quote!([]),
         "HashMap" | "BTreeMap" => quote!({}),
         "Box" => {
@@ -446,6 +447,10 @@ fn json_template_for_path(path: &syn::TypePath) -> TokenStream {
         }
         _ => quote!({}),
     }
+}
+
+fn looks_like_numeric_id_newtype(ident: &str) -> bool {
+    ident.ends_with("Id") || ident.ends_with("ID")
 }
 
 fn generic_type(arguments: &PathArguments) -> Option<&Type> {

--- a/oxanus-web/examples/web.rs
+++ b/oxanus-web/examples/web.rs
@@ -1,6 +1,6 @@
 // cargo run --package oxanus-web --example web
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 #[derive(oxanus::Registry)]
 struct ComponentRegistry(oxanus::ComponentRegistry<WorkerContext, WorkerError>);
@@ -11,66 +11,94 @@ enum WorkerError {}
 #[derive(Debug, Clone)]
 struct WorkerContext {}
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
-#[oxanus(on_demand = true)]
-struct SyncCustomerProfileJob {
-    duration_ms: u64,
-}
+mod demo {
+    pub(crate) mod crm {
+        pub(crate) mod customers {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
 
-#[derive(oxanus::Worker)]
-#[oxanus(max_retries = 0)]
-struct SyncCustomerProfileWorker;
+            #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+            #[oxanus(on_demand)]
+            pub(crate) struct SyncCustomerProfileJob {
+                pub(crate) duration_ms: u64,
+            }
 
-impl SyncCustomerProfileWorker {
-    async fn process(
-        &self,
-        job: SyncCustomerProfileJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
-        tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
-        Ok(())
+            #[derive(oxanus::Worker)]
+            #[oxanus(max_retries = 0)]
+            struct SyncCustomerProfileWorker;
+
+            impl SyncCustomerProfileWorker {
+                async fn process(
+                    &self,
+                    job: SyncCustomerProfileJob,
+                    _ctx: &oxanus::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    pub(crate) mod billing {
+        pub(crate) mod invoices {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+            #[oxanus(on_demand)]
+            pub(crate) struct GenerateInvoiceJob {
+                pub(crate) duration_ms: u64,
+            }
+
+            #[derive(oxanus::Worker)]
+            #[oxanus(max_retries = 0)]
+            struct GenerateInvoiceWorker;
+
+            impl GenerateInvoiceWorker {
+                async fn process(
+                    &self,
+                    job: GenerateInvoiceJob,
+                    _ctx: &oxanus::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    pub(crate) mod messaging {
+        pub(crate) mod receipts {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+            pub(crate) struct SendReceiptEmailJob {
+                pub(crate) duration_ms: u64,
+            }
+
+            #[derive(oxanus::Worker)]
+            #[oxanus(max_retries = 0)]
+            struct SendReceiptEmailWorker;
+
+            impl SendReceiptEmailWorker {
+                async fn process(
+                    &self,
+                    job: SendReceiptEmailJob,
+                    _ctx: &oxanus::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
-struct GenerateInvoiceJob {
-    duration_ms: u64,
-}
-
-#[derive(oxanus::Worker)]
-#[oxanus(max_retries = 0)]
-struct GenerateInvoiceWorker;
-
-impl GenerateInvoiceWorker {
-    async fn process(
-        &self,
-        job: GenerateInvoiceJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
-        tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, oxanus::Job)]
-struct SendReceiptEmailJob {
-    duration_ms: u64,
-}
-
-#[derive(oxanus::Worker)]
-#[oxanus(max_retries = 0)]
-struct SendReceiptEmailWorker;
-
-impl SendReceiptEmailWorker {
-    async fn process(
-        &self,
-        job: SendReceiptEmailJob,
-        _ctx: &oxanus::JobContext,
-    ) -> Result<(), WorkerError> {
-        tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
-        Ok(())
-    }
-}
+use demo::billing::invoices::GenerateInvoiceJob;
+use demo::crm::customers::SyncCustomerProfileJob;
+use demo::messaging::receipts::SendReceiptEmailJob;
 
 #[derive(Serialize, oxanus::Queue)]
 #[oxanus(key = "default", concurrency = 5)]

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     response::Redirect,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::JOBS_PER_PAGE;
 use crate::OxanusWebState;
@@ -12,7 +12,7 @@ use crate::error::OxanusWebError;
 use crate::templates::{
     BusyTemplate, CronRow, CronTemplate, CronWorkerView, DashboardTemplate, GlobalJobsTemplate,
     JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView, OnDemandQueueView,
-    OnDemandTemplate, QueueDetailTemplate, QueuesTemplate,
+    OnDemandRow, OnDemandTemplate, QueueDetailTemplate, QueuesTemplate,
 };
 
 pub(crate) async fn dashboard(
@@ -119,17 +119,7 @@ pub(crate) async fn on_demand_jobs(
     Extension(state): Extension<OxanusWebState>,
     Query(params): Query<OnDemandParams>,
 ) -> OnDemandTemplate {
-    let jobs = state
-        .catalog
-        .on_demand_jobs
-        .iter()
-        .map(|job| OnDemandJobView {
-            name: job.name.clone(),
-            short_name: short_type_name(&job.name),
-            args_template_json: serde_json::to_string_pretty(&job.args_template)
-                .unwrap_or_else(|_| job.args_template.to_string()),
-        })
-        .collect::<Vec<_>>();
+    let rows = build_on_demand_rows(&state.catalog.on_demand_jobs);
     let queues = state
         .catalog
         .queues
@@ -143,8 +133,8 @@ pub(crate) async fn on_demand_jobs(
     OnDemandTemplate {
         base_path: state.base_path,
         active_tab: "/on-demand",
-        total: jobs.len(),
-        jobs,
+        total: state.catalog.on_demand_jobs.len(),
+        rows,
         queues,
         scheduled: params.scheduled.as_deref() == Some("1"),
         invalid_json: params.invalid_json.as_deref() == Some("1"),
@@ -506,10 +496,6 @@ fn compare_eta(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering
     if desc { cmp.reverse() } else { cmp }
 }
 
-fn short_type_name(name: &str) -> String {
-    name.rsplit("::").next().unwrap_or(name).to_string()
-}
-
 fn on_demand_envelope_from_form(
     catalog: &oxanus::Catalog,
     form: &OnDemandEnqueueJobForm,
@@ -541,56 +527,64 @@ fn on_demand_envelope_from_form(
     job.enqueue_envelope(form.queue.clone(), args)
 }
 
+struct TypeTreeNode<T> {
+    children: BTreeMap<String, TypeTreeNode<T>>,
+    entries: Vec<T>,
+}
+
+impl<T> TypeTreeNode<T> {
+    fn new() -> Self {
+        Self {
+            children: BTreeMap::new(),
+            entries: Vec::new(),
+        }
+    }
+}
+
+fn type_tree_parts(name: &str) -> (Vec<&str>, String) {
+    let segments: Vec<&str> = name.split("::").collect();
+    let split = segments.len().saturating_sub(2);
+
+    (segments[..split].to_vec(), segments[split..].join("::"))
+}
+
+fn insert_type_tree_entry<T>(root: &mut TypeTreeNode<T>, group_segments: &[&str], entry: T) {
+    let mut node = root;
+    for seg in group_segments {
+        node = node
+            .children
+            .entry((*seg).to_string())
+            .or_insert_with(TypeTreeNode::new);
+    }
+
+    node.entries.push(entry);
+}
+
 fn build_cron_rows(
     cron_workers: &[oxanus::CronWorkerInfo],
     now: &chrono::DateTime<chrono::Utc>,
 ) -> Vec<CronRow> {
-    use std::collections::BTreeMap;
-
-    struct TreeNode {
-        children: BTreeMap<String, TreeNode>,
-        workers: Vec<CronWorkerView>,
-    }
-
-    impl TreeNode {
-        fn new() -> Self {
-            Self {
-                children: BTreeMap::new(),
-                workers: Vec::new(),
-            }
-        }
-    }
-
-    let mut root = TreeNode::new();
+    let mut root = TypeTreeNode::new();
 
     for cw in cron_workers {
-        let segments: Vec<&str> = cw.name.split("::").collect();
-
-        let split = segments.len().saturating_sub(2);
-        let group_segments = segments.get(..split).unwrap_or_default();
-        let leaf_name = segments.get(split..).unwrap_or_default().join("::");
-
-        let mut node = &mut root;
-        for seg in group_segments {
-            node = node
-                .children
-                .entry((*seg).to_string())
-                .or_insert_with(TreeNode::new);
-        }
-
-        node.workers.push(CronWorkerView {
-            short_name: leaf_name,
-            schedule: cw.schedule.to_string(),
-            queue_key: cw.queue_key.clone(),
-            next_run_micros: cw
-                .schedule
-                .after(now)
-                .next()
-                .map(|dt| dt.timestamp_micros()),
-        });
+        let (group_segments, leaf_name) = type_tree_parts(&cw.name);
+        insert_type_tree_entry(
+            &mut root,
+            &group_segments,
+            CronWorkerView {
+                short_name: leaf_name,
+                schedule: cw.schedule.to_string(),
+                queue_key: cw.queue_key.clone(),
+                next_run_micros: cw
+                    .schedule
+                    .after(now)
+                    .next()
+                    .map(|dt| dt.timestamp_micros()),
+            },
+        );
     }
 
-    fn flatten(node: &TreeNode, depth: usize, rows: &mut Vec<CronRow>) {
+    fn flatten(node: &TypeTreeNode<CronWorkerView>, depth: usize, rows: &mut Vec<CronRow>) {
         for (name, child) in &node.children {
             rows.push(CronRow::Group {
                 name: name.clone(),
@@ -598,9 +592,47 @@ fn build_cron_rows(
             });
             flatten(child, depth + 1, rows);
         }
-        for worker in &node.workers {
+        for worker in &node.entries {
             rows.push(CronRow::Worker {
                 view: worker.clone(),
+                depth,
+            });
+        }
+    }
+
+    let mut rows = Vec::new();
+    flatten(&root, 0, &mut rows);
+    rows
+}
+
+fn build_on_demand_rows(on_demand_jobs: &[oxanus::OnDemandJobInfo]) -> Vec<OnDemandRow> {
+    let mut root = TypeTreeNode::new();
+
+    for job in on_demand_jobs {
+        let (group_segments, leaf_name) = type_tree_parts(&job.name);
+        insert_type_tree_entry(
+            &mut root,
+            &group_segments,
+            OnDemandJobView {
+                name: job.name.clone(),
+                short_name: leaf_name,
+                args_template_json: serde_json::to_string_pretty(&job.args_template)
+                    .unwrap_or_else(|_| job.args_template.to_string()),
+            },
+        );
+    }
+
+    fn flatten(node: &TypeTreeNode<OnDemandJobView>, depth: usize, rows: &mut Vec<OnDemandRow>) {
+        for (name, child) in &node.children {
+            rows.push(OnDemandRow::Group {
+                name: name.clone(),
+                depth,
+            });
+            flatten(child, depth + 1, rows);
+        }
+        for job in &node.entries {
+            rows.push(OnDemandRow::Job {
+                view: job.clone(),
                 depth,
             });
         }
@@ -647,7 +679,7 @@ mod tests {
 
     #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
     #[oxanus(worker = OnDemandWorker)]
-    #[oxanus(on_demand = true)]
+    #[oxanus(on_demand)]
     #[oxanus(unique_id = "on_demand_{id}")]
     struct OnDemandJob {
         id: u64,

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -417,6 +417,23 @@ pub(crate) struct OnDemandJobView {
     pub args_template_json: String,
 }
 
+pub(crate) enum OnDemandRow {
+    Group { name: String, depth: usize },
+    Job { view: OnDemandJobView, depth: usize },
+}
+
+impl OnDemandRow {
+    fn depth(&self) -> usize {
+        match self {
+            Self::Group { depth, .. } | Self::Job { depth, .. } => *depth,
+        }
+    }
+
+    pub fn indent_px(&self) -> usize {
+        self.depth() * 20
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct OnDemandQueueView {
     pub key: String,
@@ -427,7 +444,7 @@ pub(crate) struct OnDemandQueueView {
 pub(crate) struct OnDemandTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
-    pub jobs: Vec<OnDemandJobView>,
+    pub rows: Vec<OnDemandRow>,
     pub queues: Vec<OnDemandQueueView>,
     pub total: usize,
     pub scheduled: bool,
@@ -534,7 +551,7 @@ impl GlobalJobsTemplate {
 
 #[cfg(test)]
 mod on_demand_tests {
-    use super::{OnDemandJobView, OnDemandQueueView, OnDemandTemplate};
+    use super::{OnDemandJobView, OnDemandQueueView, OnDemandRow, OnDemandTemplate};
     use askama::Template;
 
     #[test]
@@ -542,7 +559,7 @@ mod on_demand_tests {
         let template = OnDemandTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/on-demand",
-            jobs: Vec::new(),
+            rows: Vec::new(),
             queues: vec![OnDemandQueueView {
                 key: "default".to_string(),
             }],
@@ -561,10 +578,13 @@ mod on_demand_tests {
         let template = OnDemandTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/on-demand",
-            jobs: vec![OnDemandJobView {
-                name: "crate::EmailWorker".to_string(),
-                short_name: "EmailWorker".to_string(),
-                args_template_json: "{}".to_string(),
+            rows: vec![OnDemandRow::Job {
+                view: OnDemandJobView {
+                    name: "crate::EmailWorker".to_string(),
+                    short_name: "EmailWorker".to_string(),
+                    args_template_json: "{}".to_string(),
+                },
+                depth: 0,
             }],
             queues: Vec::new(),
             total: 1,
@@ -582,11 +602,20 @@ mod on_demand_tests {
         let template = OnDemandTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/on-demand",
-            jobs: vec![OnDemandJobView {
-                name: "crate::EmailWorker".to_string(),
-                short_name: "EmailWorker".to_string(),
-                args_template_json: "{\n  \"payload\": \"\"\n}".to_string(),
-            }],
+            rows: vec![
+                OnDemandRow::Group {
+                    name: "crate".to_string(),
+                    depth: 0,
+                },
+                OnDemandRow::Job {
+                    view: OnDemandJobView {
+                        name: "crate::email::EmailWorker".to_string(),
+                        short_name: "email::EmailWorker".to_string(),
+                        args_template_json: "{\n  \"payload\": \"\"\n}".to_string(),
+                    },
+                    depth: 1,
+                },
+            ],
             queues: vec![OnDemandQueueView {
                 key: "default".to_string(),
             }],
@@ -599,6 +628,8 @@ mod on_demand_tests {
 
         assert!(rendered.contains("action=\"/admin/on-demand/enqueue\""));
         assert!(rendered.contains("<option value=\"default\">default</option>"));
+        assert!(rendered.contains("crate"));
+        assert!(rendered.contains("email::EmailWorker"));
         assert!(rendered.contains("payload"));
     }
 
@@ -607,7 +638,7 @@ mod on_demand_tests {
         let template = OnDemandTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/on-demand",
-            jobs: Vec::new(),
+            rows: Vec::new(),
             queues: Vec::new(),
             total: 0,
             scheduled: true,
@@ -624,7 +655,7 @@ mod on_demand_tests {
         let template = OnDemandTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/on-demand",
-            jobs: Vec::new(),
+            rows: Vec::new(),
             queues: Vec::new(),
             total: 0,
             scheduled: false,

--- a/oxanus-web/templates/on_demand.html
+++ b/oxanus-web/templates/on_demand.html
@@ -35,7 +35,7 @@
 
         <h2 class="text-lg font-semibold mb-4">On-Demand Jobs ({{ total }})</h2>
 
-        {% if jobs.is_empty() %}
+        {% if rows.is_empty() %}
         <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
             No on-demand jobs registered
         </div>
@@ -45,17 +45,21 @@
         </div>
         {% else %}
         <div class="w-full text-sm">
-            <div class="grid grid-cols-1 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1.6fr)_auto] gap-4 border-b border-gray-800 pb-3 text-left text-xs text-gray-400 uppercase tracking-wide">
-                <div>Job</div>
+            <div class="grid grid-cols-[minmax(16rem,1fr)_auto] gap-4 border-b border-gray-800 pb-3 text-left text-xs text-gray-400 uppercase tracking-wide">
                 <div>Worker</div>
                 <div>Action</div>
             </div>
             <div>
-                {% for job in &jobs %}
+                {% for row in &rows %}
+                {% match row %}
+                {% when OnDemandRow::Group { name, depth: _ } %}
+                <div class="border-b border-gray-800/50">
+                    <div class="py-2 pt-4 font-mono text-xs text-gray-500 font-semibold" style="padding-left: {{ row.indent_px() }}px">{{ name }}</div>
+                </div>
+                {% when OnDemandRow::Job { view: job, depth: _ } %}
                 <details class="border-b border-gray-800/50">
-                    <summary class="grid cursor-pointer list-none grid-cols-1 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1.6fr)_auto] gap-4 py-3 hover:bg-gray-900/50">
-                        <span class="font-mono text-sm">{{ job.short_name }}</span>
-                        <span class="font-mono text-xs text-gray-500">{{ job.name }}</span>
+                    <summary class="grid cursor-pointer list-none grid-cols-[minmax(16rem,1fr)_auto] gap-4 py-3 hover:bg-gray-900/50">
+                        <span class="font-mono text-sm" style="padding-left: {{ row.indent_px() }}px"><span class="text-gray-600">&#8627; </span>{{ job.short_name }}</span>
                         <span class="inline-flex w-fit select-none rounded bg-green-900/50 border border-green-800 px-2.5 py-1 text-xs text-green-300 hover:bg-green-800 transition-colors">Enqueue</span>
                     </summary>
                     <form method="POST" action="{{ base_path }}/on-demand/enqueue" class="w-full pb-6 pt-3">
@@ -73,6 +77,7 @@
                         </div>
                     </form>
                 </details>
+                {% endmatch %}
                 {% endfor %}
             </div>
         </div>

--- a/oxanus/README.md
+++ b/oxanus/README.md
@@ -131,11 +131,13 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 | `#[oxanus(on_conflict = Skip)]` - handle unique job conflicts (Skip or Replace) | `#[oxanus(error = MyError)]` - set worker error type |
 | `#[oxanus(resurrect = false)]` - disable crash resurrection for this job type | `#[oxanus(registry = MyRegistry)]` - choose component registry |
 | `#[oxanus(throttle_cost = 2)]` - set per-job throttle cost | `#[oxanus(max_retries = 3)]` - set maximum retry attempts |
-| `#[oxanus(on_demand = true)]` - expose the job in the web dashboard for manual enqueueing | `#[oxanus(retry_delay = 5)]` - set retry delay in seconds |
+| `#[oxanus(on_demand)]` - expose the job in the web dashboard for manual enqueueing | `#[oxanus(retry_delay = 5)]` - set retry delay in seconds |
 |  | `#[oxanus(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
 |  | `#[oxanus(batch_size = 100, batch_timeout_ms = 500)]` - process jobs in batches |
 
 For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::...` resolves to the worker type.
+
+On-demand argument templates infer editable placeholders from field types. Numeric primitives and common numeric ID newtypes named `*Id` or `*ID` are prefilled with `0`.
 
 Batch workers use all-or-nothing result semantics: if `process_batch` returns `Ok(())`, every job in the batch is marked successful; if it returns an error or panics, every job in that batch follows the normal retry or failure path. Batch handlers should therefore be idempotent, or should only commit external side effects after the whole batch is ready to succeed.
 

--- a/oxanus/src/worker.rs
+++ b/oxanus/src/worker.rs
@@ -655,11 +655,15 @@ mod tests {
             name: String,
         }
 
+        #[repr(transparent)]
+        #[derive(Debug, Serialize, Deserialize)]
+        struct CustomerId(i32);
+
         struct NamedOnDemandWorker;
 
         #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         #[oxanus(worker = NamedOnDemandWorker)]
-        #[oxanus(on_demand = true)]
+        #[oxanus(on_demand)]
         #[serde(rename_all = "camelCase")]
         struct NamedOnDemandJob {
             name: String,
@@ -670,6 +674,7 @@ mod tests {
             tags: Vec<String>,
             labels: HashMap<String, String>,
             nested: NestedTask,
+            customer_id: CustomerId,
             #[serde(rename = "custom_id")]
             renamed_id: u64,
             #[serde(skip)]
@@ -688,6 +693,7 @@ mod tests {
                 "tags": [],
                 "labels": {},
                 "nested": {},
+                "customerId": 0,
                 "custom_id": 0,
             }))
         );
@@ -696,7 +702,7 @@ mod tests {
 
         #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         #[oxanus(worker = TupleOnDemandWorker)]
-        #[oxanus(on_demand = true)]
+        #[oxanus(on_demand)]
         struct TupleOnDemandJob(String, u64, Option<bool>, Vec<String>);
 
         assert_eq!(
@@ -708,7 +714,7 @@ mod tests {
 
         #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
         #[oxanus(worker = UnitOnDemandWorker)]
-        #[oxanus(on_demand = true)]
+        #[oxanus(on_demand)]
         struct UnitOnDemandJob;
 
         assert_eq!(

--- a/oxanus/tests/integration/registry.rs
+++ b/oxanus/tests/integration/registry.rs
@@ -12,7 +12,7 @@ struct QueueTwo;
 
 #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
 #[oxanus(worker = WorkerCounter)]
-#[oxanus(on_demand = true)]
+#[oxanus(on_demand)]
 pub struct WorkerCounterJob {
     pub key: String,
 }


### PR DESCRIPTION
## Summary
- change `#[oxanus(on_demand = true)]` to bare `#[oxanus(on_demand)]`
- infer numeric placeholders for common `*Id` / `*ID` newtype fields in on-demand JSON templates
- reuse the cron namespace tree display for the On-Demand tab
- update the web example with nested demo workers and a second on-demand job

## Verification
- `cargo fmt --all`
- `cargo check --all`
- `cargo test`
- `cargo test -p oxanus-web`
- `cargo check -p oxanus-web --example web`
- `cargo clippy --all-features --workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public derive-macro attribute syntax for on-demand jobs and tweaks generated argument templates, which could affect downstream crates and dashboard enqueue behavior.
> 
> **Overview**
> Simplifies on-demand job registration by changing the derive attribute from `#[oxanus(on_demand = true)]` to the presence-based `#[oxanus(on_demand)]` (macro now uses a `Flag`), and updates docs/tests/examples accordingly.
> 
> Improves on-demand enqueue UX by inferring `0` placeholders for numeric `*Id`/`*ID` newtype fields in generated JSON templates, and updates the web On-Demand page to display jobs in a grouped namespace tree (reusing the cron-style grouping/indentation) instead of a flat list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85dca1f91dd5f91c62258b7dcf6c15df14fe7a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->