### PR TITLE
docs: prepare 2.0.0-rc.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [2.0.0-rc.0]
+
+### Breaking Changes
+
+- Rename the project and crates from Oxanus to Oxana. Use `oxana`, `oxana-macros`, `oxana-web`, and `#[oxana(...)]` in manifests, imports, derive attributes, examples, and dashboard integrations.
+- Move enqueue-time metadata onto `#[derive(oxana::Job)]`. Job identity, conflict handling, resurrection, throttle cost, on-demand exposure, and worker binding now belong to the job type; custom job hooks now resolve `Self` as the job type.
+- Route every worker through the batch-capable execution path. Manual worker implementations now provide `run_batch`, while derive users can keep writing `process` for single-job workers or opt into `process_batch`.
+- Own job values during execution instead of borrowing them, so job payload types no longer need to implement `Sync`.
 
 ### Added
 
-- Add `#[derive(oxana::Job)]` for defining enqueue-time job metadata, including unique IDs, conflict strategy, resurrection behavior, throttle cost, and worker binding.
-- Add optional batch workers with the derive-macro `process_batch` hook, `BatchItem`, `WorkerBatchConfig`, and `#[oxana(batch_size = ..., batch_timeout_ms = ...)]` worker macro attributes.
-- Add queue length history metrics and a Queue Lengths chart to the web queues dashboard.
-- Add per-queue processing rate, growth rate, and ETA stats with web dashboard display.
-- Add `#[oxana(on_demand)]` and an On-Demand dashboard tab for manually enqueueing registered jobs.
-- Add separate Redis configuration for stats via `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools`.
+- Add batch workers with `#[oxana(batch_size = ..., batch_timeout_ms = ...)]`, `process_batch`, `BatchItem`, and `WorkerBatchConfig` for high-throughput workloads that can process jobs together.
+- Add on-demand jobs: annotate a job with `#[oxana(on_demand)]` to expose it in the web dashboard with editable JSON arguments and type-aware argument templates.
+- Add worker execution metrics, including per-minute success, failure, panic, execution-time, and histogram data through `Storage::job_metrics`, `Storage::job_metrics_for`, and the new `/metrics` dashboard pages.
+- Add queue length history, per-queue processing rates, growth rates, effective drain rates, and ETA estimates to the stats APIs and dashboard.
+- Add `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools` so counters and metrics can use a separate Redis instance from the primary job store.
+- Add dashboard actions for enqueueing cron jobs immediately and wiping the dead queue.
 
 ### Changed
 
-- Batch result stats writes and active queue length snapshots to reduce Redis calls during job completion and dashboard stats reads.
-- Replace runtime Redis `KEYS` calls with cursor-based `SCAN` for queue discovery and orphaned processing queue recovery.
-- Move job-specific derive attributes (`unique_id`, `on_conflict`, `resurrect`, and `throttle_cost`) from `#[derive(oxana::Worker)]` to `#[derive(oxana::Job)]`; `Self::...` in job hooks now resolves to the job type.
-- Change worker execution to own job values and route all worker execution through the batched runtime path; job types no longer need `Sync`.
+- Make dashboard queue and metrics views more operationally useful: queue length charts now live with queue stats, tooltips use readable worker labels, zero-value tooltip rows are hidden, and unknown ETAs sort after known drain times.
+- Reduce Redis pressure by replacing `KEYS` with cursor-based `SCAN`, batching result counter writes, and snapshotting active queue lengths during worker refreshes.
+- Improve on-demand registration so the dashboard can prefill arguments, keep job hooks intact, and choose a sensible default queue.
+- Refresh examples, package metadata, CI paths, documentation references, and dependency versions for the Oxana rename and 2.0 release candidate.
 
 ## [1.1.1]
 

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -33,7 +33,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana
+cargo add oxana@2.0.0-rc.0
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- Rewrites the top changelog entry as `2.0.0-rc.0` release notes based on commits since `1.1.1`.
- Calls out the Oxanus to Oxana rename, breaking derive/execution changes, batch workers, on-demand jobs, metrics, queue stats, and Redis stats configuration.
- Updates the README Quick Start install command to `cargo add oxana@2.0.0-rc.0`.

## Tests
- Not run. Markdown-only changes, per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to `CHANGELOG.md` and `oxana/README.md` with no runtime or API changes in code.
> 
> **Overview**
> Prepares the `2.0.0-rc.0` release documentation by replacing the prior *Unreleased* changelog section with structured release notes, including **breaking changes** (Oxanus→Oxana rename, job/worker derive metadata moves, batch execution path, owned job payloads) plus newly added metrics/stats/on-demand/batching/Redis-stats features and dashboard improvements.
> 
> Updates the README Quick Start install command to pin `oxana@2.0.0-rc.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184964bea79bd9e219a0dcec7bf61c6289531964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->