### PR TITLE
feat: add cron enqueue action to web dashboard

### DIFF
--- a/oxanus-web/examples/web.rs
+++ b/oxanus-web/examples/web.rs
@@ -94,6 +94,32 @@ mod demo {
             }
         }
     }
+
+    pub(crate) mod maintenance {
+        pub(crate) mod cleanup {
+            use crate::{ComponentRegistry, DefaultQueue, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxanus::Job)]
+            pub(crate) struct CleanupExpiredSessionsJob {}
+
+            #[derive(oxanus::Worker)]
+            #[oxanus(max_retries = 0)]
+            #[oxanus(cron(schedule = "*/30 * * * * *", queue = DefaultQueue))]
+            struct CleanupExpiredSessionsWorker;
+
+            impl CleanupExpiredSessionsWorker {
+                async fn process(
+                    &self,
+                    _job: CleanupExpiredSessionsJob,
+                    _ctx: &oxanus::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
 }
 
 use demo::billing::invoices::GenerateInvoiceJob;

--- a/oxanus-web/src/handlers.rs
+++ b/oxanus-web/src/handlers.rs
@@ -102,7 +102,10 @@ pub(crate) async fn metric_detail(
     })
 }
 
-pub(crate) async fn cron_jobs(Extension(state): Extension<OxanusWebState>) -> CronTemplate {
+pub(crate) async fn cron_jobs(
+    Extension(state): Extension<OxanusWebState>,
+    Query(params): Query<CronParams>,
+) -> CronTemplate {
     let now = chrono::Utc::now();
     let rows = build_cron_rows(&state.catalog.cron_workers, &now);
     let total = state.catalog.cron_workers.len();
@@ -112,7 +115,22 @@ pub(crate) async fn cron_jobs(Extension(state): Extension<OxanusWebState>) -> Cr
         active_tab: "/cron",
         rows,
         total,
+        enqueued: params.enqueued.as_deref() == Some("1"),
     }
+}
+
+pub(crate) async fn enqueue_cron_job(
+    Extension(state): Extension<OxanusWebState>,
+    Form(form): Form<CronEnqueueJobForm>,
+) -> Result<Redirect, OxanusWebError> {
+    let envelope = cron_envelope_from_form(&state.catalog, &form)?;
+
+    state.storage.enqueue_envelope(envelope).await?;
+
+    Ok(Redirect::to(&format!(
+        "{}/cron?enqueued=1",
+        state.base_path
+    )))
 }
 
 pub(crate) async fn on_demand_jobs(
@@ -328,38 +346,13 @@ pub(crate) async fn enqueue_job(
     Extension(state): Extension<OxanusWebState>,
     Form(form): Form<EnqueueJobForm>,
 ) -> Result<Redirect, OxanusWebError> {
-    let now = chrono::Utc::now().timestamp_micros();
-    let id = uuid::Uuid::new_v4().to_string();
-    let args: serde_json::Value =
-        serde_json::from_str(&form.args).map_err(oxanus::OxanusError::from)?;
-    let job_state: Option<serde_json::Value> = match form.state.as_deref() {
-        Some(s) if !s.is_empty() => {
-            Some(serde_json::from_str(s).map_err(oxanus::OxanusError::from)?)
-        }
-        _ => None,
-    };
-
-    let envelope = oxanus::JobEnvelope {
-        id: id.clone(),
-        queue: form.queue.clone(),
-        job: oxanus::JobData {
-            name: form.name,
-            args,
-        },
-        meta: oxanus::JobMeta {
-            id,
-            retries: 0,
-            unique: false,
-            on_conflict: None,
-            created_at: now,
-            scheduled_at: now,
-            started_at: None,
-            state: job_state,
-            resurrect: true,
-            error: None,
-            throttle_cost: None,
-        },
-    };
+    let envelope = immediate_envelope(
+        form.queue,
+        form.name,
+        parse_json(&form.args)?,
+        parse_optional_json(form.state.as_deref())?,
+        true,
+    );
 
     state.storage.enqueue_envelope(envelope).await?;
 
@@ -427,6 +420,11 @@ pub(crate) struct EnqueueJobForm {
 }
 
 #[derive(Deserialize)]
+pub(crate) struct CronEnqueueJobForm {
+    name: String,
+}
+
+#[derive(Deserialize)]
 pub(crate) struct OnDemandEnqueueJobForm {
     queue: String,
     name: String,
@@ -439,6 +437,12 @@ pub(crate) struct OnDemandParams {
     scheduled: Option<String>,
     #[serde(default)]
     invalid_json: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct CronParams {
+    #[serde(default)]
+    enqueued: Option<String>,
 }
 
 fn list_opts(page: usize) -> oxanus::QueueListOpts {
@@ -521,10 +525,72 @@ fn on_demand_envelope_from_form(
                 form.name
             ))
         })?;
-    let args: serde_json::Value =
-        serde_json::from_str(&form.args).map_err(oxanus::OxanusError::from)?;
 
-    job.enqueue_envelope(form.queue.clone(), args)
+    job.enqueue_envelope(form.queue.clone(), parse_json(&form.args)?)
+}
+
+fn cron_envelope_from_form(
+    catalog: &oxanus::Catalog,
+    form: &CronEnqueueJobForm,
+) -> Result<oxanus::JobEnvelope, oxanus::OxanusError> {
+    let job = catalog
+        .cron_workers
+        .iter()
+        .find(|job| job.name == form.name)
+        .ok_or_else(|| {
+            oxanus::OxanusError::GenericError(format!("Cron job {} is not registered", form.name))
+        })?;
+
+    Ok(immediate_envelope(
+        job.queue_key.clone(),
+        job.name.clone(),
+        serde_json::json!({}),
+        None,
+        job.resurrect,
+    ))
+}
+
+fn parse_json(input: &str) -> Result<serde_json::Value, oxanus::OxanusError> {
+    serde_json::from_str(input).map_err(oxanus::OxanusError::from)
+}
+
+fn parse_optional_json(
+    input: Option<&str>,
+) -> Result<Option<serde_json::Value>, oxanus::OxanusError> {
+    input
+        .filter(|value| !value.is_empty())
+        .map(parse_json)
+        .transpose()
+}
+
+fn immediate_envelope(
+    queue: String,
+    name: String,
+    args: serde_json::Value,
+    state: Option<serde_json::Value>,
+    resurrect: bool,
+) -> oxanus::JobEnvelope {
+    let now = chrono::Utc::now().timestamp_micros();
+    let id = uuid::Uuid::new_v4().to_string();
+
+    oxanus::JobEnvelope {
+        id: id.clone(),
+        queue,
+        job: oxanus::JobData { name, args },
+        meta: oxanus::JobMeta {
+            id,
+            retries: 0,
+            unique: false,
+            on_conflict: None,
+            created_at: now,
+            scheduled_at: now,
+            started_at: None,
+            state,
+            resurrect,
+            error: None,
+            throttle_cost: None,
+        },
+    }
 }
 
 struct TypeTreeNode<T> {
@@ -572,6 +638,7 @@ fn build_cron_rows(
             &mut root,
             &group_segments,
             CronWorkerView {
+                name: cw.name.clone(),
                 short_name: leaf_name,
                 schedule: cw.schedule.to_string(),
                 queue_key: cw.queue_key.clone(),
@@ -663,8 +730,8 @@ fn build_on_demand_queue_views(queues: &[oxanus::QueueInfo]) -> Vec<OnDemandQueu
 #[cfg(test)]
 mod tests {
     use super::{
-        OnDemandEnqueueJobForm, build_on_demand_queue_views, enqueue_on_demand_job,
-        on_demand_envelope_from_form, sort_queues,
+        CronEnqueueJobForm, OnDemandEnqueueJobForm, build_on_demand_queue_views,
+        cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
     };
     use crate::OxanusWebState;
     use axum::Form;
@@ -674,6 +741,8 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
     use std::io::Error as WorkerError;
+
+    const CRON_WORKER_NAME: &str = "test::CleanupCronWorker";
 
     #[derive(Serialize)]
     struct StaticQueue;
@@ -736,6 +805,20 @@ mod tests {
             .catalog()
     }
 
+    fn cron_catalog() -> oxanus::Catalog {
+        oxanus::Catalog {
+            workers: Vec::new(),
+            cron_workers: vec![oxanus::CronWorkerInfo {
+                name: CRON_WORKER_NAME.to_string(),
+                schedule: "*/5 * * * * *".parse().unwrap(),
+                queue_key: "default".to_string(),
+                resurrect: false,
+            }],
+            queues: Vec::new(),
+            on_demand_jobs: Vec::new(),
+        }
+    }
+
     fn queue_with_eta(key: &str, eta_s: Option<f64>) -> oxanus::QueueStats {
         oxanus::QueueStats {
             key: key.to_string(),
@@ -794,6 +877,41 @@ mod tests {
             .map(|queue| queue.key.as_str())
             .collect::<Vec<_>>();
         assert_eq!(keys, vec!["never", "slow", "fast"]);
+    }
+
+    #[test]
+    fn cron_form_rejects_unknown_jobs() {
+        let catalog = cron_catalog();
+
+        let err = cron_envelope_from_form(
+            &catalog,
+            &CronEnqueueJobForm {
+                name: "missing".to_string(),
+            },
+        )
+        .expect_err("unknown cron jobs should not be accepted");
+
+        assert!(matches!(err, oxanus::OxanusError::GenericError(_)));
+    }
+
+    #[test]
+    fn cron_form_builds_immediate_envelope() {
+        let catalog = cron_catalog();
+        let envelope = cron_envelope_from_form(
+            &catalog,
+            &CronEnqueueJobForm {
+                name: CRON_WORKER_NAME.to_string(),
+            },
+        )
+        .expect("valid cron form should build an envelope");
+
+        assert_eq!(envelope.queue, "default");
+        assert_eq!(envelope.job.name, CRON_WORKER_NAME);
+        assert_eq!(envelope.job.args, serde_json::json!({}));
+        assert!(!envelope.meta.unique);
+        assert!(envelope.meta.on_conflict.is_none());
+        assert!(!envelope.meta.resurrect);
+        assert_eq!(envelope.meta.scheduled_at, envelope.meta.created_at);
     }
 
     #[test]

--- a/oxanus-web/src/lib.rs
+++ b/oxanus-web/src/lib.rs
@@ -45,6 +45,7 @@ pub fn router(state: OxanusWebState) -> Router {
         .route("/metrics", get(handlers::metrics))
         .route("/metrics/job", get(handlers::metric_detail))
         .route("/cron", get(handlers::cron_jobs))
+        .route("/cron/enqueue", post(handlers::enqueue_cron_job))
         .route("/on-demand", get(handlers::on_demand_jobs))
         .route("/on-demand/enqueue", post(handlers::enqueue_on_demand_job))
         .route("/scheduled", get(handlers::scheduled_jobs))

--- a/oxanus-web/src/templates.rs
+++ b/oxanus-web/src/templates.rs
@@ -395,6 +395,7 @@ impl CronRow {
 
 #[derive(Clone)]
 pub(crate) struct CronWorkerView {
+    pub name: String,
     pub short_name: String,
     pub schedule: String,
     pub queue_key: String,
@@ -408,6 +409,7 @@ pub(crate) struct CronTemplate {
     pub active_tab: &'static str,
     pub rows: Vec<CronRow>,
     pub total: usize,
+    pub enqueued: bool,
 }
 
 #[derive(Clone)]
@@ -551,6 +553,55 @@ impl GlobalJobsTemplate {
 }
 
 #[cfg(test)]
+mod cron_tests {
+    use super::{CronRow, CronTemplate, CronWorkerView};
+    use askama::Template;
+
+    #[test]
+    fn cron_template_renders_enqueue_now_form_at_end_of_row() {
+        let template = CronTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/cron",
+            rows: vec![CronRow::Worker {
+                view: CronWorkerView {
+                    name: "crate::workers::EmailCronWorker".to_string(),
+                    short_name: "EmailCronWorker".to_string(),
+                    schedule: "0 * * * * *".to_string(),
+                    queue_key: "default".to_string(),
+                    next_run_micros: None,
+                },
+                depth: 0,
+            }],
+            total: 1,
+            enqueued: false,
+        };
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains("<th class=\"pb-3 text-right\">Action</th>"));
+        assert!(rendered.contains("action=\"/admin/cron/enqueue\""));
+        assert!(rendered.contains("name=\"name\" value=\"crate::workers::EmailCronWorker\""));
+        assert!(rendered.contains("Enqueue now"));
+    }
+
+    #[test]
+    fn cron_template_shows_notice_after_successful_enqueue() {
+        let template = CronTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/cron",
+            rows: Vec::new(),
+            total: 0,
+            enqueued: true,
+        };
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains("Cron job enqueued."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
+    }
+}
+
+#[cfg(test)]
 mod on_demand_tests {
     use super::{OnDemandJobView, OnDemandQueueView, OnDemandRow, OnDemandTemplate};
     use askama::Template;
@@ -651,6 +702,7 @@ mod on_demand_tests {
         let rendered = template.render().unwrap();
 
         assert!(rendered.contains("Job scheduled."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
     }
 
     #[test]
@@ -668,5 +720,6 @@ mod on_demand_tests {
         let rendered = template.render().unwrap();
 
         assert!(rendered.contains("Invalid JSON."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
     }
 }

--- a/oxanus-web/templates/_auto_dismiss_notices.html
+++ b/oxanus-web/templates/_auto_dismiss_notices.html
@@ -1,0 +1,12 @@
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        for (const notice of document.querySelectorAll("[data-auto-dismiss-notice]")) {
+            setTimeout(() => {
+                notice.style.transition = "opacity 200ms ease, transform 200ms ease";
+                notice.style.opacity = "0";
+                notice.style.transform = "translateY(-4px)";
+                setTimeout(() => notice.remove(), 220);
+            }, 3000);
+        }
+    });
+</script>

--- a/oxanus-web/templates/cron.html
+++ b/oxanus-web/templates/cron.html
@@ -14,6 +14,12 @@
 
         {% include "_tabs.html" %}
 
+        {% if enqueued %}
+        <div data-auto-dismiss-notice class="mb-4 rounded border border-green-800 bg-green-950/40 px-4 py-3 text-sm text-green-300">
+            Cron job enqueued.
+        </div>
+        {% endif %}
+
         <h2 class="text-lg font-semibold mb-4">Cron Workers ({{ total }})</h2>
 
         {% if rows.is_empty() %}
@@ -29,6 +35,7 @@
                         <th class="pb-3 pr-4">Queue</th>
                         <th class="pb-3 pr-4">Schedule</th>
                         <th class="pb-3">Next Run</th>
+                        <th class="pb-3 text-right">Action</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -36,7 +43,7 @@
                     {% match row %}
                     {% when CronRow::Group { name, depth: _ } %}
                     <tr class="border-b border-gray-800/50">
-                        <td colspan="4" class="py-2 pt-4 font-mono text-xs text-gray-500 font-semibold" style="padding-left: {{ row.indent_px() }}px">{{ name }}</td>
+                        <td colspan="5" class="py-2 pt-4 font-mono text-xs text-gray-500 font-semibold" style="padding-left: {{ row.indent_px() }}px">{{ name }}</td>
                     </tr>
                     {% when CronRow::Worker { view: cw, depth: _ } %}
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
@@ -44,6 +51,12 @@
                         <td class="py-3 pr-4 font-mono text-sm text-gray-400">{{ cw.queue_key }}</td>
                         <td class="py-3 pr-4 font-mono text-sm text-yellow-400">{{ cw.schedule }}</td>
                         <td class="py-3 text-gray-300">{{ cw.next_run_micros|relative_time_micros_opt }}</td>
+                        <td class="py-3 text-right">
+                            <form method="POST" action="{{ base_path }}/cron/enqueue" class="inline">
+                                <input type="hidden" name="name" value="{{ cw.name }}">
+                                <button type="submit" class="whitespace-nowrap rounded bg-green-900/50 border border-green-800 px-2.5 py-1 text-xs text-green-300 hover:bg-green-800 transition-colors">Enqueue now</button>
+                            </form>
+                        </td>
                     </tr>
                     {% endmatch %}
                     {% endfor %}
@@ -52,5 +65,6 @@
         </div>
         {% endif %}
     </div>
+    {% include "_auto_dismiss_notices.html" %}
 </body>
 </html>

--- a/oxanus-web/templates/on_demand.html
+++ b/oxanus-web/templates/on_demand.html
@@ -23,12 +23,12 @@
         {% include "_tabs.html" %}
 
         {% if scheduled %}
-        <div class="mb-4 rounded border border-green-800 bg-green-950/40 px-4 py-3 text-sm text-green-300">
+        <div data-auto-dismiss-notice class="mb-4 rounded border border-green-800 bg-green-950/40 px-4 py-3 text-sm text-green-300">
             Job scheduled.
         </div>
         {% endif %}
         {% if invalid_json %}
-        <div class="mb-4 rounded border border-red-800 bg-red-950/40 px-4 py-3 text-sm text-red-300">
+        <div data-auto-dismiss-notice class="mb-4 rounded border border-red-800 bg-red-950/40 px-4 py-3 text-sm text-red-300">
             Invalid JSON.
         </div>
         {% endif %}
@@ -83,5 +83,6 @@
         </div>
         {% endif %}
     </div>
+    {% include "_auto_dismiss_notices.html" %}
 </body>
 </html>

--- a/oxanus/src/config.rs
+++ b/oxanus/src/config.rs
@@ -185,6 +185,7 @@ impl<DT, ET> Config<DT, ET> {
                 name: name.clone(),
                 schedule: cron_job.schedule.clone(),
                 queue_key: cron_job.queue_key.clone(),
+                resurrect: cron_job.resurrect,
             })
             .collect();
         cron_workers.sort_by(|a, b| a.name.cmp(&b.name));

--- a/oxanus/src/storage_types.rs
+++ b/oxanus/src/storage_types.rs
@@ -84,4 +84,6 @@ pub struct CronWorkerInfo {
     pub schedule: cron::Schedule,
     /// The queue key this worker runs on.
     pub queue_key: String,
+    /// Whether jobs for this worker should be resurrected if a process dies.
+    pub resurrect: bool,
 }


### PR DESCRIPTION
## Summary
- Add an Enqueue now action to the Cron dashboard tab.
- Enqueue manual cron runs immediately with duplicate-friendly raw envelope semantics while preserving the cron worker resurrect setting.
- Add auto-dismissing notices for cron and on-demand dashboard messages.
- Add a cron worker to the web example so the Cron tab has a runnable row.

## Verification
- cargo fmt --all
- cargo clippy --all-features --workspace
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new web endpoint that can manually enqueue cron jobs and tweaks envelope construction/resurrection semantics; mistakes could cause unexpected job volume or resurrect behavior, but scope is limited to admin UI and catalog metadata.
> 
> **Overview**
> Adds an **“Enqueue now”** action to the Cron tab, backed by a new `POST /cron/enqueue` handler that builds an immediate `JobEnvelope` for the selected cron worker and redirects with an `enqueued` success flag.
> 
> Updates cron worker metadata to include `resurrect` in `CronWorkerInfo`/catalog generation and uses it when manually enqueueing cron runs. Refactors web enqueue code by centralizing JSON parsing/envelope creation helpers, and adds auto-dismissing success/error notices shared by the cron and on-demand pages.
> 
> Extends the `oxanus-web` example with a simple cron worker so the Cron UI has a runnable row, and adds template/handler tests for the new cron enqueue flow and notice rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b6ef2d8ca7a7bae5c7d9de03d0b0787f29d8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->