### PR TITLE
chore: bump oxana rc versions to 2.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.3", path = "oxana" }
+oxana = { version = "2.0.0-rc.4", path = "oxana" }
 oxana-macros = { version = "2.0.0-rc.0", path = "oxana-macros" }

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -33,7 +33,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.3
+cargo add oxana@2.0.0-rc.4
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- Bump `oxana` from `2.0.0-rc.3` to `2.0.0-rc.4`.
- Bump `oxana-web` from `2.0.0-rc.3` to `2.0.0-rc.4`.
- Update the workspace `oxana` dependency, `Cargo.lock`, and README install example to match.

## Test plan
- [x] `cargo check --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version/metadata bump only; no functional code changes beyond updating crate versions and lockfile entries.
> 
> **Overview**
> Bumps the `oxana` and `oxana-web` crate versions from `2.0.0-rc.3` to `2.0.0-rc.4` across the workspace.
> 
> Updates `Cargo.lock`, the workspace `oxana` dependency version, and the README install snippet to match the new RC version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1680457beffc556f19769250912e725435968920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->