### PR TITLE
chore: bump oxana rc versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-rc.0]
+## [2.0.0-rc.3]
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.2", path = "oxana" }
+oxana = { version = "2.0.0-rc.3", path = "oxana" }
 oxana-macros = { version = "2.0.0-rc.0", path = "oxana-macros" }

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -33,7 +33,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.0
+cargo add oxana@2.0.0-rc.3
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- Bump `oxana` and workspace dependency metadata to `2.0.0-rc.3`.
- Bump `oxana-web` to `2.0.0-rc.3`.
- Update `Cargo.lock`, the Oxana README quick-start version, and the changelog heading.

## Test plan
- [x] `cargo check --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version/metadata updates only (crate versions, lockfile, and docs) with no functional code changes.
> 
> **Overview**
> Bumps the `oxana` workspace dependency and crate versions (`oxana`, `oxana-web`) from `2.0.0-rc.2` to `2.0.0-rc.3`, updating `Cargo.lock` accordingly.
> 
> Updates release/documentation references to match the new RC, including the `CHANGELOG.md` section header and the `oxana` README quick-start `cargo add` version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adca2715a2d099c1b4a8d60c89aad2ae11b9a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->