### PR TITLE
v2.0.0-rc.6 chore: align crate rc versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-rc.5]
+## [2.0.0-rc.6]
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.6"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.5", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.0", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.6", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.6", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.6"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -33,7 +33,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.5
+cargo add oxana@2.0.0-rc.6
 ```
 
 ```rust


### PR DESCRIPTION
## Summary

- Bump `oxana`, `oxana-macros`, and `oxana-web` to `2.0.0-rc.6`.
- Align workspace dependency versions and `Cargo.lock` package metadata.
- Update the changelog heading and README install snippet to match the new RC.

## Testing

- `cargo check --all`
- `cargo test`
- `cargo test --workspace`

## Review

No code behavior changed. This PR only aligns release candidate metadata across manifests, lockfile, changelog, and README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release-metadata/version alignment across manifests, lockfile, changelog, and README with no runtime logic changes.
> 
> **Overview**
> Updates the workspace and all published crates (`oxana`, `oxana-macros`, `oxana-web`) to **`2.0.0-rc.6`**, aligning versions in `Cargo.toml`, each crate manifest, and `Cargo.lock`.
> 
> Refreshes release metadata/docs by renaming the changelog entry header to `2.0.0-rc.6` and updating the README install snippet to reference the new RC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9644deabe47c32f9a52bf30a5f315fb9f523c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->