### PR TITLE
refactor: simplify job progress state

### DIFF
--- a/oxana-web/examples/web.rs
+++ b/oxana-web/examples/web.rs
@@ -146,7 +146,6 @@ mod demo {
                     ctx.state
                         .update_progress((
                             0,
-                            0,
                             job.duration_s,
                             "Starting long-running job".to_string(),
                         ))
@@ -157,9 +156,8 @@ mod demo {
                         ctx.state
                             .update_progress((
                                 second,
-                                second,
                                 job.duration_s,
-                                Some(format!("Processed second {second} of {}", job.duration_s)),
+                                Some(format!("Completed second {second} of {}", job.duration_s)),
                             ))
                             .await?;
                     }

--- a/oxana-web/src/filters.rs
+++ b/oxana-web/src/filters.rs
@@ -174,7 +174,7 @@ fn progress_parts(val: &serde_json::Value) -> Option<oxana::JobProgress> {
 }
 
 fn should_show_progress(val: &serde_json::Value) -> bool {
-    progress_parts(val).is_some_and(|progress| progress.processed != 0 || progress.total != 0)
+    progress_parts(val).is_some_and(|progress| progress.total > 0)
 }
 
 fn progress_eta_s(
@@ -183,11 +183,11 @@ fn progress_eta_s(
     now_micros: i64,
 ) -> Option<f64> {
     let progress = progress_parts(val)?;
-    if progress.total <= 0 || progress.processed <= 0 || scheduled_at_micros <= 0 {
+    if progress.total <= 0 || progress.cursor <= 0 || scheduled_at_micros <= 0 {
         return None;
     }
 
-    let remaining = progress.total.saturating_sub(progress.processed).max(0);
+    let remaining = progress.total.saturating_sub(progress.cursor).max(0);
     if remaining == 0 {
         return Some(0.0);
     }
@@ -197,8 +197,8 @@ fn progress_eta_s(
         return None;
     }
 
-    let processed = progress.processed.max(0) as f64;
-    Some(elapsed_s * (remaining as f64 / processed))
+    let cursor = progress.cursor.max(0) as f64;
+    Some(elapsed_s * (remaining as f64 / cursor))
 }
 
 #[askama::filter_fn]
@@ -217,13 +217,13 @@ pub fn job_progress_percent(
     let Some(progress) = progress_parts(val) else {
         return Ok("0".to_string());
     };
-    let processed = progress.processed;
+    let cursor = progress.cursor;
     let total = progress.total;
     if total <= 0 {
         return Ok("0".to_string());
     }
 
-    let percent = ((processed.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
+    let percent = ((cursor.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
     Ok(format!("{percent:.0}"))
 }
 
@@ -235,20 +235,20 @@ pub fn job_progress_summary(
     let Some(progress) = progress_parts(val) else {
         return Ok("0 / 0".to_string());
     };
-    let processed = progress.processed;
+    let cursor = progress.cursor;
     let total = progress.total;
     if total <= 0 {
         return Ok(format!(
             "{} / {}",
-            format_with_commas(processed.max(0) as u64),
+            format_with_commas(cursor.max(0) as u64),
             total
         ));
     }
 
-    let percent = ((processed.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
+    let percent = ((cursor.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
     Ok(format!(
         "{} / {} ({percent:.0}%)",
-        format_with_commas(processed.max(0) as u64),
+        format_with_commas(cursor.max(0) as u64),
         format_with_commas(total as u64)
     ))
 }
@@ -286,8 +286,7 @@ mod tests {
     #[test]
     fn progress_parts_recognizes_update_progress_state() {
         let value = json!({
-            "cursor": 42,
-            "processed": 25,
+            "cursor": 25,
             "total": 100,
             "note": "importing users"
         });
@@ -295,8 +294,7 @@ mod tests {
         assert_eq!(
             progress_parts(&value),
             Some(oxana::JobProgress {
-                cursor: 42,
-                processed: 25,
+                cursor: 25,
                 total: 100,
                 note: Some("importing users".to_string()),
             })
@@ -306,10 +304,9 @@ mod tests {
             Some(oxana::JobProgress::from(42))
         );
         assert_eq!(
-            progress_parts(&json!([42, 25, 100])),
+            progress_parts(&json!([25, 100])),
             Some(oxana::JobProgress {
-                cursor: 42,
-                processed: 25,
+                cursor: 25,
                 total: 100,
                 note: None,
             })
@@ -317,17 +314,15 @@ mod tests {
     }
 
     #[test]
-    fn progress_display_requires_processed_or_total() {
+    fn progress_display_requires_total() {
         assert!(!should_show_progress(&json!(42)));
         assert!(!should_show_progress(&json!({
             "cursor": 42,
-            "processed": 0,
             "total": 0
         })));
-        assert!(should_show_progress(&json!([42, 1, 100])));
+        assert!(should_show_progress(&json!([1, 100])));
         assert!(should_show_progress(&json!({
             "cursor": 42,
-            "processed": 0,
             "total": 100
         })));
     }
@@ -335,8 +330,7 @@ mod tests {
     #[test]
     fn progress_eta_uses_scheduled_time_and_progress_rate() {
         let state = json!({
-            "cursor": 42,
-            "processed": 25,
+            "cursor": 25,
             "total": 100
         });
 
@@ -348,8 +342,7 @@ mod tests {
         assert_eq!(
             progress_eta_s(
                 &json!({
-                    "cursor": 42,
-                    "processed": 0,
+                    "cursor": 0,
                     "total": 100
                 }),
                 1_000_000,
@@ -357,17 +350,17 @@ mod tests {
             ),
             None
         );
-        assert_eq!(progress_eta_s(&json!([42, 25, 100]), 0, 11_000_000), None);
+        assert_eq!(progress_eta_s(&json!([25, 100]), 0, 11_000_000), None);
     }
 
     #[test]
     fn progress_eta_is_zero_when_complete() {
         assert_eq!(
-            progress_eta_s(&json!([42, 100, 100]), 1_000_000, 11_000_000),
+            progress_eta_s(&json!([100, 100]), 1_000_000, 11_000_000),
             Some(0.0)
         );
         assert_eq!(
-            progress_eta_s(&json!([42, 125, 100]), 1_000_000, 11_000_000),
+            progress_eta_s(&json!([125, 100]), 1_000_000, 11_000_000),
             Some(0.0)
         );
     }

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -183,19 +183,18 @@ the current attempt with `ctx.state.get::<T>()`. This is useful for resumable jo
 that need to continue from the last completed item after a retry.
 
 For long-running jobs, use `ctx.state.update_progress(...)` to store progress in a
-structured format. The web dashboard renders a progress bar when `processed` or
-`total` is set:
+structured format. The web dashboard renders a progress bar when `total` is set:
 
 ```rust
 ctx.state
-    .update_progress((cursor, processed, total, Some("importing users".to_string())))
+    .update_progress((cursor, total, Some("importing users".to_string())))
     .await?;
 ```
 
-`update_progress` accepts a cursor value, `(cursor, processed, total)`, or
-`(cursor, processed, total, note)`. Cursor-only state remains useful for resumable
-jobs and is shown as normal state in the dashboard. `ctx.state.progress().await?`
-reloads the latest stored progress for the current job.
+`update_progress` accepts a cursor value, `(cursor, total)`, or
+`(cursor, total, note)`. Cursor-only state remains useful for resumable jobs and is
+shown as normal state in the dashboard. `ctx.state.progress().await?` reloads the
+latest stored progress for the current job.
 
 ### Configuration
 

--- a/oxana/src/job_state.rs
+++ b/oxana/src/job_state.rs
@@ -12,8 +12,8 @@ pub struct JobState {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct JobProgress {
     pub cursor: i64,
-    pub processed: i64,
     pub total: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
 }
 
@@ -21,40 +21,36 @@ impl From<i64> for JobProgress {
     fn from(cursor: i64) -> Self {
         Self {
             cursor,
-            processed: 0,
             total: 0,
             note: None,
         }
     }
 }
 
-impl From<(i64, i64, i64)> for JobProgress {
-    fn from((cursor, processed, total): (i64, i64, i64)) -> Self {
+impl From<(i64, i64)> for JobProgress {
+    fn from((cursor, total): (i64, i64)) -> Self {
         Self {
             cursor,
-            processed,
             total,
             note: None,
         }
     }
 }
 
-impl From<(i64, i64, i64, String)> for JobProgress {
-    fn from((cursor, processed, total, note): (i64, i64, i64, String)) -> Self {
+impl From<(i64, i64, String)> for JobProgress {
+    fn from((cursor, total, note): (i64, i64, String)) -> Self {
         Self {
             cursor,
-            processed,
             total,
             note: Some(note),
         }
     }
 }
 
-impl From<(i64, i64, i64, Option<String>)> for JobProgress {
-    fn from((cursor, processed, total, note): (i64, i64, i64, Option<String>)) -> Self {
+impl From<(i64, i64, Option<String>)> for JobProgress {
+    fn from((cursor, total, note): (i64, i64, Option<String>)) -> Self {
         Self {
             cursor,
-            processed,
             total,
             note,
         }
@@ -66,13 +62,13 @@ impl From<(i64, i64, i64, Option<String>)> for JobProgress {
 enum JobProgressRepr {
     Struct {
         cursor: i64,
-        processed: i64,
+        #[serde(default)]
         total: i64,
         #[serde(default)]
         note: Option<String>,
     },
-    Tuple4(i64, i64, i64, Option<String>),
-    Tuple3(i64, i64, i64),
+    Tuple3WithNote(i64, i64, Option<String>),
+    Tuple2(i64, i64),
     Cursor(i64),
 }
 
@@ -84,19 +80,16 @@ impl<'de> serde::Deserialize<'de> for JobProgress {
         Ok(match JobProgressRepr::deserialize(deserializer)? {
             JobProgressRepr::Struct {
                 cursor,
-                processed,
                 total,
                 note,
             }
-            | JobProgressRepr::Tuple4(cursor, processed, total, note) => Self {
+            | JobProgressRepr::Tuple3WithNote(cursor, total, note) => Self {
                 cursor,
-                processed,
                 total,
                 note,
             },
-            JobProgressRepr::Tuple3(cursor, processed, total) => Self {
+            JobProgressRepr::Tuple2(cursor, total) => Self {
                 cursor,
-                processed,
                 total,
                 note: None,
             },
@@ -165,26 +158,24 @@ mod tests {
             JobProgress::from(7),
             JobProgress {
                 cursor: 7,
-                processed: 0,
                 total: 0,
                 note: None,
             }
         );
         assert_eq!(
-            JobProgress::from((7, 3, 10)),
+            JobProgress::from((7, 10)),
             JobProgress {
                 cursor: 7,
-                processed: 3,
                 total: 10,
                 note: None,
             }
         );
         assert_eq!(
-            JobProgress::from((7, 3, 10, "chunk imported".to_string())).note,
+            JobProgress::from((7, 10, "chunk imported".to_string())).note,
             Some("chunk imported".to_string())
         );
         assert_eq!(
-            JobProgress::from((7, 3, 10, Some("chunk imported".to_string()))).note,
+            JobProgress::from((7, 10, Some("chunk imported".to_string()))).note,
             Some("chunk imported".to_string())
         );
     }
@@ -193,7 +184,6 @@ mod tests {
     fn job_progress_deserializes_from_supported_shapes() {
         let expected = JobProgress {
             cursor: 7,
-            processed: 3,
             total: 10,
             note: None,
         };
@@ -203,11 +193,11 @@ mod tests {
             JobProgress::from(7)
         );
         assert_eq!(
-            serde_json::from_value::<JobProgress>(json!([7, 3, 10])).unwrap(),
+            serde_json::from_value::<JobProgress>(json!([7, 10])).unwrap(),
             expected
         );
         assert_eq!(
-            serde_json::from_value::<JobProgress>(json!([7, 3, 10, "chunk imported"])).unwrap(),
+            serde_json::from_value::<JobProgress>(json!([7, 10, "chunk imported"])).unwrap(),
             JobProgress {
                 note: Some("chunk imported".to_string()),
                 ..expected.clone()


### PR DESCRIPTION
## Summary
- Simplify `JobProgress` to `cursor`, `total`, and optional `note`.
- Update dashboard progress display, percent, and ETA to use `cursor / total`.
- Update README and web example usage for the new progress tuple shapes.

## Verification
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --all-features --workspace`

## Review
- Pre-landing diff review completed; no issues found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the serialized shape of `JobProgress` and how the web dashboard computes percent/ETA, which could affect compatibility with previously stored tuple-shaped progress state and any callers using the old `(cursor, processed, total, ...)` API.
> 
> **Overview**
> Simplifies job progress state by removing `processed` from `JobProgress`, leaving just `cursor`, `total`, and optional `note`, and updates supported `update_progress` tuple shapes accordingly.
> 
> Updates the web dashboard progress rendering logic (show/hide, percent, summary, and ETA) to use `cursor / total` and only display a progress bar when `total > 0`, with tests adjusted to match.
> 
> Refreshes docs and the `oxana-web` example to use the new `update_progress((cursor, total, note))` format and tweaks the sample progress message text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9957ff37cb769f520db5558fd1e33eae668fb180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->