### PR TITLE
Add sortable metrics columns

### DIFF
--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -71,7 +71,7 @@ pub(crate) async fn metrics(
     Query(params): Query<MetricsParams>,
 ) -> Result<MetricsTemplate, OxanaWebError> {
     let query = oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0));
-    let mut metrics = state.storage.job_metrics(query).await?;
+    let metrics = state.storage.job_metrics(query).await?;
     let sort = params
         .sort
         .as_deref()
@@ -83,13 +83,15 @@ pub(crate) async fn metrics(
         "desc"
     };
     let sort_key = if sort.is_empty() { "total_time" } else { sort };
+    let mut table_workers = metrics.workers.clone();
 
-    sort_worker_metrics(&mut metrics.workers, sort_key, dir == "desc");
+    sort_worker_metrics(&mut table_workers, sort_key, dir == "desc");
 
     Ok(MetricsTemplate {
         base_path: state.base_path,
         active_tab: "/metrics",
         metrics,
+        table_workers,
         sort: sort.to_string(),
         dir: dir.to_string(),
     })

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -83,9 +83,7 @@ pub(crate) async fn metrics(
         "desc"
     };
     let sort_key = if sort.is_empty() { "total_time" } else { sort };
-    let mut table_workers = metrics.workers.clone();
-
-    sort_worker_metrics(&mut table_workers, sort_key, dir == "desc");
+    let table_workers = sorted_worker_metrics(&metrics.workers, sort_key, dir == "desc");
 
     Ok(MetricsTemplate {
         base_path: state.base_path,
@@ -562,7 +560,13 @@ fn valid_metric_sort(sort: &str) -> bool {
     )
 }
 
-fn sort_worker_metrics(workers: &mut [oxana::WorkerMetricsSummary], sort: &str, desc: bool) {
+fn sorted_worker_metrics(
+    workers: &[oxana::WorkerMetricsSummary],
+    sort: &str,
+    desc: bool,
+) -> Vec<oxana::WorkerMetricsSummary> {
+    let mut workers = workers.to_vec();
+
     workers.sort_by(|a, b| {
         let cmp = match sort {
             "processed" => a.totals.processed.cmp(&b.totals.processed),
@@ -579,6 +583,8 @@ fn sort_worker_metrics(workers: &mut [oxana::WorkerMetricsSummary], sort: &str, 
 
         cmp.then_with(|| a.identity.worker.cmp(&b.identity.worker))
     });
+
+    workers
 }
 
 fn compare_eta(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering {
@@ -826,7 +832,7 @@ mod tests {
     use super::{
         CronEnqueueJobForm, OnDemandEnqueueJobForm, build_on_demand_queue_views,
         cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
-        sort_worker_metrics,
+        sorted_worker_metrics,
     };
     use crate::OxanaWebState;
     use axum::Form;
@@ -1000,32 +1006,33 @@ mod tests {
 
     #[test]
     fn worker_metrics_sort_defaults_to_descending_metric_values() {
-        let mut workers = vec![
+        let workers = vec![
             worker_metrics("fast", 5, 5, 0, 100, 5),
             worker_metrics("busy", 20, 18, 2, 90, 10),
             worker_metrics("idle", 1, 1, 0, 500, 1),
         ];
 
-        sort_worker_metrics(&mut workers, "processed", true);
+        let sorted = sorted_worker_metrics(&workers, "processed", true);
 
-        let names = workers
+        let names = sorted
             .iter()
             .map(|worker| worker.identity.worker.as_str())
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["busy", "fast", "idle"]);
+        assert_eq!(workers[0].identity.worker, "fast");
     }
 
     #[test]
     fn worker_metrics_sort_uses_average_execution_time() {
-        let mut workers = vec![
+        let workers = vec![
             worker_metrics("quick", 5, 5, 0, 100, 5),
             worker_metrics("slow", 2, 2, 0, 600, 2),
             worker_metrics("medium", 3, 3, 0, 300, 3),
         ];
 
-        sort_worker_metrics(&mut workers, "avg_time", true);
+        let sorted = sorted_worker_metrics(&workers, "avg_time", true);
 
-        let names = workers
+        let names = sorted
             .iter()
             .map(|worker| worker.identity.worker.as_str())
             .collect::<Vec<_>>();

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -71,12 +71,27 @@ pub(crate) async fn metrics(
     Query(params): Query<MetricsParams>,
 ) -> Result<MetricsTemplate, OxanaWebError> {
     let query = oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0));
-    let metrics = state.storage.job_metrics(query).await?;
+    let mut metrics = state.storage.job_metrics(query).await?;
+    let sort = params
+        .sort
+        .as_deref()
+        .filter(|sort| valid_metric_sort(sort))
+        .unwrap_or("");
+    let dir = if !sort.is_empty() && params.dir.as_deref() == Some("asc") {
+        "asc"
+    } else {
+        "desc"
+    };
+    let sort_key = if sort.is_empty() { "total_time" } else { sort };
+
+    sort_worker_metrics(&mut metrics.workers, sort_key, dir == "desc");
 
     Ok(MetricsTemplate {
         base_path: state.base_path,
         active_tab: "/metrics",
         metrics,
+        sort: sort.to_string(),
+        dir: dir.to_string(),
     })
 }
 
@@ -443,6 +458,10 @@ pub(crate) struct QueuesParams {
 #[derive(Deserialize)]
 pub(crate) struct MetricsParams {
     #[serde(default)]
+    sort: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
+    #[serde(default)]
     minutes: Option<usize>,
 }
 
@@ -531,6 +550,32 @@ fn sort_queues(
             };
             if desc { cmp.reverse() } else { cmp }
         }
+    });
+}
+
+fn valid_metric_sort(sort: &str) -> bool {
+    matches!(
+        sort,
+        "processed" | "succeeded" | "failed" | "total_time" | "avg_time"
+    )
+}
+
+fn sort_worker_metrics(workers: &mut [oxana::WorkerMetricsSummary], sort: &str, desc: bool) {
+    workers.sort_by(|a, b| {
+        let cmp = match sort {
+            "processed" => a.totals.processed.cmp(&b.totals.processed),
+            "succeeded" => a.totals.succeeded.cmp(&b.totals.succeeded),
+            "failed" => a.totals.failed.cmp(&b.totals.failed),
+            "avg_time" => a
+                .totals
+                .average_execution_ms()
+                .partial_cmp(&b.totals.average_execution_ms())
+                .unwrap_or(std::cmp::Ordering::Equal),
+            _ => a.totals.execution_ms.cmp(&b.totals.execution_ms),
+        };
+        let cmp = if desc { cmp.reverse() } else { cmp };
+
+        cmp.then_with(|| a.identity.worker.cmp(&b.identity.worker))
     });
 }
 
@@ -779,6 +824,7 @@ mod tests {
     use super::{
         CronEnqueueJobForm, OnDemandEnqueueJobForm, build_on_demand_queue_views,
         cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
+        sort_worker_metrics,
     };
     use crate::OxanaWebState;
     use axum::Form;
@@ -924,6 +970,64 @@ mod tests {
             .map(|queue| queue.key.as_str())
             .collect::<Vec<_>>();
         assert_eq!(keys, vec!["never", "slow", "fast"]);
+    }
+
+    fn worker_metrics(
+        worker: &str,
+        processed: u64,
+        succeeded: u64,
+        failed: u64,
+        execution_ms: u64,
+        successful_executions: u64,
+    ) -> oxana::WorkerMetricsSummary {
+        oxana::WorkerMetricsSummary {
+            identity: oxana::MetricIdentity {
+                worker: worker.to_string(),
+            },
+            totals: oxana::JobMetricsTotals {
+                processed,
+                succeeded,
+                failed,
+                execution_ms,
+                successful_executions,
+                ..oxana::JobMetricsTotals::default()
+            },
+            series: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn worker_metrics_sort_defaults_to_descending_metric_values() {
+        let mut workers = vec![
+            worker_metrics("fast", 5, 5, 0, 100, 5),
+            worker_metrics("busy", 20, 18, 2, 90, 10),
+            worker_metrics("idle", 1, 1, 0, 500, 1),
+        ];
+
+        sort_worker_metrics(&mut workers, "processed", true);
+
+        let names = workers
+            .iter()
+            .map(|worker| worker.identity.worker.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["busy", "fast", "idle"]);
+    }
+
+    #[test]
+    fn worker_metrics_sort_uses_average_execution_time() {
+        let mut workers = vec![
+            worker_metrics("quick", 5, 5, 0, 100, 5),
+            worker_metrics("slow", 2, 2, 0, 600, 2),
+            worker_metrics("medium", 3, 3, 0, 300, 3),
+        ];
+
+        sort_worker_metrics(&mut workers, "avg_time", true);
+
+        let names = workers
+            .iter()
+            .map(|worker| worker.identity.worker.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["slow", "medium", "quick"]);
     }
 
     #[test]

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -249,6 +249,7 @@ pub(crate) struct MetricsTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub metrics: oxana::JobMetricsSnapshot,
+    pub table_workers: Vec<oxana::WorkerMetricsSummary>,
     pub sort: String,
     pub dir: String,
 }
@@ -353,8 +354,28 @@ mod metrics_template_tests {
                 series: Vec::new(),
                 workers: Vec::new(),
             },
+            table_workers: Vec::new(),
             sort: sort.to_string(),
             dir: dir.to_string(),
+        }
+    }
+
+    fn worker_metrics(worker: &str, execution_ms: u64) -> oxana::WorkerMetricsSummary {
+        oxana::WorkerMetricsSummary {
+            identity: oxana::MetricIdentity {
+                worker: worker.to_string(),
+            },
+            totals: oxana::JobMetricsTotals {
+                execution_ms,
+                successful_executions: 1,
+                ..oxana::JobMetricsTotals::default()
+            },
+            series: vec![oxana::JobMetricsPoint {
+                timestamp: 60,
+                execution_ms,
+                successful_executions: 1,
+                ..oxana::JobMetricsPoint::default()
+            }],
         }
     }
 
@@ -387,6 +408,29 @@ mod metrics_template_tests {
             template.sort_href("total_time"),
             "/admin/metrics?sort=total_time&dir=asc&minutes=120"
         );
+    }
+
+    #[test]
+    fn metrics_chart_data_uses_snapshot_worker_order() {
+        let mut template = metrics_template("processed", "desc");
+        template.metrics.series = vec![oxana::JobMetricsPoint {
+            timestamp: 60,
+            ..oxana::JobMetricsPoint::default()
+        }];
+        template.metrics.workers = vec![
+            worker_metrics("ChartFirst", 100),
+            worker_metrics("ChartSecond", 200),
+        ];
+        template.table_workers = vec![
+            worker_metrics("TableFirst", 300),
+            worker_metrics("TableSecond", 400),
+        ];
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.execution_chart_data_json()).unwrap();
+
+        assert_eq!(payload["series"][0]["fullLabel"], "ChartFirst");
+        assert_eq!(payload["series"][1]["fullLabel"], "ChartSecond");
     }
 }
 

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -249,9 +249,53 @@ pub(crate) struct MetricsTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub metrics: oxana::JobMetricsSnapshot,
+    pub sort: String,
+    pub dir: String,
 }
 
 impl MetricsTemplate {
+    pub fn has_sort(&self) -> bool {
+        !self.sort.is_empty()
+    }
+
+    fn effective_sort(&self) -> &str {
+        if self.sort.is_empty() {
+            "total_time"
+        } else {
+            &self.sort
+        }
+    }
+
+    pub fn next_dir(&self, col: &str) -> &'static str {
+        if self.effective_sort() == col {
+            if self.dir == "desc" { "asc" } else { "desc" }
+        } else {
+            "desc"
+        }
+    }
+
+    pub fn sort_arrow(&self, col: &str) -> &'static str {
+        if self.effective_sort() == col {
+            if self.dir == "asc" {
+                " \u{25B2}"
+            } else {
+                " \u{25BC}"
+            }
+        } else {
+            ""
+        }
+    }
+
+    pub fn sort_href(&self, col: &str) -> String {
+        format!(
+            "{}/metrics?sort={}&dir={}&minutes={}",
+            self.base_path,
+            col,
+            self.next_dir(col),
+            self.metrics.minutes
+        )
+    }
+
     pub fn metric_identity_label(&self, identity: &oxana::MetricIdentity) -> String {
         metric_identity_label(identity)
     }
@@ -290,6 +334,59 @@ impl MetricsTemplate {
             "series": series,
         })
         .to_string()
+    }
+}
+
+#[cfg(test)]
+mod metrics_template_tests {
+    use super::MetricsTemplate;
+
+    fn metrics_template(sort: &str, dir: &str) -> MetricsTemplate {
+        MetricsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/metrics",
+            metrics: oxana::JobMetricsSnapshot {
+                starts_at: 0,
+                ends_at: 0,
+                minutes: 120,
+                totals: oxana::JobMetricsTotals::default(),
+                series: Vec::new(),
+                workers: Vec::new(),
+            },
+            sort: sort.to_string(),
+            dir: dir.to_string(),
+        }
+    }
+
+    #[test]
+    fn metrics_sort_href_preserves_chart_window_and_defaults_descending() {
+        let template = metrics_template("", "desc");
+
+        assert_eq!(
+            template.sort_href("processed"),
+            "/admin/metrics?sort=processed&dir=desc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn metrics_sort_href_toggles_current_column() {
+        let template = metrics_template("processed", "desc");
+
+        assert_eq!(
+            template.sort_href("processed"),
+            "/admin/metrics?sort=processed&dir=asc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn metrics_default_sort_shows_total_time_indicator() {
+        let template = metrics_template("", "desc");
+
+        assert_eq!(template.sort_arrow("total_time"), " \u{25BC}");
+        assert_eq!(
+            template.sort_href("total_time"),
+            "/admin/metrics?sort=total_time&dir=asc&minutes=120"
+        );
     }
 }
 

--- a/oxana-web/templates/metrics.html
+++ b/oxana-web/templates/metrics.html
@@ -105,7 +105,7 @@
 
         <section>
             <h2 class="text-lg font-semibold mb-4">Workers</h2>
-            {% if metrics.workers.is_empty() %}
+            {% if table_workers.is_empty() %}
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
                 No metrics
             </div>
@@ -123,7 +123,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for row in &metrics.workers %}
+                        {% for row in &table_workers %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">
                                 <a href="{{ base_path }}/metrics/job?worker={{ row.identity.worker|urlencode }}&amp;minutes={{ metrics.minutes }}" title="{{ row.identity.worker }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ self.metric_identity_label(&row.identity) }}</a>

--- a/oxana-web/templates/metrics.html
+++ b/oxana-web/templates/metrics.html
@@ -47,6 +47,10 @@
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
             <h2 class="text-lg font-semibold">Metrics</h2>
             <form method="GET" action="{{ base_path }}/metrics" class="flex items-center gap-2 text-sm">
+                {% if self.has_sort() %}
+                <input type="hidden" name="sort" value="{{ sort }}">
+                <input type="hidden" name="dir" value="{{ dir }}">
+                {% endif %}
                 <label for="minutes" class="text-gray-400">Window</label>
                 <select id="minutes" name="minutes" class="bg-gray-900 border border-gray-800 rounded px-3 py-1.5 text-gray-200" onchange="this.form.submit()">
                     <option value="60" {% if metrics.minutes == 60 %}selected{% endif %}>60 minutes</option>
@@ -111,11 +115,11 @@
                     <thead>
                         <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
                             <th class="pb-3 pr-4">Worker</th>
-                            <th class="pb-3 pr-4 text-right">Processed</th>
-                            <th class="pb-3 pr-4 text-right">Succeeded</th>
-                            <th class="pb-3 pr-4 text-right">Failed</th>
-                            <th class="pb-3 pr-4 text-right">Total Time</th>
-                            <th class="pb-3 text-right">Avg Time</th>
+                            <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("processed") }}" class="hover:text-gray-200">Processed{{ self.sort_arrow("processed") }}</a></th>
+                            <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("succeeded") }}" class="hover:text-gray-200">Succeeded{{ self.sort_arrow("succeeded") }}</a></th>
+                            <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("failed") }}" class="hover:text-gray-200">Failed{{ self.sort_arrow("failed") }}</a></th>
+                            <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("total_time") }}" class="hover:text-gray-200">Total Time{{ self.sort_arrow("total_time") }}</a></th>
+                            <th class="pb-3 text-right"><a href="{{ self.sort_href("avg_time") }}" class="hover:text-gray-200">Avg Time{{ self.sort_arrow("avg_time") }}</a></th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## Summary
- Make the `/metrics` worker table columns clickable for Processed, Succeeded, Failed, Total Time, and Avg Time.
- Sort descending on first click, toggle direction on subsequent clicks, and preserve the selected metrics window.
- Show the default `Total Time` descending indicator before any explicit sort is selected.

## Verification
- `cargo fmt --all`
- `cargo test -p oxana-web` (32 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI and presentation change that adds query-parameter-driven sorting for the metrics workers table; main risk is incorrect ordering or unexpected defaults for invalid sort inputs.
> 
> **Overview**
> Adds column sorting to the `/metrics` workers table: headers become links for *Processed/Succeeded/Failed/Total Time/Avg Time*, defaulting to **Total Time (desc)** and toggling direction on repeated clicks while preserving the selected `minutes` window.
> 
> Implements server-side validation and sorting (`sort`/`dir` query params, `valid_metric_sort`, `sorted_worker_metrics`), passes a separate `table_workers` list to the template, and adds template helpers/tests to generate sort URLs and arrows without affecting chart series ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6e5a543d1c339ff40b46a81708160c3364caf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->