### PR TITLE
feat: show active jobs on queue detail

### DIFF
--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -286,11 +286,13 @@ pub(crate) async fn queue_detail(
             })
         });
     let total = queue_stats.as_ref().map_or(0, |q| q.enqueued);
-    let busy = stats
+    let active_jobs = stats
         .processing
         .iter()
         .filter(|p| p.job_envelope.queue == queue_key)
-        .count();
+        .cloned()
+        .collect::<Vec<_>>();
+    let busy = active_jobs.len();
 
     let mut jobs = state
         .storage
@@ -305,6 +307,7 @@ pub(crate) async fn queue_detail(
         active_tab: "/queues",
         queue_key,
         queue_stats,
+        active_jobs,
         busy,
         jobs,
         page,

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -461,6 +461,7 @@ pub(crate) struct QueueDetailTemplate {
     pub active_tab: &'static str,
     pub queue_key: String,
     pub queue_stats: Option<oxana::QueueStats>,
+    pub active_jobs: Vec<oxana::StatsProcessing>,
     pub busy: usize,
     pub jobs: Vec<oxana::JobEnvelope>,
     pub page: usize,

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -23,6 +23,64 @@
             </form>
         </div>
 
+        {% if !active_jobs.is_empty() %}
+        <section class="mb-8">
+            <h2 class="text-lg font-semibold mb-4">Currently Processing ({{ active_jobs.len() }})</h2>
+            <div class="space-y-3">
+                {% for item in &active_jobs %}
+                <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                    <div class="flex items-start justify-between mb-2">
+                        <div class="flex items-center gap-2">
+                            <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
+                            <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
+                        </div>
+                        <span class="text-xs text-gray-500 font-mono">{{ item.job_envelope.id }}</span>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
+                        <div>
+                            <span class="text-gray-500">Process:</span>
+                            <span class="ml-1 text-gray-300 font-mono">{{ item.process_id }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Started:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.started_at|relative_time_micros_opt }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Scheduled:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.scheduled_at|relative_time_micros }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Retries:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.retries }}</span>
+                        </div>
+                    </div>
+                    {% if item.job_envelope.job.args|has_args %}
+                    <details class="mt-3">
+                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
+                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ item.job_envelope.job.args|pretty_json }}</pre>
+                    </details>
+                    {% endif %}
+                    {% match item.job_envelope.meta.state %}
+                    {% when Some with (state) %}
+                    {% if state|has_args %}
+                    <details class="mt-3">
+                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">State</summary>
+                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ state|pretty_json }}</pre>
+                    </details>
+                    {% endif %}
+                    {% when None %}
+                    {% endmatch %}
+                    <div class="mt-3 flex justify-end">
+                        <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ item.job_envelope.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
+                            <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
+                        </form>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
         {% match queue_stats %}
         {% when Some with (qs) %}
         <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4 mb-8">


### PR DESCRIPTION
## Summary
- Shows jobs currently processing on the selected queue at the top of the queue detail dashboard page.
- Reuses `StatsProcessing` from `storage.stats()` and keeps the existing busy count tied to the filtered active jobs.
- Includes job metadata, process id, arguments/state details, and the existing delete action for active jobs.

## Test Coverage
All new code paths are covered by template compile/type checks and existing dashboard crate tests.

## Pre-Landing Review
No issues found in the small dashboard-only diff.

## Design Review
Frontend template changed. Lite review: active jobs render only when present, directly under the queue header, using existing dashboard card styling.

## Eval Results
No prompt-related files changed. Evals skipped.

## Plan Completion
No plan file detected.

## Test plan
- [x] `cargo fmt`
- [x] `cargo check --all`
- [x] `cargo test -p oxana-web` (21 passed)
- [x] `cargo test` (rerun passed after one transient `test_latency` timing failure passed in isolation)
- [x] `cargo clippy --all-features --workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/dashboard-only change that reuses existing `storage.stats()` processing data; no changes to job execution or storage behavior.
> 
> **Overview**
> Shows *currently processing* jobs at the top of the queue detail page.
> 
> The `queue_detail` handler now collects and passes `active_jobs` (filtered `stats.processing`) into `QueueDetailTemplate`, and `busy` is derived from this filtered list. The `queue_detail.html` template renders these active jobs (process id, timing/retry metadata, optional args/state details) and includes the existing per-job delete action for them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca6fa05129d871b1d25a19abdc1ea6bffaa7f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->