### PR TITLE
feat: allow jobs to disable retry state resume

### DIFF
--- a/oxana-macros/src/job.rs
+++ b/oxana-macros/src/job.rs
@@ -18,6 +18,7 @@ struct OxanaJobArgs {
     unique_id: Option<UniqueIdSpec>,
     on_conflict: Option<Ident>,
     resurrect: Option<bool>,
+    resume: Option<bool>,
     throttle_cost: Option<ThrottleCost>,
     on_demand: Flag,
 }
@@ -168,6 +169,18 @@ pub fn expand_derive_job(input: DeriveInput) -> TokenStream {
         None => quote!(),
     };
 
+    let resume = match args.resume {
+        Some(value) => quote! {
+            fn should_resume() -> bool
+            where
+                Self: Sized,
+            {
+                #value
+            }
+        },
+        None => quote!(),
+    };
+
     let throttle_cost = match &args.throttle_cost {
         Some(throttle_cost) => expand_throttle_cost(throttle_cost),
         None => quote!(),
@@ -191,6 +204,8 @@ pub fn expand_derive_job(input: DeriveInput) -> TokenStream {
             #on_conflict
 
             #resurrect
+
+            #resume
 
             #throttle_cost
 

--- a/oxana-macros/src/lib.rs
+++ b/oxana-macros/src/lib.rs
@@ -37,6 +37,7 @@ pub fn derive_queue(input: TokenStream) -> TokenStream {
 /// #[derive(Serialize, oxana::Job)]
 /// #[oxana(on_conflict = Replace)]
 /// #[oxana(unique_id = "foo_{id}")]
+/// #[oxana(resume = false)]
 /// #[oxana(throttle_cost = Self::throttle_cost)]
 /// struct TestJob {
 ///     id: i32,

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -131,6 +131,7 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 | `#[oxana(unique_id = "worker_{id}")]` - define unique job identifiers | `#[oxana(context = MyContext)]` - set worker context type |
 | `#[oxana(on_conflict = Skip)]` - handle unique job conflicts (Skip or Replace) | `#[oxana(error = MyError)]` - set worker error type |
 | `#[oxana(resurrect = false)]` - disable crash resurrection for this job type | `#[oxana(registry = MyRegistry)]` - choose component registry |
+| `#[oxana(resume = false)]` - reset prior-attempt job state on retry |  |
 | `#[oxana(throttle_cost = 2)]` - set per-job throttle cost | `#[oxana(max_retries = 3)]` - set maximum retry attempts |
 | `#[oxana(on_demand)]` - expose the job in the web dashboard for manual enqueueing | `#[oxana(retry_delay = 5)]` - set retry delay in seconds |
 |  | `#[oxana(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
@@ -180,7 +181,9 @@ The context provides shared state and utilities to workers. It can include:
 
 Workers can persist job state with `ctx.state.update(...)` and read the state from
 the current attempt with `ctx.state.get::<T>()`. This is useful for resumable jobs
-that need to continue from the last completed item after a retry.
+that need to continue from the last completed item after a retry. Jobs resume
+state by default; use `#[oxana(resume = false)]` to clear prior-attempt state
+before each retry.
 
 For long-running jobs, use `ctx.state.update_progress(...)` to store progress in a
 structured format. The web dashboard renders a progress bar when `total` is set:

--- a/oxana/src/drainer.rs
+++ b/oxana/src/drainer.rs
@@ -66,7 +66,7 @@ where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let envelope = match config.storage.internal.get_job(&job_id).await? {
+    let mut envelope = match config.storage.internal.get_job(&job_id).await? {
         Some(envelope) => envelope,
         None => return Ok(ProcessJobResult::Missing),
     };
@@ -74,6 +74,12 @@ where
     let job = config
         .registry
         .build(&envelope.job.name, envelope.job.args.clone(), &ctx.0)?;
+
+    let should_resume = job.should_resume();
+    if !should_resume {
+        envelope.meta.state = None;
+        config.storage.internal.update_job(&envelope).await?;
+    }
 
     let job_ctx = JobContext {
         meta: envelope.meta.clone(),

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -32,6 +32,9 @@ where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
+    if !worker.should_resume() {
+        envelope.meta.state = None;
+    }
     config.storage.internal.set_started_at(envelope).await?;
     let policy = execution_policy(&worker, 0, envelope);
 
@@ -96,6 +99,12 @@ where
         .enumerate()
         .map(|(index, envelope)| execution_policy(&worker, index, envelope))
         .collect();
+
+    if !worker.should_resume() {
+        for envelope in envelopes.iter_mut() {
+            envelope.meta.state = None;
+        }
+    }
 
     config
         .storage
@@ -375,7 +384,6 @@ fn job_contexts(storage: &crate::Storage, envelopes: &[JobEnvelope]) -> Vec<JobC
         .map(|envelope| job_context(storage, envelope))
         .collect()
 }
-
 async fn handle_err<DT, ET>(
     config: &Config<DT, ET>,
     err_msg: &str,

--- a/oxana/src/job_state.rs
+++ b/oxana/src/job_state.rs
@@ -22,7 +22,7 @@ where
     I: Iterator,
 {
     iter: std::iter::Skip<std::iter::Enumerate<I>>,
-    state: Option<&'a JobState>,
+    state: &'a JobState,
     current_index: Option<usize>,
     total: usize,
 }
@@ -31,17 +31,14 @@ impl<'a, I> JobProgressIterator<'a, I>
 where
     I: Iterator,
 {
-    pub async fn new(state: impl Into<Option<&'a JobState>>, iter: I) -> Result<Self, OxanaError> {
+    pub async fn new(state: impl Into<&'a JobState>, iter: I) -> Result<Self, OxanaError> {
         let state = state.into();
-        let cursor = match state {
-            Some(state) => state
-                .progress()
-                .await?
-                .map(|progress| usize::try_from(progress.cursor.max(0)))
-                .transpose()?
-                .unwrap_or(0),
-            None => 0,
-        };
+        let cursor = state
+            .progress()
+            .await?
+            .map(|progress| usize::try_from(progress.cursor.max(0)))
+            .transpose()?
+            .unwrap_or(0);
         let (min_remaining, max_remaining) = iter.size_hint();
         let total = max_remaining.unwrap_or(min_remaining);
 
@@ -69,9 +66,9 @@ where
     }
 
     async fn mark_current_completed(&mut self) -> Result<(), OxanaError> {
-        if let (Some(state), Some(index)) = (self.state, self.current_index.take()) {
+        if let Some(index) = self.current_index.take() {
             let cursor = index + 1;
-            state
+            self.state
                 .update_progress((i64::try_from(cursor)?, i64::try_from(self.total)?))
                 .await?;
         }
@@ -222,7 +219,7 @@ impl JobState {
 
 #[cfg(test)]
 mod tests {
-    use super::{JobProgress, JobProgressIterator};
+    use super::JobProgress;
     use serde_json::json;
 
     #[test]
@@ -281,20 +278,5 @@ mod tests {
                 .unwrap(),
             expected
         );
-    }
-
-    #[tokio::test]
-    async fn job_progress_iterator_without_state_iterates_items() {
-        let mut iter = JobProgressIterator::new(None, ["one", "two"].into_iter())
-            .await
-            .unwrap();
-
-        assert_eq!(iter.current_index(), None);
-        assert_eq!(iter.next().await.unwrap(), Some("one"));
-        assert_eq!(iter.current_index(), Some(0));
-        assert_eq!(iter.next().await.unwrap(), Some("two"));
-        assert_eq!(iter.current_index(), Some(1));
-        assert_eq!(iter.next().await.unwrap(), None);
-        assert_eq!(iter.current_index(), None);
     }
 }

--- a/oxana/src/worker.rs
+++ b/oxana/src/worker.rs
@@ -43,6 +43,13 @@ pub trait Job: Send + serde::Serialize {
         true
     }
 
+    fn should_resume() -> bool
+    where
+        Self: Sized,
+    {
+        true
+    }
+
     fn throttle_cost(&self) -> Option<u64> {
         None
     }
@@ -138,6 +145,9 @@ pub trait Processable: Send {
     fn len(&self) -> usize;
     fn max_retries(&self, index: usize) -> u32;
     fn retry_delay(&self, index: usize, retries: u32) -> u64;
+    fn should_resume(&self) -> bool {
+        true
+    }
 }
 
 pub type BoxedProcessable<ET> = Box<dyn Processable<Error = ET>>;
@@ -156,7 +166,7 @@ pub(crate) struct BoundBatchJob<W, A> {
 impl<W, A> Processable for BoundJob<W, A>
 where
     W: Worker<A> + Send + Sync + 'static,
-    A: Send + 'static,
+    A: Job + Send + 'static,
 {
     type Error = W::Error;
 
@@ -184,13 +194,17 @@ where
         assert_eq!(index, 0, "single job index must be zero");
         self.worker.retry_delay(&self.job, retries)
     }
+
+    fn should_resume(&self) -> bool {
+        A::should_resume()
+    }
 }
 
 #[async_trait::async_trait]
 impl<W, A> Processable for BoundBatchJob<W, A>
 where
     W: Worker<A> + Send + Sync + 'static,
-    A: Send + 'static,
+    A: Job + Send + 'static,
 {
     type Error = W::Error;
 
@@ -221,6 +235,10 @@ where
     fn retry_delay(&self, index: usize, retries: u32) -> u64 {
         let job = self.jobs.get(index).expect("batch job index out of bounds");
         self.worker.retry_delay(job, retries)
+    }
+
+    fn should_resume(&self) -> bool {
+        A::should_resume()
     }
 }
 
@@ -632,6 +650,28 @@ mod tests {
         }
 
         assert!(<DefaultResurrectJob as oxana::Job>::should_resurrect());
+    }
+
+    #[test]
+    fn test_define_job_with_resume_false() {
+        use crate as oxana;
+
+        struct NoResumeWorker;
+
+        #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+        #[oxana(worker = NoResumeWorker)]
+        #[oxana(resume = false)]
+        struct NoResumeJob {}
+
+        assert!(!<NoResumeJob as oxana::Job>::should_resume());
+
+        struct DefaultResumeWorker;
+
+        #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+        #[oxana(worker = DefaultResumeWorker)]
+        struct DefaultResumeJob {}
+
+        assert!(<DefaultResumeJob as oxana::Job>::should_resume());
     }
 
     #[test]

--- a/oxana/src/worker_registry.rs
+++ b/oxana/src/worker_registry.rs
@@ -65,7 +65,7 @@ pub fn job_factory<W, A, DT, ET>(
 ) -> Result<BoxedProcessable<ET>, OxanaError>
 where
     W: Worker<A, Error = ET> + FromContext<DT> + 'static,
-    A: serde::de::DeserializeOwned + Send + 'static,
+    A: Job + serde::de::DeserializeOwned + Send + 'static,
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
@@ -80,7 +80,7 @@ pub fn job_batch_factory<W, A, DT, ET>(
 ) -> Result<BatchBuild<ET>, OxanaError>
 where
     W: Worker<A, Error = ET> + FromContext<DT> + 'static,
-    A: serde::de::DeserializeOwned + Send + 'static,
+    A: Job + serde::de::DeserializeOwned + Send + 'static,
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {

--- a/oxana/tests/integration/retry.rs
+++ b/oxana/tests/integration/retry.rs
@@ -102,3 +102,256 @@ pub async fn test_retry() -> TestResult {
 
     Ok(())
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkerStateResumeDefaultJob {
+    pub attempts_key: String,
+    pub observations_key: String,
+    pub read_mode: WorkerStateReadMode,
+}
+
+pub struct WorkerStateResumeDefault {
+    state: WorkerState,
+}
+
+impl oxana::Job for WorkerStateResumeDefaultJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<WorkerStateResumeDefault>()
+    }
+}
+
+impl oxana::FromContext<WorkerState> for WorkerStateResumeDefault {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<WorkerStateResumeDefaultJob> for WorkerStateResumeDefault {
+    type Error = WorkerError;
+
+    async fn run_batch(
+        &self,
+        jobs: Vec<oxana::BatchItem<WorkerStateResumeDefaultJob>>,
+    ) -> Result<(), WorkerError> {
+        for item in jobs {
+            record_state_retry_attempt(
+                &self.state,
+                &item.ctx,
+                &item.job.attempts_key,
+                &item.job.observations_key,
+                item.job.read_mode,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    fn retry_delay(&self, _job: &WorkerStateResumeDefaultJob, _retries: u32) -> u64 {
+        0
+    }
+
+    fn max_retries(&self, _job: &WorkerStateResumeDefaultJob) -> u32 {
+        1
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkerStateNoResumeJob {
+    pub attempts_key: String,
+    pub observations_key: String,
+    pub read_mode: WorkerStateReadMode,
+}
+
+pub struct WorkerStateNoResume {
+    state: WorkerState,
+}
+
+impl oxana::Job for WorkerStateNoResumeJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<WorkerStateNoResume>()
+    }
+
+    fn should_resume() -> bool {
+        false
+    }
+}
+
+impl oxana::FromContext<WorkerState> for WorkerStateNoResume {
+    fn from_context(ctx: &WorkerState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<WorkerStateNoResumeJob> for WorkerStateNoResume {
+    type Error = WorkerError;
+
+    async fn run_batch(
+        &self,
+        jobs: Vec<oxana::BatchItem<WorkerStateNoResumeJob>>,
+    ) -> Result<(), WorkerError> {
+        for item in jobs {
+            record_state_retry_attempt(
+                &self.state,
+                &item.ctx,
+                &item.job.attempts_key,
+                &item.job.observations_key,
+                item.job.read_mode,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    fn retry_delay(&self, _job: &WorkerStateNoResumeJob, _retries: u32) -> u64 {
+        0
+    }
+
+    fn max_retries(&self, _job: &WorkerStateNoResumeJob) -> u32 {
+        1
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum WorkerStateReadMode {
+    State,
+    Progress,
+}
+
+async fn record_state_retry_attempt(
+    state: &WorkerState,
+    ctx: &oxana::JobContext,
+    attempts_key: &str,
+    observations_key: &str,
+    read_mode: WorkerStateReadMode,
+) -> Result<(), WorkerError> {
+    let observed = match read_mode {
+        WorkerStateReadMode::State => {
+            let seen_state = ctx
+                .state
+                .get::<i64>()
+                .await
+                .map_err(|e| WorkerError::Generic(e.to_string()))?;
+            seen_state.map_or_else(|| "none".to_string(), |value| value.to_string())
+        }
+        WorkerStateReadMode::Progress => {
+            let seen_progress = ctx
+                .state
+                .progress()
+                .await
+                .map_err(|e| WorkerError::Generic(e.to_string()))?;
+            seen_progress.map_or_else(|| "none".to_string(), |value| value.cursor.to_string())
+        }
+    };
+
+    let mut redis = state.redis.get().await?;
+    let _: usize = redis.rpush(observations_key, observed).await?;
+    let attempt: i64 = redis.incr(attempts_key, 1).await?;
+
+    match read_mode {
+        WorkerStateReadMode::State => ctx.state.update(attempt).await,
+        WorkerStateReadMode::Progress => ctx.state.update_progress((attempt, 2)).await,
+    }
+    .map_err(|e| WorkerError::Generic(e.to_string()))?;
+
+    if attempt == 1 {
+        return Err(WorkerError::Generic("retry once".to_string()));
+    }
+
+    Ok(())
+}
+
+async fn run_state_retry_test<W, A>(
+    build_job: impl FnOnce(String, String) -> A,
+    expected_observations: &[&str],
+) -> TestResult
+where
+    W: oxana::Worker<A, Error = WorkerError> + oxana::FromContext<WorkerState> + 'static,
+    A: oxana::Job + serde::de::DeserializeOwned + Send + 'static,
+{
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxana::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let config = oxana::Config::new(&storage)
+        .register_queue::<QueueOne>()
+        .register_worker::<W, A>()
+        .exit_when_processed(2);
+
+    let attempts_key = uuid::Uuid::new_v4().to_string();
+    let observations_key = uuid::Uuid::new_v4().to_string();
+
+    storage
+        .enqueue(QueueOne, build_job(attempts_key, observations_key.clone()))
+        .await?;
+
+    oxana::run(config, ctx).await?;
+
+    let observations: Vec<String> = redis_conn.lrange(observations_key, 0, -1).await?;
+    let expected_observations = expected_observations
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(observations, expected_observations);
+    assert_eq!(storage.dead_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_retry_resumes_state_by_default() -> TestResult {
+    run_state_retry_test::<WorkerStateResumeDefault, WorkerStateResumeDefaultJob>(
+        |attempts_key, observations_key| WorkerStateResumeDefaultJob {
+            attempts_key,
+            observations_key,
+            read_mode: WorkerStateReadMode::State,
+        },
+        &["none", "1"],
+    )
+    .await
+}
+
+#[tokio::test]
+pub async fn test_retry_resumes_progress_by_default() -> TestResult {
+    run_state_retry_test::<WorkerStateResumeDefault, WorkerStateResumeDefaultJob>(
+        |attempts_key, observations_key| WorkerStateResumeDefaultJob {
+            attempts_key,
+            observations_key,
+            read_mode: WorkerStateReadMode::Progress,
+        },
+        &["none", "1"],
+    )
+    .await
+}
+
+#[tokio::test]
+pub async fn test_retry_resets_state_when_resume_is_false() -> TestResult {
+    run_state_retry_test::<WorkerStateNoResume, WorkerStateNoResumeJob>(
+        |attempts_key, observations_key| WorkerStateNoResumeJob {
+            attempts_key,
+            observations_key,
+            read_mode: WorkerStateReadMode::State,
+        },
+        &["none", "none"],
+    )
+    .await
+}
+
+#[tokio::test]
+pub async fn test_retry_resets_progress_when_resume_is_false() -> TestResult {
+    run_state_retry_test::<WorkerStateNoResume, WorkerStateNoResumeJob>(
+        |attempts_key, observations_key| WorkerStateNoResumeJob {
+            attempts_key,
+            observations_key,
+            read_mode: WorkerStateReadMode::Progress,
+        },
+        &["none", "none"],
+    )
+    .await
+}


### PR DESCRIPTION
## Summary
- Adds `#[oxana(resume = false)]` support for jobs that should clear saved state and progress before retry attempts.
- Propagates the resume policy through registered single and batch jobs into executor and drainer paths.
- Updates README and macro docs, plus integration coverage for default resume behavior and `resume = false` reset behavior.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --workspace`
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry execution behavior by conditionally clearing persisted job state/progress before processing, affecting both normal execution and `drain` paths. Risk is moderate because it touches core job execution semantics and persistence updates, though behavior is opt-out and covered by new tests.
> 
> **Overview**
> Adds a new per-job resume policy (`Job::should_resume()` / `#[oxana(resume = false)]`) to control whether persisted job state/progress is carried across retry attempts.
> 
> When resume is disabled, the executor clears `envelope.meta.state` before starting single or batch execution, and the queue `drain` path also clears and persists the reset state before processing. Documentation is updated and new unit/integration tests verify default resume behavior vs. `resume = false` for both state and progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36efd6ac0c948e6764b07cafd123dff8b524587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->