### PR TITLE
feat: add dead queue wipe action

### DIFF
--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -204,6 +204,14 @@ pub(crate) async fn dead_jobs(
     })
 }
 
+pub(crate) async fn wipe_dead(
+    Extension(state): Extension<OxanusWebState>,
+) -> Result<Redirect, OxanusWebError> {
+    state.storage.wipe_dead().await?;
+
+    Ok(Redirect::to(&format!("{}/dead", state.base_path)))
+}
+
 pub(crate) async fn retry_jobs(
     Extension(state): Extension<OxanusWebState>,
     Query(params): Query<PaginationParams>,

--- a/oxanus-web/src/lib.rs
+++ b/oxanus-web/src/lib.rs
@@ -49,6 +49,7 @@ pub fn router(state: OxanusWebState) -> Router {
         .route("/on-demand/enqueue", post(handlers::enqueue_on_demand_job))
         .route("/scheduled", get(handlers::scheduled_jobs))
         .route("/dead", get(handlers::dead_jobs))
+        .route("/dead/wipe", post(handlers::wipe_dead))
         .route("/retries", get(handlers::retry_jobs))
         .route("/queues/{queue_key}", get(handlers::queue_detail))
         .route("/enqueue", post(handlers::enqueue_job))

--- a/oxanus-web/templates/_stats_cards.html
+++ b/oxanus-web/templates/_stats_cards.html
@@ -1,12 +1,4 @@
-        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4 mb-10">
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Processed</div>
-                <div class="text-2xl font-semibold text-green-400">{{ stats.global.processed|format_number_i64 }}</div>
-            </div>
-            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
-                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Failed</div>
-                <div class="text-2xl font-semibold text-red-400">{{ stats.global.failed|format_number_i64 }}</div>
-            </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-10">
             <a href="{{ base_path }}/busy" class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block">
                 <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">Busy</div>
                 <div class="text-2xl font-semibold text-purple-400">{{ stats.processing.len() }}</div>

--- a/oxanus-web/templates/global_jobs.html
+++ b/oxanus-web/templates/global_jobs.html
@@ -23,6 +23,13 @@
                 {% endif %}
             </h2>
             <div class="flex items-center gap-2 text-sm">
+                {% if kind.is_dead() %}
+                {% if total > 0 %}
+                <form method="POST" action="{{ base_path }}/dead/wipe" onsubmit="return confirmWipeDead()">
+                    <button type="submit" class="px-3 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 transition-colors">Wipe</button>
+                </form>
+                {% endif %}
+                {% endif %}
                 {% if page > 1 %}
                 <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
                 {% else %}
@@ -166,6 +173,10 @@
             btn.textContent = 'Copy failed';
             setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);
         });
+    }
+    function confirmWipeDead() {
+        var input = prompt('Type WIPE to permanently remove all dead jobs.');
+        return input === 'WIPE';
     }
     </script>
 </body>

--- a/oxanus/src/storage.rs
+++ b/oxanus/src/storage.rs
@@ -422,6 +422,15 @@ impl Storage {
         self.internal.wipe_queue(&queue.key()).await
     }
 
+    /// Removes all jobs from the dead queue.
+    ///
+    /// # Returns
+    ///
+    /// An [`OxanusError`] if the operation fails.
+    pub async fn wipe_dead(&self) -> Result<(), OxanusError> {
+        self.internal.wipe_dead().await
+    }
+
     /// Returns Prometheus metrics based on the current stats.
     ///
     /// # Returns

--- a/oxanus/src/storage_internal.rs
+++ b/oxanus/src/storage_internal.rs
@@ -637,6 +637,12 @@ impl StorageInternal {
         Ok(())
     }
 
+    pub async fn wipe_dead(&self) -> Result<(), OxanusError> {
+        let mut redis = self.connection().await?;
+        let _: () = (*redis).del(&self.keys.dead).await?;
+        Ok(())
+    }
+
     pub async fn list_dead(&self, opts: &QueueListOpts) -> Result<Vec<JobEnvelope>, OxanusError> {
         let mut redis = self.connection().await?;
         let start = opts.offset as isize;
@@ -2822,6 +2828,36 @@ mod tests {
         assert_eq!(storage.enqueued_count(&queue).await?, 0);
         assert!(storage.get_job(&envelope1.id).await?.is_none());
         assert!(storage.get_job(&envelope2.id).await?.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wipe_dead() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+        let envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let envelope2 = JobEnvelope::new(queue, TestJob {})?;
+
+        storage.kill(&envelope1, "first failed".to_string()).await?;
+        storage
+            .kill(&envelope2, "second failed".to_string())
+            .await?;
+
+        assert_eq!(storage.dead_count().await?, 2);
+
+        storage.wipe_dead().await?;
+
+        assert_eq!(storage.dead_count().await?, 0);
+        assert!(
+            storage
+                .list_dead(&QueueListOpts {
+                    count: 10,
+                    offset: 0,
+                })
+                .await?
+                .is_empty()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- remove processed and failed total tiles from the shared web dashboard stats cards
- add a Dead page Wipe button guarded by a `WIPE` confirmation prompt
- add `Storage::wipe_dead()` and a Redis-backed internal wipe path with coverage

## Verification
- `cargo fmt`
- `cargo clippy --all-features --workspace`
- `cargo test -p oxanus test_wipe_dead`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a destructive operation that deletes the entire dead-job list in Redis and exposes it via a new POST route; misuse or insufficient access control could lead to unintended data loss.
> 
> **Overview**
> Adds a new dead-queue **Wipe** action in the web UI (`POST /dead/wipe`) that prompts for typing `WIPE` before clearing all dead jobs and redirecting back to the Dead page.
> 
> Extends core storage with `Storage::wipe_dead()` backed by a Redis `DEL` on the dead list, with a new `test_wipe_dead` covering the behavior.
> 
> Updates the shared dashboard stats cards layout by removing the Processed/Failed total tiles and adjusting the grid columns accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcb5ada294fdd382144d15e6b09751f35fdd8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->