### PR TITLE
feat: show job progress ETA in dashboard

### DIFF
--- a/oxana-web/src/filters.rs
+++ b/oxana-web/src/filters.rs
@@ -177,6 +177,30 @@ fn should_show_progress(val: &serde_json::Value) -> bool {
     progress_parts(val).is_some_and(|progress| progress.processed != 0 || progress.total != 0)
 }
 
+fn progress_eta_s(
+    val: &serde_json::Value,
+    scheduled_at_micros: i64,
+    now_micros: i64,
+) -> Option<f64> {
+    let progress = progress_parts(val)?;
+    if progress.total <= 0 || progress.processed <= 0 || scheduled_at_micros <= 0 {
+        return None;
+    }
+
+    let remaining = progress.total.saturating_sub(progress.processed).max(0);
+    if remaining == 0 {
+        return Some(0.0);
+    }
+
+    let elapsed_s = (now_micros - scheduled_at_micros) as f64 / 1_000_000.0;
+    if elapsed_s <= 0.0 {
+        return None;
+    }
+
+    let processed = progress.processed.max(0) as f64;
+    Some(elapsed_s * (remaining as f64 / processed))
+}
+
 #[askama::filter_fn]
 pub fn show_job_progress(
     val: &serde_json::Value,
@@ -239,9 +263,24 @@ pub fn job_progress_note(
         .unwrap_or_default())
 }
 
+#[askama::filter_fn]
+pub fn job_progress_eta(
+    val: &serde_json::Value,
+    _env: &dyn askama::Values,
+    scheduled_at_micros: &i64,
+) -> askama::Result<String> {
+    Ok(progress_eta_s(
+        val,
+        *scheduled_at_micros,
+        chrono::Utc::now().timestamp_micros(),
+    )
+    .map(format_duration_from_secs)
+    .unwrap_or_else(|| "—".to_string()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{progress_parts, should_show_progress};
+    use super::{progress_eta_s, progress_parts, should_show_progress};
     use serde_json::json;
 
     #[test]
@@ -291,5 +330,45 @@ mod tests {
             "processed": 0,
             "total": 100
         })));
+    }
+
+    #[test]
+    fn progress_eta_uses_scheduled_time_and_progress_rate() {
+        let state = json!({
+            "cursor": 42,
+            "processed": 25,
+            "total": 100
+        });
+
+        assert_eq!(progress_eta_s(&state, 1_000_000, 11_000_000), Some(30.0));
+    }
+
+    #[test]
+    fn progress_eta_is_unknown_without_rate() {
+        assert_eq!(
+            progress_eta_s(
+                &json!({
+                    "cursor": 42,
+                    "processed": 0,
+                    "total": 100
+                }),
+                1_000_000,
+                11_000_000
+            ),
+            None
+        );
+        assert_eq!(progress_eta_s(&json!([42, 25, 100]), 0, 11_000_000), None);
+    }
+
+    #[test]
+    fn progress_eta_is_zero_when_complete() {
+        assert_eq!(
+            progress_eta_s(&json!([42, 100, 100]), 1_000_000, 11_000_000),
+            Some(0.0)
+        );
+        assert_eq!(
+            progress_eta_s(&json!([42, 125, 100]), 1_000_000, 11_000_000),
+            Some(0.0)
+        );
     }
 }

--- a/oxana-web/templates/_job_progress.html
+++ b/oxana-web/templates/_job_progress.html
@@ -6,7 +6,10 @@
                 {{ state|job_progress_summary }}
             </div>
         </div>
-        <div class="shrink-0 text-sm font-semibold text-cyan-200">{{ state|job_progress_percent }}%</div>
+        <div class="shrink-0 text-right">
+            <div class="text-sm font-semibold text-cyan-200">{{ state|job_progress_percent }}%</div>
+            <div class="mt-1 text-[11px] text-cyan-200/70">ETA {{ state|job_progress_eta(progress_scheduled_at) }}</div>
+        </div>
     </div>
     <div class="mt-3 h-2 overflow-hidden rounded-full bg-gray-800">
         <div class="h-full rounded-full bg-cyan-400 transition-all" style="width: {{ state|job_progress_percent }}%"></div>

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -148,6 +148,7 @@
                     {% when Some with (state) %}
                     {% if state|has_args %}
                     {% if state|show_job_progress %}
+                    {% let progress_scheduled_at = item.job_envelope.meta.scheduled_at %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <div class="mt-3">

--- a/oxana-web/templates/global_jobs.html
+++ b/oxana-web/templates/global_jobs.html
@@ -100,6 +100,7 @@
                 {% when Some with (state) %}
                 {% if state|has_args %}
                 {% if state|show_job_progress %}
+                {% let progress_scheduled_at = job.meta.scheduled_at %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">

--- a/oxana-web/templates/job_detail.html
+++ b/oxana-web/templates/job_detail.html
@@ -77,6 +77,7 @@
             {% match job.meta.state %}
             {% when Some with (state) %}
             {% if state|show_job_progress %}
+            {% let progress_scheduled_at = job.meta.scheduled_at %}
             {% include "_job_progress.html" %}
             {% else %}
             <details class="mt-3" open>

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -119,6 +119,7 @@
                     {% when Some with (state) %}
                     {% if state|has_args %}
                     {% if state|show_job_progress %}
+                    {% let progress_scheduled_at = item.job_envelope.meta.scheduled_at %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <details class="mt-3">
@@ -201,6 +202,7 @@
                 {% when Some with (state) %}
                 {% if state|has_args %}
                 {% if state|show_job_progress %}
+                {% let progress_scheduled_at = job.meta.scheduled_at %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">


### PR DESCRIPTION
## Summary
- Adds a simple ETA estimate to dashboard job progress cards, based on elapsed time since the job's scheduled timestamp and current processed/total progress.
- Wires each existing progress-card caller to pass the job's scheduled timestamp into the shared partial.
- Covers ETA behavior for normal progress, unknown rates, and completed jobs.

## Test Coverage
Progress ETA helper has unit coverage for estimated, unknown, and complete states.

## Pre-Landing Review
No issues found in the dashboard ETA diff.

## Design Review
Small template-only dashboard change; ETA is displayed under the existing percentage in the shared progress component.

## Eval Results
No prompt-related files changed; evals skipped.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p oxana-web`
- [x] `cargo test`

Generated with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/template change with a small, well-guarded ETA calculation; no auth, persistence, or external side effects.
> 
> **Overview**
> Adds an **ETA estimate** to the shared job progress card, computed from elapsed time since `scheduled_at` and the current `processed/total` rate (falling back to `—` when unknown).
> 
> Wires all existing progress-card call sites (`busy`, `global_jobs`, `job_detail`, `queue_detail`) to pass `scheduled_at` into the partial, and adds unit tests covering estimated/unknown/complete ETA behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de78ba0ae7132e432d977dd770904126da332d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->