### PR TITLE
Preselect preferred on-demand queue

### DIFF
--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -120,15 +120,7 @@ pub(crate) async fn on_demand_jobs(
     Query(params): Query<OnDemandParams>,
 ) -> OnDemandTemplate {
     let rows = build_on_demand_rows(&state.catalog.on_demand_jobs);
-    let queues = state
-        .catalog
-        .queues
-        .iter()
-        .filter(|queue| !queue.dynamic)
-        .map(|queue| OnDemandQueueView {
-            key: queue.key.clone(),
-        })
-        .collect::<Vec<_>>();
+    let queues = build_on_demand_queue_views(&state.catalog.queues);
 
     OnDemandTemplate {
         base_path: state.base_path,
@@ -643,10 +635,28 @@ fn build_on_demand_rows(on_demand_jobs: &[oxanus::OnDemandJobInfo]) -> Vec<OnDem
     rows
 }
 
+fn build_on_demand_queue_views(queues: &[oxanus::QueueInfo]) -> Vec<OnDemandQueueView> {
+    let selected_queue = ["default", "main"].into_iter().find(|candidate| {
+        queues
+            .iter()
+            .any(|queue| !queue.dynamic && queue.key == *candidate)
+    });
+
+    queues
+        .iter()
+        .filter(|queue| !queue.dynamic)
+        .map(|queue| OnDemandQueueView {
+            key: queue.key.clone(),
+            selected: selected_queue == Some(queue.key.as_str()),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        OnDemandEnqueueJobForm, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
+        OnDemandEnqueueJobForm, build_on_demand_queue_views, enqueue_on_demand_job,
+        on_demand_envelope_from_form, sort_queues,
     };
     use crate::OxanusWebState;
     use axum::Form;
@@ -735,6 +745,15 @@ mod tests {
         }
     }
 
+    fn queue_info(key: &str, dynamic: bool) -> oxanus::QueueInfo {
+        oxanus::QueueInfo {
+            key: key.to_string(),
+            dynamic,
+            concurrency: 1,
+            throttle: None,
+        }
+    }
+
     #[test]
     fn eta_sort_ascending_places_unknown_last() {
         let mut queues = vec![
@@ -788,6 +807,48 @@ mod tests {
         .expect_err("dynamic queues should not be accepted");
 
         assert!(matches!(err, oxanus::OxanusError::GenericError(_)));
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_default_queue() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("alpha", false),
+            queue_info("default", false),
+            queue_info("main", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["default"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_main_when_default_is_missing() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("default", true),
+            queue_info("main", false),
+            queue_info("worker", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["main"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_do_not_preselect_other_queues() {
+        let views =
+            build_on_demand_queue_views(&[queue_info("alpha", false), queue_info("worker", false)]);
+
+        assert!(views.iter().all(|queue| !queue.selected));
     }
 
     #[test]

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -437,6 +437,7 @@ impl OnDemandRow {
 #[derive(Clone)]
 pub(crate) struct OnDemandQueueView {
     pub key: String,
+    pub selected: bool,
 }
 
 #[derive(Template, WebTemplate)]
@@ -562,6 +563,7 @@ mod on_demand_tests {
             rows: Vec::new(),
             queues: vec![OnDemandQueueView {
                 key: "default".to_string(),
+                selected: true,
             }],
             total: 0,
             scheduled: false,
@@ -618,6 +620,7 @@ mod on_demand_tests {
             ],
             queues: vec![OnDemandQueueView {
                 key: "default".to_string(),
+                selected: true,
             }],
             total: 1,
             scheduled: false,
@@ -627,7 +630,7 @@ mod on_demand_tests {
         let rendered = template.render().unwrap();
 
         assert!(rendered.contains("action=\"/admin/on-demand/enqueue\""));
-        assert!(rendered.contains("<option value=\"default\">default</option>"));
+        assert!(rendered.contains("<option value=\"default\" selected>default</option>"));
         assert!(rendered.contains("crate"));
         assert!(rendered.contains("email::EmailWorker"));
         assert!(rendered.contains("payload"));

--- a/oxanus-web/templates/on_demand.html
+++ b/oxanus-web/templates/on_demand.html
@@ -67,7 +67,7 @@
                         <label class="block text-xs text-gray-500 mb-1" for="queue-{{ loop.index }}">Queue</label>
                         <select id="queue-{{ loop.index }}" name="queue" class="w-full sm:w-72 mb-3 rounded bg-gray-950 border border-gray-800 px-3 py-2 text-sm text-gray-200">
                             {% for queue in &queues %}
-                            <option value="{{ queue.key }}">{{ queue.key }}</option>
+                            <option value="{{ queue.key }}" {% if queue.selected %}selected{% endif %}>{{ queue.key }}</option>
                             {% endfor %}
                         </select>
                         <label class="block text-xs text-gray-500 mb-1" for="args-{{ loop.index }}">Arguments</label>


### PR DESCRIPTION
## Summary
- Preselect the `default` static queue in on-demand enqueue forms when it exists.
- Fall back to `main` when `default` is not registered as a static queue.
- Keep other queue lists unselected and cover the preference behavior with focused tests.

## Verification
- `cargo fmt`
- `cargo clippy --all-features --workspace`
- `cargo test -p oxanus-web on_demand`
- `cargo check --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/template behavior change that only affects which static queue is preselected in the on-demand enqueue dropdown; enqueue validation and backend behavior remain unchanged.
> 
> **Overview**
> On-demand enqueue forms now **preselect a preferred static queue**: choose `default` when present, otherwise fall back to `main`, leaving all other static-queue lists unselected.
> 
> This introduces a `selected` flag on `OnDemandQueueView`, renders it as the HTML `selected` attribute in `on_demand.html`, and adds focused unit tests covering the queue preselection rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2796fd5e16e22eae96f3ea9e36ec7e3b7bd0bc23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->