### PR TITLE
chore: bump oxana rc versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.0", path = "oxana" }
+oxana = { version = "2.0.0-rc.1", path = "oxana" }
 oxana-macros = { version = "2.0.0-rc.0", path = "oxana-macros" }

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxana from 2.0.0-rc.0 to 2.0.0-rc.1
- Bump oxana-web from 2.0.0-rc.0 to 2.0.0-rc.1
- Refresh Cargo.lock for the local package versions

## Verification
- cargo check --all

Tests intentionally not run per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps crate version numbers and refreshes `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Bumps `oxana` and `oxana-web` crate versions from `2.0.0-rc.0` to `2.0.0-rc.1`, including updating the workspace dependency pin in `Cargo.toml`.
> 
> Refreshes `Cargo.lock` to reflect the new local crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a2478f3202258d4dd7adc0eb3aa0e4e800c262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->