### PR TITLE
fix: prefer on-demand queue for manual jobs

### DIFF
--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -756,11 +756,13 @@ fn build_on_demand_rows(on_demand_jobs: &[oxana::OnDemandJobInfo]) -> Vec<OnDema
 }
 
 fn build_on_demand_queue_views(queues: &[oxana::QueueInfo]) -> Vec<OnDemandQueueView> {
-    let selected_queue = ["default", "main"].into_iter().find(|candidate| {
-        queues
-            .iter()
-            .any(|queue| !queue.dynamic && queue.key == *candidate)
-    });
+    let selected_queue = ["on_demand", "default", "main"]
+        .into_iter()
+        .find(|candidate| {
+            queues
+                .iter()
+                .any(|queue| !queue.dynamic && queue.key == *candidate)
+        });
 
     queues
         .iter()
@@ -981,7 +983,25 @@ mod tests {
     }
 
     #[test]
-    fn on_demand_queue_views_preselect_default_queue() {
+    fn on_demand_queue_views_preselect_on_demand_queue() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("alpha", false),
+            queue_info("on_demand", false),
+            queue_info("default", false),
+            queue_info("main", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["on_demand"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_default_when_on_demand_is_missing() {
         let views = build_on_demand_queue_views(&[
             queue_info("alpha", false),
             queue_info("default", false),


### PR DESCRIPTION
## Summary
- Prefer the static `on_demand` queue when preselecting the web dashboard on-demand enqueue form.
- Preserve fallback selection for `default` and `main` queues.
- Add regression coverage for the new queue priority order.

## Tests
- `cargo test -p oxana-web on_demand_queue_views`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes default queue preselection in the on-demand enqueue UI and adds/updates unit tests; no storage, auth, or job execution logic is modified.
> 
> **Overview**
> Updates the on-demand enqueue form’s queue preselection to prefer the static `on_demand` queue when present, while keeping the existing fallbacks to `default` and then `main`.
> 
> Renames/adjusts the related unit test and adds coverage to ensure `default` is selected when `on_demand` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a088ddee7f15ca83740b325a1641a0e7f6eacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->