### PR TITLE
chore: bump oxana rc versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-rc.3]
+## [2.0.0-rc.5]
 
 ### Breaking Changes
 
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Move enqueue-time metadata onto `#[derive(oxana::Job)]`. Job identity, conflict handling, resurrection, throttle cost, on-demand exposure, and worker binding now belong to the job type; custom job hooks now resolve `Self` as the job type.
 - Route every worker through the batch-capable execution path. Manual worker implementations now provide `run_batch`, while derive users can keep writing `process` for single-job workers or opt into `process_batch`.
 - Own job values during execution instead of borrowing them, so job payload types no longer need to implement `Sync`.
+- Simplify structured job progress to cursor/total values. `JobProgress` no longer exposes a separate `processed` field, and `update_progress` tuple helpers now use `(cursor, total)` or `(cursor, total, note)`.
 
 ### Added
 
@@ -20,11 +21,12 @@ All notable changes to this project will be documented in this file.
 - Add `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools` so counters and metrics can use a separate Redis instance from the primary job store.
 - Add dashboard actions for enqueueing cron jobs immediately and wiping the dead queue.
 - Add structured job progress state with `ctx.state.update_progress(...)`, `ctx.state.progress()`, and dashboard progress bars for long-running jobs.
+- Add `ctx.state.iter_with_progress(...)` and `JobProgressIterator` for resumable iterator-style jobs that should restart from the saved cursor and advance progress as items complete.
 
 ### Changed
 
 - Make dashboard queue and metrics views more operationally useful: queue length charts now live with queue stats, tooltips use readable worker labels, zero-value tooltip rows are hidden, and unknown ETAs sort after known drain times.
-- Show progress-aware job state in the dashboard while preserving cursor-only resumable state as raw job state.
+- Show progress-aware job state and ETA estimates in the dashboard while preserving cursor-only resumable state as raw job state.
 - Reduce Redis pressure by replacing `KEYS` with cursor-based `SCAN`, batching result counter writes, and snapshotting active queue lengths during worker refreshes.
 - Improve on-demand registration so the dashboard can prefill arguments, keep job hooks intact, and choose a sensible default queue.
 - Refresh examples, package metadata, CI paths, documentation references, and dependency versions for the Oxana rename and 2.0 release candidate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.4", path = "oxana" }
+oxana = { version = "2.0.0-rc.5", path = "oxana" }
 oxana-macros = { version = "2.0.0-rc.0", path = "oxana-macros" }

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -33,7 +33,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.4
+cargo add oxana@2.0.0-rc.5
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- bump `oxana` and `oxana-web` to `2.0.0-rc.5`
- update the lockfile and README install snippet
- update the 2.0 RC changelog for recent progress-state and dashboard ETA changes

## Verification
- `cargo check --all`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR primarily updates crate versions and associated release notes/docs, with no functional code changes in the diff.
> 
> **Overview**
> Bumps the workspace and published crate versions from `2.0.0-rc.4` to `2.0.0-rc.5` (including `Cargo.lock`) and updates the README install snippet accordingly.
> 
> Refreshes the `2.0.0-rc.5` changelog entry to reflect recent progress-state API simplification and dashboard updates (ETA estimates and iterator-style progress helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569e4b9cee62792e2b3025010c716304fe1f2e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->