### PR TITLE
chore: bump oxana-web rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.7"
 dependencies = [
  "askama",
  "askama_web",

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.7"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."


### PR DESCRIPTION
## Summary
- Bump `oxana-web` from `2.0.0-rc.6` to `2.0.0-rc.7`
- Refresh the matching `Cargo.lock` package metadata

## Tests
- `cargo test -p oxana-web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version/lockfile metadata update only, with no functional code changes.
> 
> **Overview**
> Updates `oxana-web` crate metadata to `2.0.0-rc.7` and refreshes the corresponding `Cargo.lock` entry to reflect the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e9d10f4a72e13743abf14e78cb210f656745c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->