### PR TITLE
Add job detail dashboard page

### DIFF
--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -11,8 +11,8 @@ use crate::OxanaWebState;
 use crate::error::OxanaWebError;
 use crate::templates::{
     BusyTemplate, CronRow, CronTemplate, CronWorkerView, DashboardTemplate, GlobalJobsTemplate,
-    JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView, OnDemandQueueView,
-    OnDemandRow, OnDemandTemplate, QueueDetailTemplate, QueuesTemplate,
+    JobDetailTemplate, JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView,
+    OnDemandQueueView, OnDemandRow, OnDemandTemplate, QueueDetailTemplate, QueuesTemplate,
 };
 
 pub(crate) async fn dashboard(
@@ -254,6 +254,21 @@ pub(crate) async fn retry_jobs(
     })
 }
 
+pub(crate) async fn job_detail(
+    Extension(state): Extension<OxanaWebState>,
+    Path(job_id): Path<String>,
+) -> Result<JobDetailTemplate, OxanaWebError> {
+    let (job, is_dead) = find_job(&state.storage, &job_id).await?;
+
+    Ok(JobDetailTemplate {
+        base_path: state.base_path,
+        active_tab: "/jobs",
+        job_id,
+        job,
+        is_dead,
+    })
+}
+
 pub(crate) async fn queue_detail(
     Extension(state): Extension<OxanaWebState>,
     Path(queue_key): Path<String>,
@@ -314,6 +329,33 @@ pub(crate) async fn queue_detail(
         total,
         has_next,
     })
+}
+
+async fn find_job(
+    storage: &oxana::Storage,
+    job_id: &str,
+) -> Result<(Option<oxana::JobEnvelope>, bool), oxana::OxanaError> {
+    let job_id = job_id.to_string();
+    if let Some(job) = storage.get_job(&job_id).await? {
+        return Ok((Some(job), false));
+    }
+
+    let dead_count = storage.dead_count().await?;
+    if dead_count == 0 {
+        return Ok((None, false));
+    }
+
+    let dead_jobs = storage
+        .list_dead(&oxana::QueueListOpts {
+            count: dead_count,
+            offset: 0,
+        })
+        .await?;
+    let Some(dead_job) = dead_jobs.into_iter().find(|job| job.id == job_id) else {
+        return Ok((None, false));
+    };
+
+    Ok((Some(dead_job), true))
 }
 
 pub(crate) async fn wipe_queue(

--- a/oxana-web/src/lib.rs
+++ b/oxana-web/src/lib.rs
@@ -52,6 +52,7 @@ pub fn router(state: OxanaWebState) -> Router {
         .route("/dead", get(handlers::dead_jobs))
         .route("/dead/wipe", post(handlers::wipe_dead))
         .route("/retries", get(handlers::retry_jobs))
+        .route("/jobs/{job_id}", get(handlers::job_detail))
         .route("/queues/{queue_key}", get(handlers::queue_detail))
         .route("/enqueue", post(handlers::enqueue_job))
         .route("/queues/{queue_key}/wipe", post(handlers::wipe_queue))

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -553,6 +553,16 @@ impl GlobalJobsTemplate {
     }
 }
 
+#[derive(Template, WebTemplate)]
+#[template(path = "job_detail.html")]
+pub(crate) struct JobDetailTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub job_id: String,
+    pub job: Option<oxana::JobEnvelope>,
+    pub is_dead: bool,
+}
+
 #[cfg(test)]
 mod cron_tests {
     use super::{CronRow, CronTemplate, CronWorkerView};

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -112,9 +112,13 @@
                             <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
                             <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
                         </div>
-                        <span class="text-xs text-gray-500 font-mono">{{ item.process_id }}</span>
+                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
                     </div>
-                    <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
+                    <div class="grid grid-cols-1 sm:grid-cols-5 gap-2 text-xs text-gray-400 mt-2">
+                        <div>
+                            <span class="text-gray-500">Process:</span>
+                            <span class="ml-1 text-gray-300 font-mono">{{ item.process_id }}</span>
+                        </div>
                         <div>
                             <span class="text-gray-500">Queue:</span>
                             <a href="{{ base_path }}/queues/{{ item.job_envelope.queue|urlencode }}" class="ml-1 text-blue-400 hover:text-blue-300 hover:underline">{{ item.job_envelope.queue }}</a>

--- a/oxana-web/templates/global_jobs.html
+++ b/oxana-web/templates/global_jobs.html
@@ -51,9 +51,12 @@
         <div class="space-y-3">
             {% for job in &jobs %}
             <div class="bg-gray-900 border {{ kind.border_class() }} rounded-lg p-4">
-                <div class="flex items-center gap-2 mb-2">
-                    <span class="inline-block w-2 h-2 rounded-full {{ kind.dot_class() }}"></span>
-                    <span class="font-semibold text-sm">{{ job.job.name }}</span>
+                <div class="flex items-start justify-between mb-2">
+                    <div class="flex items-center gap-2">
+                        <span class="inline-block w-2 h-2 rounded-full {{ kind.dot_class() }}"></span>
+                        <span class="font-semibold text-sm">{{ job.job.name }}</span>
+                    </div>
+                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
                     <div>

--- a/oxana-web/templates/job_detail.html
+++ b/oxana-web/templates/job_detail.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Job: {{ job_id }} - Oxana</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-950 text-gray-100 min-h-screen">
+    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="flex items-center justify-between mb-6">
+            <h1 class="text-2xl font-bold tracking-tight">Oxana Dashboard</h1>
+        </div>
+
+        {% include "_tabs.html" %}
+
+        {% match job %}
+        {% when Some with (job) %}
+        <div class="flex items-center justify-between mb-4">
+            <div>
+                <h2 class="text-lg font-semibold">
+                    <a href="{{ base_path }}/metrics/job?worker={{ job.job.name|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ job.job.name }}</a>
+                </h2>
+                <div class="mt-1 text-xs text-gray-500 font-mono break-all">{{ job.id }}</div>
+            </div>
+            {% if is_dead %}
+            <span class="px-2 py-1 rounded bg-red-900/50 border border-red-800 text-red-300 text-xs">Dead</span>
+            {% endif %}
+        </div>
+
+        <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400">
+                <div>
+                    <span class="text-gray-500">Queue:</span>
+                    <a href="{{ base_path }}/queues/{{ job.queue|urlencode }}" class="ml-1 text-blue-400 hover:text-blue-300 hover:underline">{{ job.queue }}</a>
+                </div>
+                <div>
+                    <span class="text-gray-500">Retries:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.retries }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Created:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.created_at|relative_time_micros }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Scheduled:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.scheduled_at|relative_time_micros }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Started:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.started_at|relative_time_micros_opt }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Unique:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.unique }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Resurrect:</span>
+                    <span class="ml-1 text-gray-300">{{ job.meta.resurrect }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500">Throttle cost:</span>
+                    <span class="ml-1 text-gray-300">
+                        {% match job.meta.throttle_cost %}
+                        {% when Some with (cost) %}{{ cost }}
+                        {% when None %}&mdash;
+                        {% endmatch %}
+                    </span>
+                </div>
+            </div>
+
+            <details class="mt-3" open>
+                <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
+                <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ job.job.args|pretty_json }}</pre>
+            </details>
+
+            {% match job.meta.state %}
+            {% when Some with (state) %}
+            <details class="mt-3" open>
+                <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">State</summary>
+                <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ state|pretty_json }}</pre>
+            </details>
+            {% when None %}
+            {% endmatch %}
+
+            {% match job.meta.error %}
+            {% when Some with (error) %}
+            <details class="mt-3" open>
+                <summary class="text-xs text-red-400 cursor-pointer hover:text-red-300">Error</summary>
+                <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50">{{ error }}</pre>
+            </details>
+            {% when None %}
+            {% endmatch %}
+        </div>
+        {% when None %}
+        <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
+            No job found for <span class="font-mono">{{ job_id }}</span>
+        </div>
+        {% endmatch %}
+    </div>
+</body>
+</html>

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -23,64 +23,6 @@
             </form>
         </div>
 
-        {% if !active_jobs.is_empty() %}
-        <section class="mb-8">
-            <h2 class="text-lg font-semibold mb-4">Currently Processing ({{ active_jobs.len() }})</h2>
-            <div class="space-y-3">
-                {% for item in &active_jobs %}
-                <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-                    <div class="flex items-start justify-between mb-2">
-                        <div class="flex items-center gap-2">
-                            <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
-                            <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
-                        </div>
-                        <span class="text-xs text-gray-500 font-mono">{{ item.job_envelope.id }}</span>
-                    </div>
-                    <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
-                        <div>
-                            <span class="text-gray-500">Process:</span>
-                            <span class="ml-1 text-gray-300 font-mono">{{ item.process_id }}</span>
-                        </div>
-                        <div>
-                            <span class="text-gray-500">Started:</span>
-                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.started_at|relative_time_micros_opt }}</span>
-                        </div>
-                        <div>
-                            <span class="text-gray-500">Scheduled:</span>
-                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.scheduled_at|relative_time_micros }}</span>
-                        </div>
-                        <div>
-                            <span class="text-gray-500">Retries:</span>
-                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.retries }}</span>
-                        </div>
-                    </div>
-                    {% if item.job_envelope.job.args|has_args %}
-                    <details class="mt-3">
-                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
-                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ item.job_envelope.job.args|pretty_json }}</pre>
-                    </details>
-                    {% endif %}
-                    {% match item.job_envelope.meta.state %}
-                    {% when Some with (state) %}
-                    {% if state|has_args %}
-                    <details class="mt-3">
-                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">State</summary>
-                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ state|pretty_json }}</pre>
-                    </details>
-                    {% endif %}
-                    {% when None %}
-                    {% endmatch %}
-                    <div class="mt-3 flex justify-end">
-                        <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ item.job_envelope.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
-                            <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
-                        </form>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-        </section>
-        {% endif %}
-
         {% match queue_stats %}
         {% when Some with (qs) %}
         <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4 mb-8">
@@ -136,14 +78,75 @@
         {% when None %}
         {% endmatch %}
 
+        {% if !active_jobs.is_empty() %}
+        <section class="mb-8">
+            <h2 class="text-lg font-semibold mb-4">Currently Processing ({{ active_jobs.len() }})</h2>
+            <div class="space-y-3">
+                {% for item in &active_jobs %}
+                <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                    <div class="flex items-start justify-between mb-2">
+                        <div class="flex items-center gap-2">
+                            <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
+                            <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
+                        </div>
+                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
+                        <div>
+                            <span class="text-gray-500">Process:</span>
+                            <span class="ml-1 text-gray-300 font-mono">{{ item.process_id }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Started:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.started_at|relative_time_micros_opt }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Scheduled:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.scheduled_at|relative_time_micros }}</span>
+                        </div>
+                        <div>
+                            <span class="text-gray-500">Retries:</span>
+                            <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.retries }}</span>
+                        </div>
+                    </div>
+                    {% if item.job_envelope.job.args|has_args %}
+                    <details class="mt-3">
+                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
+                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ item.job_envelope.job.args|pretty_json }}</pre>
+                    </details>
+                    {% endif %}
+                    {% match item.job_envelope.meta.state %}
+                    {% when Some with (state) %}
+                    {% if state|has_args %}
+                    <details class="mt-3">
+                        <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">State</summary>
+                        <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ state|pretty_json }}</pre>
+                    </details>
+                    {% endif %}
+                    {% when None %}
+                    {% endmatch %}
+                    <div class="mt-3 flex justify-end">
+                        <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ item.job_envelope.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
+                            <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
+                        </form>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
         <div class="flex items-center justify-between mb-4">
-            <h2 class="text-lg font-semibold">
+            <div>
+                <h2 class="text-lg font-semibold">Enqueued</h2>
+                <div class="mt-1 text-sm text-gray-400">
                 {% if total > 0 %}
                 {{ self.range_start() }}&ndash;{{ self.range_end() }} of {{ total }} jobs
                 {% else %}
                 0 jobs
                 {% endif %}
-            </h2>
+                </div>
+            </div>
             <div class="flex items-center gap-2 text-sm">
                 {% if page > 1 %}
                 <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
@@ -168,7 +171,7 @@
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
                 <div class="flex items-start justify-between mb-2">
                     <span class="font-semibold text-sm">{{ job.job.name }}</span>
-                    <span class="text-xs text-gray-500 font-mono">{{ job.id }}</span>
+                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs text-gray-400 mt-2">
                     <div>

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -108,6 +108,7 @@ The dashboard exposes these pages:
 - `/busy` - Currently processing jobs
 - `/queues` - All queues with stats
 - `/queues/{queue_key}` - Jobs in a specific queue
+- `/jobs/{job_id}` - Details for a specific job
 - `/metrics` - Worker execution metrics
 - `/metrics/job?worker=...` - Metrics for a specific worker
 - `/cron` - Cron job schedules

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -239,6 +239,19 @@ impl Storage {
         self.internal.delete_job(id).await
     }
 
+    /// Returns a job by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the job to return
+    ///
+    /// # Returns
+    ///
+    /// The job envelope when present, or [`None`] if the job no longer exists.
+    pub async fn get_job(&self, id: &JobId) -> Result<Option<JobEnvelope>, OxanaError> {
+        self.internal.get_job(id).await
+    }
+
     /// Returns per-queue statistics for queues matching the given patterns.
     ///
     /// Each pattern is matched against queue names using the same glob syntax


### PR DESCRIPTION
## Summary
- Add /jobs/{job_id} dashboard page that shows job metadata, args, state, and errors
- Link job IDs from queue, busy, scheduled, retry, and dead job cards to the detail page
- Expose Storage::get_job for dashboard lookup, with dead-queue fallback in the web handler

## Verification
- cargo clippy --all-features --workspace
- cargo test -p oxana-web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new dashboard route and storage API (`Storage::get_job`) plus a dead-queue fallback lookup that may impact performance for large dead queues and could affect dashboard responsiveness.
> 
> **Overview**
> Adds a new `GET /jobs/{job_id}` dashboard page that renders a dedicated job detail view (metadata, args/state, and error output) and indicates when the job is in the dead queue.
> 
> Updates existing job listings (busy view, global dead/scheduled/retries lists, and per-queue detail) to link job IDs to the new detail page, and tweaks the queue detail layout to surface queue stat cards earlier.
> 
> Exposes `Storage::get_job` in `oxana` and uses it in the web handler with a fallback search through dead jobs when the job is no longer in the primary job store; README is updated to document the new route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3829fc7c8dbe46212752f417f020ff851a45cd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->