### PR TITLE
feat: show job argument pills in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Add dashboard actions for enqueueing cron jobs immediately and wiping the dead queue.
 - Add structured job progress state with `ctx.state.update_progress(...)`, `ctx.state.progress()`, and dashboard progress bars for long-running jobs.
 - Add `ctx.state.iter_with_progress(...)` and `JobProgressIterator` for resumable iterator-style jobs that should restart from the saved cursor and advance progress as items complete.
+- Show scalar job arguments as compact dashboard pills while preserving raw JSON for complex arguments.
 
 ### Changed
 

--- a/oxana-web/src/filters.rs
+++ b/oxana-web/src/filters.rs
@@ -169,6 +169,68 @@ pub fn has_args(val: &serde_json::Value, _env: &dyn askama::Values) -> askama::R
     Ok(!empty)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimpleArgPill {
+    pub key: String,
+    pub value: String,
+}
+
+fn simple_arg_value(val: &serde_json::Value) -> Option<String> {
+    match val {
+        serde_json::Value::Null => Some("null".to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::String(value) => Some(if value.is_empty() {
+            "\"\"".to_string()
+        } else {
+            value.clone()
+        }),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => None,
+    }
+}
+
+fn simple_args_for(val: &serde_json::Value) -> Vec<SimpleArgPill> {
+    let serde_json::Value::Object(args) = val else {
+        return Vec::new();
+    };
+
+    args.iter()
+        .filter_map(|(key, value)| {
+            simple_arg_value(value).map(|value| SimpleArgPill {
+                key: key.clone(),
+                value,
+            })
+        })
+        .collect()
+}
+
+#[askama::filter_fn]
+pub fn simple_args(
+    val: &serde_json::Value,
+    _env: &dyn askama::Values,
+) -> askama::Result<Vec<SimpleArgPill>> {
+    Ok(simple_args_for(val))
+}
+
+fn should_show_args_json(val: &serde_json::Value) -> bool {
+    match val {
+        serde_json::Value::Null => false,
+        serde_json::Value::Object(args) if args.is_empty() => false,
+        serde_json::Value::Object(args) => {
+            args.values().any(|value| simple_arg_value(value).is_none())
+        }
+        serde_json::Value::Array(_)
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => true,
+    }
+}
+
+#[askama::filter_fn]
+pub fn show_args_json(val: &serde_json::Value, _env: &dyn askama::Values) -> askama::Result<bool> {
+    Ok(should_show_args_json(val))
+}
+
 fn progress_parts(val: &serde_json::Value) -> Option<oxana::JobProgress> {
     serde_json::from_value(val.clone()).ok()
 }
@@ -280,8 +342,79 @@ pub fn job_progress_eta(
 
 #[cfg(test)]
 mod tests {
-    use super::{progress_eta_s, progress_parts, should_show_progress};
+    use super::{
+        SimpleArgPill, progress_eta_s, progress_parts, should_show_args_json, should_show_progress,
+        simple_args_for,
+    };
     use serde_json::json;
+
+    #[test]
+    fn simple_args_include_top_level_scalar_values() {
+        let value = json!({
+            "game_id": 12345,
+            "league": "nba",
+            "dry_run": true,
+            "missing": null,
+        });
+
+        assert_eq!(
+            simple_args_for(&value),
+            vec![
+                SimpleArgPill {
+                    key: "game_id".to_string(),
+                    value: "12345".to_string(),
+                },
+                SimpleArgPill {
+                    key: "league".to_string(),
+                    value: "nba".to_string(),
+                },
+                SimpleArgPill {
+                    key: "dry_run".to_string(),
+                    value: "true".to_string(),
+                },
+                SimpleArgPill {
+                    key: "missing".to_string(),
+                    value: "null".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn simple_args_include_scalar_values_from_mixed_args() {
+        let value = json!({
+            "game_id": 12345,
+            "metadata": { "season": 2026 },
+        });
+
+        assert_eq!(
+            simple_args_for(&value),
+            vec![SimpleArgPill {
+                key: "game_id".to_string(),
+                value: "12345".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn simple_args_require_an_object() {
+        assert!(simple_args_for(&json!(12345)).is_empty());
+        assert!(simple_args_for(&json!(["game_id", 12345])).is_empty());
+    }
+
+    #[test]
+    fn args_json_only_shows_when_pills_do_not_cover_everything() {
+        assert!(!should_show_args_json(&json!({})));
+        assert!(!should_show_args_json(&json!({
+            "game_id": 12345,
+            "dry_run": false,
+        })));
+        assert!(should_show_args_json(&json!({
+            "game_id": 12345,
+            "metadata": { "season": 2026 },
+        })));
+        assert!(should_show_args_json(&json!(12345)));
+    }
 
     #[test]
     fn progress_parts_recognizes_update_progress_state() {

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -705,6 +705,89 @@ pub(crate) struct JobDetailTemplate {
 }
 
 #[cfg(test)]
+mod job_card_tests {
+    use super::{GlobalJobsTemplate, JobListKind};
+    use askama::Template;
+    use serde_json::json;
+
+    fn job_envelope(args: serde_json::Value) -> oxana::JobEnvelope {
+        oxana::JobEnvelope {
+            id: "job-1".to_string(),
+            queue: "default".to_string(),
+            job: oxana::JobData {
+                name: "crate::ImportGame".to_string(),
+                args,
+            },
+            meta: oxana::JobMeta {
+                id: "job-1".to_string(),
+                retries: 0,
+                unique: false,
+                on_conflict: None,
+                created_at: 1_000_000,
+                scheduled_at: 1_000_000,
+                started_at: None,
+                state: None,
+                resurrect: true,
+                error: None,
+                throttle_cost: None,
+            },
+        }
+    }
+
+    #[test]
+    fn global_job_cards_render_simple_arg_pills() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            jobs: vec![job_envelope(json!({
+                "game_id": 12345,
+                "dry_run": false,
+            }))],
+            page: 1,
+            total: 1,
+            has_next: false,
+        };
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains("title=\"game_id: 12345\""));
+        assert!(rendered.contains("title=\"dry_run: false\""));
+        assert!(
+            !rendered.contains(
+                "<summary class=\"text-xs text-gray-500 cursor-pointer hover:text-gray-300\">Arguments</summary>"
+            )
+        );
+    }
+
+    #[test]
+    fn global_job_cards_render_pills_and_json_args_when_any_arg_is_complex() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            jobs: vec![job_envelope(json!({
+                "game_id": 12345,
+                "metadata": { "season": 2026 },
+            }))],
+            page: 1,
+            total: 1,
+            has_next: false,
+        };
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains("title=\"game_id: 12345\""));
+        assert!(!rendered.contains("title=\"metadata:"));
+        assert!(
+            rendered.contains(
+                "<summary class=\"text-xs text-gray-500 cursor-pointer hover:text-gray-300\">Arguments</summary>"
+            )
+        );
+    }
+}
+
+#[cfg(test)]
 mod cron_tests {
     use super::{CronRow, CronTemplate, CronWorkerView};
     use askama::Template;

--- a/oxana-web/templates/_arg_pills.html
+++ b/oxana-web/templates/_arg_pills.html
@@ -1,0 +1,10 @@
+{% if !arg_pills.is_empty() %}
+<div class="mt-3 flex flex-wrap gap-2">
+    {% for arg in &arg_pills %}
+    <span class="inline-flex max-w-full overflow-hidden rounded-full border border-gray-700 bg-gray-800/70 align-middle text-xs" title="{{ arg.key }}: {{ arg.value }}" aria-label="Argument {{ arg.key }} {{ arg.value }}">
+        <span class="shrink-0 border-r border-gray-700 px-2 py-1 text-gray-400">{{ arg.key }}</span>
+        <span class="min-w-0 truncate px-2 py-1 font-mono text-gray-100">{{ arg.value }}</span>
+    </span>
+    {% endfor %}
+</div>
+{% endif %}

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -136,7 +136,9 @@
                             <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.retries }}</span>
                         </div>
                     </div>
-                    {% if item.job_envelope.job.args|has_args %}
+                    {% let arg_pills = item.job_envelope.job.args|simple_args %}
+                    {% include "_arg_pills.html" %}
+                    {% if item.job_envelope.job.args|show_args_json %}
                     <div class="mt-3">
                         <details>
                             <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>

--- a/oxana-web/templates/global_jobs.html
+++ b/oxana-web/templates/global_jobs.html
@@ -76,7 +76,9 @@
                         <span class="ml-1 text-gray-300">{{ job.meta.scheduled_at|relative_time_micros }}</span>
                     </div>
                 </div>
-                {% if job.job.args|has_args %}
+                {% let arg_pills = job.job.args|simple_args %}
+                {% include "_arg_pills.html" %}
+                {% if job.job.args|show_args_json %}
                 <details class="mt-3" open>
                     <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
                     <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ job.job.args|pretty_json }}</pre>

--- a/oxana-web/templates/job_detail.html
+++ b/oxana-web/templates/job_detail.html
@@ -69,10 +69,14 @@
                 </div>
             </div>
 
+            {% let arg_pills = job.job.args|simple_args %}
+            {% include "_arg_pills.html" %}
+            {% if job.job.args|show_args_json %}
             <details class="mt-3" open>
                 <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
                 <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ job.job.args|pretty_json }}</pre>
             </details>
+            {% endif %}
 
             {% match job.meta.state %}
             {% when Some with (state) %}

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -109,7 +109,9 @@
                             <span class="ml-1 text-gray-300">{{ item.job_envelope.meta.retries }}</span>
                         </div>
                     </div>
-                    {% if item.job_envelope.job.args|has_args %}
+                    {% let arg_pills = item.job_envelope.job.args|simple_args %}
+                    {% include "_arg_pills.html" %}
+                    {% if item.job_envelope.job.args|show_args_json %}
                     <details class="mt-3">
                         <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
                         <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ item.job_envelope.job.args|pretty_json }}</pre>
@@ -192,7 +194,9 @@
                         <span class="ml-1 text-gray-300">{{ job.meta.scheduled_at|relative_time_micros }}</span>
                     </div>
                 </div>
-                {% if job.job.args|has_args %}
+                {% let arg_pills = job.job.args|simple_args %}
+                {% include "_arg_pills.html" %}
+                {% if job.job.args|show_args_json %}
                 <details class="mt-3" open>
                     <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-300">Arguments</summary>
                     <pre class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800">{{ job.job.args|pretty_json }}</pre>


### PR DESCRIPTION
## Summary
- Render scalar job arguments as compact pills across dashboard job cards.
- Keep raw JSON arguments visible when payloads contain complex values like arrays or objects.
- Add filter and Askama render tests for simple and mixed argument payloads.
- Update `CHANGELOG.md` for the dashboard improvement.

## Test Coverage
All new code paths have test coverage through `filters.rs` unit tests and `GlobalJobsTemplate` render tests.

## Pre-Landing Review
No issues found. The earlier untracked partial concern is resolved by committing `oxana-web/templates/_arg_pills.html`.

## Design Review
Design Review (lite): no issues found. The partial follows the existing dashboard Tailwind style.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN.

## Plan Completion
No plan file detected.

## TODOS
No `TODOS.md` exists in this repo.

## Documentation
- Updated `CHANGELOG.md`.

## Test plan
- [x] `cargo test --workspace` (132 passed, 3 ignored)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --workspace --all-targets -- -D warnings`

Generated with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds new Askama filters/partials to change how job arguments render, with unit/template render tests to reduce regression risk.
> 
> **Overview**
> **Dashboard job argument rendering is updated** to show top-level scalar JSON args (null/bool/number/string) as compact pills across job cards and detail views.
> 
> Raw JSON argument blocks are now **shown only when the payload is non-object or contains any complex values** (arrays/objects), and a new `_arg_pills.html` partial plus filter/unit and template render tests are added; `CHANGELOG.md` is updated to document the improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acb75fb564a59fb25cfe1ce9a67d8011a2bd24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->