### PR TITLE
Runtime queue controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-rc.6]
+## [2.0.0-rc]
 
 ### Breaking Changes
 
@@ -23,6 +23,11 @@ All notable changes to this project will be documented in this file.
 - Add structured job progress state with `ctx.state.update_progress(...)`, `ctx.state.progress()`, and dashboard progress bars for long-running jobs.
 - Add `ctx.state.iter_with_progress(...)` and `JobProgressIterator` for resumable iterator-style jobs that should restart from the saved cursor and advance progress as items complete.
 - Show scalar job arguments as compact dashboard pills while preserving raw JSON for complex arguments.
+- Add runtime queue configuration storage for queue state and dynamic concurrency overrides.
+- Add dynamic queue concurrency through `QueueConfig::dynamic_concurrency(...)` and `#[oxana(concurrency = Dynamic(...))]`.
+- Add `Storage::set_queue_concurrency`, `Storage::set_queue_state`, `Storage::pause_queue`, `Storage::unpause_queue`, and `Storage::reset_queue_config` for changing queue runtime behavior without restarting workers.
+- Add dashboard controls for pausing queues and changing dynamic queue concurrency from queue detail pages.
+- Add dynamic concurrency examples, including seeded dynamic tenant queues in the web dashboard example.
 
 ### Changed
 
@@ -31,6 +36,14 @@ All notable changes to this project will be documented in this file.
 - Reduce Redis pressure by replacing `KEYS` with cursor-based `SCAN`, batching result counter writes, and snapshotting active queue lengths during worker refreshes.
 - Improve on-demand registration so the dashboard can prefill arguments, keep job hooks intact, and choose a sensible default queue.
 - Refresh examples, package metadata, CI paths, documentation references, and dependency versions for the Oxana rename and 2.0 release candidate.
+- Apply runtime queue state and dynamic concurrency changes while dispatchers are running.
+- Clear persisted concurrency overrides when a dynamic queue is set back to its effective default.
+- Treat a dynamic child queue's effective concurrency default as the inherited base queue runtime concurrency.
+- Show dashboard concurrency overrides with the default value struck through.
+
+### Fixed
+
+- Avoid persisting runtime queue config when a queue is only using its default configuration.
 
 ## [1.1.1]
 

--- a/oxana-macros/src/queue.rs
+++ b/oxana-macros/src/queue.rs
@@ -3,7 +3,7 @@ use heck::ToSnakeCase;
 use proc_macro_error2::abort;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, Path};
+use syn::{Data, DeriveInput, Expr, ExprCall, ExprLit, ExprPath, Fields, Lit, Path};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(oxana), supports(struct_any))]
@@ -11,8 +11,82 @@ struct OxanaArgs {
     registry: Option<Path>,
     key: Option<String>,
     prefix: Option<String>,
-    concurrency: Option<usize>,
+    concurrency: Option<ConcurrencyArg>,
     throttle: Option<ThrottleArgs>,
+}
+
+#[derive(Debug)]
+enum ConcurrencyArg {
+    Fixed(usize),
+    Dynamic(usize),
+}
+
+impl FromMeta for ConcurrencyArg {
+    fn from_expr(expr: &Expr) -> darling::Result<Self> {
+        match expr {
+            Expr::Lit(expr_lit) => parse_concurrency_value(expr_lit).map(Self::Fixed),
+            Expr::Call(expr_call) => parse_concurrency_call(expr_call),
+            Expr::Group(group) => Self::from_expr(&group.expr),
+            _ => Err(darling::Error::custom(
+                "expected integer literal, Fixed(<integer>), or Dynamic(<integer>)",
+            )
+            .with_span(expr)),
+        }
+    }
+}
+
+fn parse_concurrency_call(expr_call: &ExprCall) -> darling::Result<ConcurrencyArg> {
+    let Expr::Path(ExprPath { path, .. }) = expr_call.func.as_ref() else {
+        return Err(
+            darling::Error::custom("expected Fixed(<integer>) or Dynamic(<integer>)")
+                .with_span(expr_call),
+        );
+    };
+    let Some(ident) = path.get_ident() else {
+        return Err(
+            darling::Error::custom("expected Fixed(<integer>) or Dynamic(<integer>)")
+                .with_span(path),
+        );
+    };
+    let mut args = expr_call.args.iter();
+    let Some(arg) = args.next() else {
+        return Err(
+            darling::Error::custom("expected exactly one integer argument").with_span(expr_call),
+        );
+    };
+    if args.next().is_some() {
+        return Err(
+            darling::Error::custom("expected exactly one integer argument").with_span(expr_call),
+        );
+    }
+
+    let value = parse_concurrency_expr(arg)?;
+    match ident.to_string().as_str() {
+        "Fixed" => Ok(ConcurrencyArg::Fixed(value)),
+        "Dynamic" => Ok(ConcurrencyArg::Dynamic(value)),
+        _ => Err(
+            darling::Error::custom("expected Fixed(<integer>) or Dynamic(<integer>)")
+                .with_span(ident),
+        ),
+    }
+}
+
+fn parse_concurrency_expr(expr: &Expr) -> darling::Result<usize> {
+    match expr {
+        Expr::Lit(expr_lit) => parse_concurrency_value(expr_lit),
+        Expr::Group(group) => parse_concurrency_expr(&group.expr),
+        _ => Err(darling::Error::custom("expected integer literal").with_span(expr)),
+    }
+}
+
+fn parse_concurrency_value(expr_lit: &ExprLit) -> darling::Result<usize> {
+    let Lit::Int(value) = &expr_lit.lit else {
+        return Err(darling::Error::custom("expected integer literal").with_span(expr_lit));
+    };
+
+    value
+        .base10_parse()
+        .map_err(|err| darling::Error::custom(err.to_string()).with_span(value))
 }
 
 #[derive(Debug, FromMeta)]
@@ -64,7 +138,8 @@ pub fn expand_derive_queue(input: DeriveInput) -> TokenStream {
     };
 
     let concurrency = match args.concurrency {
-        Some(v) => quote!(.concurrency(#v)),
+        Some(ConcurrencyArg::Fixed(v)) => quote!(.concurrency(#v)),
+        Some(ConcurrencyArg::Dynamic(v)) => quote!(.dynamic_concurrency(#v)),
         None => quote!(),
     };
 

--- a/oxana-web/examples/web.rs
+++ b/oxana-web/examples/web.rs
@@ -186,6 +186,25 @@ struct PriorityQueue;
 #[oxana(key = "progress", concurrency = 1)]
 struct ProgressQueue;
 
+#[derive(Serialize)]
+struct TenantQueueBase;
+
+impl oxana::Queue for TenantQueueBase {
+    fn key(&self) -> String {
+        "tenant".to_string()
+    }
+
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(1)
+    }
+}
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(prefix = "tenant", concurrency = Dynamic(1))]
+struct TenantQueue {
+    tenant: &'static str,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let storage = oxana::Storage::builder().build_from_env()?;
@@ -356,17 +375,57 @@ async fn seed_sample_jobs(storage: &oxana::Storage) -> Result<(), oxana::OxanaEr
         .await?;
     storage
         .enqueue(
-            DefaultQueue,
+            PriorityQueue,
             SyncCustomerProfileJob {
-                duration_ms: seconds(150),
+                duration_ms: seconds(100),
             },
         )
         .await?;
+    seed_dynamic_tenant_jobs(storage).await?;
     storage
         .enqueue(ProgressQueue, LongRunningProgressJob { duration_s: 150 })
         .await?;
 
-    println!("Seeded sample jobs across default and priority queues");
+    println!("Seeded sample jobs across default, priority, and tenant dynamic queues");
+
+    Ok(())
+}
+
+async fn seed_dynamic_tenant_jobs(storage: &oxana::Storage) -> Result<(), oxana::OxanaError> {
+    storage.set_queue_concurrency(TenantQueueBase, 2).await?;
+    storage
+        .set_queue_concurrency(TenantQueue { tenant: "acme" }, 3)
+        .await?;
+    storage
+        .set_queue_state(TenantQueue { tenant: "globex" }, oxana::QueueState::Paused)
+        .await?;
+
+    for duration_ms in [seconds(45), seconds(90), seconds(135), seconds(180)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "acme" },
+                SyncCustomerProfileJob { duration_ms },
+            )
+            .await?;
+    }
+
+    for duration_ms in [seconds(60), seconds(120), seconds(180)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "globex" },
+                GenerateInvoiceJob { duration_ms },
+            )
+            .await?;
+    }
+
+    for duration_ms in [seconds(30), seconds(75), seconds(150)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "initech" },
+                SendReceiptEmailJob { duration_ms },
+            )
+            .await?;
+    }
 
     Ok(())
 }

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -19,12 +19,13 @@ pub(crate) async fn dashboard(
     Extension(state): Extension<OxanaWebState>,
 ) -> Result<DashboardTemplate, OxanaWebError> {
     let stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
 
     Ok(DashboardTemplate {
         base_path: state.base_path,
         active_tab: "",
         stats,
-        concurrency_map: state.concurrency_map,
+        queue_configs,
     })
 }
 
@@ -32,12 +33,13 @@ pub(crate) async fn busy(
     Extension(state): Extension<OxanaWebState>,
 ) -> Result<BusyTemplate, OxanaWebError> {
     let stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
 
     Ok(BusyTemplate {
         base_path: state.base_path,
         active_tab: "/busy",
         stats,
-        concurrency_map: state.concurrency_map,
+        queue_configs,
     })
 }
 
@@ -46,6 +48,7 @@ pub(crate) async fn queues_list(
     Query(params): Query<QueuesParams>,
 ) -> Result<QueuesTemplate, OxanaWebError> {
     let mut stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
     let query = oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0));
     let queue_lengths = state.storage.queue_length_metrics(query).await?;
 
@@ -53,13 +56,13 @@ pub(crate) async fn queues_list(
     let dir = params.dir.as_deref().unwrap_or("asc");
     let desc = dir == "desc";
 
-    sort_queues(&mut stats.queues, &state.concurrency_map, sort, desc);
+    sort_queues(&mut stats.queues, &queue_configs, sort, desc);
 
     Ok(QueuesTemplate {
         base_path: state.base_path,
         active_tab: "/queues",
         stats,
-        concurrency_map: state.concurrency_map,
+        queue_configs,
         queue_lengths,
         sort: sort.to_string(),
         dir: dir.to_string(),
@@ -293,6 +296,7 @@ pub(crate) async fn queue_detail(
     let opts = list_opts(page);
 
     let stats = state.storage.stats().await?;
+    let queue_config = queue_runtime_config_for(&state, &queue_key).await?;
     let queue_stats = stats
         .queues
         .iter()
@@ -326,7 +330,7 @@ pub(crate) async fn queue_detail(
 
     let mut jobs = state
         .storage
-        .list_queue_jobs(RawQueue(queue_key.clone()), &opts)
+        .list_queue_jobs(RawQueue::fixed(queue_key.clone()), &opts)
         .await?;
 
     let has_next = jobs.len() > JOBS_PER_PAGE;
@@ -337,6 +341,7 @@ pub(crate) async fn queue_detail(
         active_tab: "/queues",
         queue_key,
         queue_stats,
+        queue_config,
         active_jobs,
         busy,
         jobs,
@@ -379,7 +384,7 @@ pub(crate) async fn wipe_queue(
 ) -> Result<Redirect, OxanaWebError> {
     state
         .storage
-        .wipe_queue(RawQueue(queue_key.clone()))
+        .wipe_queue(RawQueue::fixed(queue_key.clone()))
         .await?;
 
     Ok(Redirect::to(&format!(
@@ -387,6 +392,24 @@ pub(crate) async fn wipe_queue(
         state.base_path,
         urlencoding::encode(&queue_key)
     )))
+}
+
+pub(crate) async fn pause_queue(
+    Extension(state): Extension<OxanaWebState>,
+    Path(queue_key): Path<String>,
+) -> Result<Redirect, OxanaWebError> {
+    set_queue_state(&state, &queue_key, oxana::QueueState::Paused).await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
+}
+
+pub(crate) async fn unpause_queue(
+    Extension(state): Extension<OxanaWebState>,
+    Path(queue_key): Path<String>,
+) -> Result<Redirect, OxanaWebError> {
+    set_queue_state(&state, &queue_key, oxana::QueueState::Active).await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
 }
 
 pub(crate) async fn delete_job(
@@ -423,15 +446,61 @@ pub(crate) async fn enqueue_job(
 // --- Helpers ---
 
 #[derive(Serialize)]
-struct RawQueue(String);
+struct RawQueue {
+    key: String,
+    #[serde(skip_serializing)]
+    concurrency: oxana::QueueConcurrency,
+}
+
+impl RawQueue {
+    fn fixed(key: String) -> Self {
+        Self {
+            key,
+            concurrency: oxana::QueueConcurrency::Fixed(1),
+        }
+    }
+
+    fn from_catalog(catalog: &oxana::Catalog, key: &str) -> Self {
+        let base_key = base_queue_key(key);
+        let concurrency = catalog
+            .queues
+            .iter()
+            .find(|queue| queue.key == base_key)
+            .map_or(oxana::QueueConcurrency::Fixed(1), |queue| {
+                if queue.dynamic_concurrency {
+                    oxana::QueueConcurrency::Dynamic {
+                        default: queue.concurrency,
+                    }
+                } else {
+                    oxana::QueueConcurrency::Fixed(queue.concurrency)
+                }
+            });
+
+        Self {
+            key: key.to_string(),
+            concurrency,
+        }
+    }
+}
 
 impl oxana::Queue for RawQueue {
     fn key(&self) -> String {
-        self.0.clone()
+        self.key.clone()
     }
 
     fn to_config() -> oxana::QueueConfig {
         oxana::QueueConfig::as_static("")
+    }
+
+    fn config(&self) -> oxana::QueueConfig {
+        match self.concurrency {
+            oxana::QueueConcurrency::Fixed(concurrency) => {
+                oxana::QueueConfig::as_static(self.key.clone()).concurrency(concurrency)
+            }
+            oxana::QueueConcurrency::Dynamic { default } => {
+                oxana::QueueConfig::as_static(self.key.clone()).dynamic_concurrency(default)
+            }
+        }
     }
 }
 
@@ -516,9 +585,180 @@ fn list_opts(page: usize) -> oxana::QueueListOpts {
     }
 }
 
+async fn queue_config_map(
+    storage: &oxana::Storage,
+    catalog: &oxana::Catalog,
+    stats: &oxana::Stats,
+) -> Result<HashMap<String, oxana::QueueRuntimeConfig>, oxana::OxanaError> {
+    let mut keys = queue_config_keys(catalog, stats);
+    let stored_configs = storage.queue_configs(&keys).await?;
+    let mut configs = default_queue_config_map(catalog);
+
+    for (key, config) in stored_configs {
+        configs.insert(
+            key.clone(),
+            merge_queue_runtime_config(catalog, &key, config),
+        );
+    }
+
+    keys.sort();
+    keys.dedup();
+    for key in keys {
+        if configs.contains_key(&key) {
+            continue;
+        }
+
+        let fallback = default_queue_config_for_key(&configs, &key);
+        configs.insert(key, fallback);
+    }
+
+    Ok(configs)
+}
+
+fn queue_config_keys(catalog: &oxana::Catalog, stats: &oxana::Stats) -> Vec<String> {
+    let mut keys = catalog
+        .queues
+        .iter()
+        .map(|queue| queue.key.clone())
+        .collect::<Vec<_>>();
+
+    for queue in &stats.queues {
+        keys.push(queue.key.clone());
+        keys.extend(
+            queue
+                .queues
+                .iter()
+                .map(|dynamic_queue| format!("{}#{}", queue.key, dynamic_queue.suffix)),
+        );
+    }
+
+    keys
+}
+
+fn default_queue_config_map(
+    catalog: &oxana::Catalog,
+) -> HashMap<String, oxana::QueueRuntimeConfig> {
+    catalog
+        .queues
+        .iter()
+        .map(|queue| {
+            (
+                queue.key.clone(),
+                oxana::QueueRuntimeConfig::new(queue.concurrency),
+            )
+        })
+        .collect()
+}
+
+fn default_queue_config_for_key(
+    configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> oxana::QueueRuntimeConfig {
+    configs
+        .get(base_queue_key(queue_key))
+        .cloned()
+        .unwrap_or_else(|| oxana::QueueRuntimeConfig::new(1))
+}
+
+fn merge_queue_runtime_config(
+    catalog: &oxana::Catalog,
+    queue_key: &str,
+    mut config: oxana::QueueRuntimeConfig,
+) -> oxana::QueueRuntimeConfig {
+    if !queue_uses_dynamic_concurrency(catalog, queue_key) {
+        config.concurrency = None;
+    }
+
+    config.with_defaults(default_queue_runtime_config(catalog, queue_key))
+}
+
+fn queue_uses_dynamic_concurrency(catalog: &oxana::Catalog, queue_key: &str) -> bool {
+    let base_key = base_queue_key(queue_key);
+    catalog
+        .queues
+        .iter()
+        .find(|queue| queue.key == base_key)
+        .is_some_and(|queue| queue.dynamic_concurrency)
+}
+
+async fn queue_runtime_config_for(
+    state: &OxanaWebState,
+    queue_key: &str,
+) -> Result<oxana::QueueRuntimeConfig, oxana::OxanaError> {
+    if let Some(config) = queue_runtime_config_by_key(&state.storage, queue_key).await? {
+        return Ok(merge_queue_runtime_config(
+            &state.catalog,
+            queue_key,
+            config,
+        ));
+    }
+
+    let base_key = base_queue_key(queue_key);
+
+    if base_key != queue_key
+        && let Some(config) = queue_runtime_config_by_key(&state.storage, base_key).await?
+    {
+        return Ok(merge_queue_runtime_config(&state.catalog, base_key, config));
+    }
+
+    Ok(default_queue_runtime_config(&state.catalog, base_key))
+}
+
+fn default_queue_runtime_config(
+    catalog: &oxana::Catalog,
+    queue_key: &str,
+) -> oxana::QueueRuntimeConfig {
+    let base_key = base_queue_key(queue_key);
+
+    catalog
+        .queues
+        .iter()
+        .find(|queue| queue.key == base_key)
+        .map_or_else(
+            || oxana::QueueRuntimeConfig::new(1),
+            |queue| oxana::QueueRuntimeConfig::new(queue.concurrency),
+        )
+}
+
+async fn queue_runtime_config_by_key(
+    storage: &oxana::Storage,
+    queue_key: &str,
+) -> Result<Option<oxana::QueueRuntimeConfig>, oxana::OxanaError> {
+    let configs = storage.queue_configs(&[queue_key.to_string()]).await?;
+    Ok(configs.get(queue_key).cloned())
+}
+
+fn base_queue_key(queue_key: &str) -> &str {
+    queue_key
+        .split_once('#')
+        .map_or(queue_key, |(base, _)| base)
+}
+
+async fn set_queue_state(
+    state: &OxanaWebState,
+    queue_key: &str,
+    queue_state: oxana::QueueState,
+) -> Result<(), oxana::OxanaError> {
+    state
+        .storage
+        .set_queue_state(
+            RawQueue::from_catalog(&state.catalog, queue_key),
+            queue_state,
+        )
+        .await
+}
+
+fn queue_redirect(base_path: &str, queue_key: &str) -> Redirect {
+    Redirect::to(&format!(
+        "{}/queues/{}",
+        base_path,
+        urlencoding::encode(queue_key)
+    ))
+}
+
 fn sort_queues(
     queues: &mut [oxana::QueueStats],
-    concurrency_map: &HashMap<String, usize>,
+    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
     sort: &str,
     desc: bool,
 ) {
@@ -538,10 +778,18 @@ fn sort_queues(
                     .partial_cmp(&b.rate.processed_per_minute)
                     .unwrap_or(std::cmp::Ordering::Equal),
                 "concurrency" => {
-                    let ca = concurrency_map.get(&a.key).copied().unwrap_or(0);
-                    let cb = concurrency_map.get(&b.key).copied().unwrap_or(0);
+                    let ca = queue_configs
+                        .get(&a.key)
+                        .and_then(|config| config.concurrency)
+                        .unwrap_or(0);
+                    let cb = queue_configs
+                        .get(&b.key)
+                        .and_then(|config| config.concurrency)
+                        .unwrap_or(0);
                     ca.cmp(&cb)
                 }
+                "state" => queue_state_order(queue_configs, &a.key)
+                    .cmp(&queue_state_order(queue_configs, &b.key)),
                 "latency" => a
                     .latency_s
                     .partial_cmp(&b.latency_s)
@@ -551,6 +799,13 @@ fn sort_queues(
             if desc { cmp.reverse() } else { cmp }
         }
     });
+}
+
+fn queue_state_order(queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>, key: &str) -> u8 {
+    match queue_configs.get(key).map(|config| config.state) {
+        Some(oxana::QueueState::Paused) => 1,
+        _ => 0,
+    }
 }
 
 fn valid_metric_sort(sort: &str) -> bool {
@@ -830,7 +1085,7 @@ fn build_on_demand_queue_views(queues: &[oxana::QueueInfo]) -> Vec<OnDemandQueue
 #[cfg(test)]
 mod tests {
     use super::{
-        CronEnqueueJobForm, OnDemandEnqueueJobForm, build_on_demand_queue_views,
+        CronEnqueueJobForm, OnDemandEnqueueJobForm, RawQueue, build_on_demand_queue_views,
         cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
         sorted_worker_metrics,
     };
@@ -839,6 +1094,7 @@ mod tests {
     use axum::extract::Extension;
     use axum::http::{StatusCode, header};
     use axum::response::IntoResponse;
+    use oxana::Queue as _;
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
     use std::io::Error as WorkerError;
@@ -942,8 +1198,29 @@ mod tests {
             key: key.to_string(),
             dynamic,
             concurrency: 1,
+            dynamic_concurrency: false,
             throttle: None,
         }
+    }
+
+    #[test]
+    fn raw_queue_from_catalog_preserves_dynamic_concurrency_mode() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 7;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+
+        let queue = RawQueue::from_catalog(&catalog, "tenant#acme");
+        assert_eq!(queue.key(), "tenant#acme");
+        assert_eq!(
+            queue.config().concurrency,
+            oxana::QueueConcurrency::Dynamic { default: 7 }
+        );
     }
 
     #[test]
@@ -978,6 +1255,32 @@ mod tests {
             .map(|queue| queue.key.as_str())
             .collect::<Vec<_>>();
         assert_eq!(keys, vec!["never", "slow", "fast"]);
+    }
+
+    #[test]
+    fn state_sort_uses_runtime_queue_config() {
+        let mut queues = vec![
+            queue_with_eta("active", None),
+            queue_with_eta("paused", None),
+            queue_with_eta("missing", None),
+        ];
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert("active".to_string(), oxana::QueueRuntimeConfig::new(1));
+        queue_configs.insert(
+            "paused".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(1),
+                state: oxana::QueueState::Paused,
+            },
+        );
+
+        sort_queues(&mut queues, &queue_configs, "state", false);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["active", "missing", "paused"]);
     }
 
     fn worker_metrics(

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -591,28 +591,18 @@ async fn queue_config_map(
     stats: &oxana::Stats,
 ) -> Result<HashMap<String, oxana::QueueRuntimeConfig>, oxana::OxanaError> {
     let mut keys = queue_config_keys(catalog, stats);
-    let stored_configs = storage.queue_configs(&keys).await?;
-    let mut configs = default_queue_config_map(catalog);
-
-    for (key, config) in stored_configs {
-        configs.insert(
-            key.clone(),
-            merge_queue_runtime_config(catalog, &key, config),
-        );
-    }
-
     keys.sort();
     keys.dedup();
-    for key in keys {
-        if configs.contains_key(&key) {
-            continue;
-        }
 
-        let fallback = default_queue_config_for_key(&configs, &key);
-        configs.insert(key, fallback);
-    }
+    let stored_configs = storage.queue_configs(&keys).await?;
 
-    Ok(configs)
+    Ok(keys
+        .into_iter()
+        .map(|key| {
+            let config = queue_runtime_config_from_map(catalog, &stored_configs, &key);
+            (key, config)
+        })
+        .collect())
 }
 
 fn queue_config_keys(catalog: &oxana::Catalog, stats: &oxana::Stats) -> Vec<String> {
@@ -635,41 +625,41 @@ fn queue_config_keys(catalog: &oxana::Catalog, stats: &oxana::Stats) -> Vec<Stri
     keys
 }
 
-fn default_queue_config_map(
-    catalog: &oxana::Catalog,
-) -> HashMap<String, oxana::QueueRuntimeConfig> {
-    catalog
-        .queues
-        .iter()
-        .map(|queue| {
-            (
-                queue.key.clone(),
-                oxana::QueueRuntimeConfig::new(queue.concurrency),
-            )
-        })
-        .collect()
-}
-
-fn default_queue_config_for_key(
-    configs: &HashMap<String, oxana::QueueRuntimeConfig>,
-    queue_key: &str,
-) -> oxana::QueueRuntimeConfig {
-    configs
-        .get(base_queue_key(queue_key))
-        .cloned()
-        .unwrap_or_else(|| oxana::QueueRuntimeConfig::new(1))
-}
-
 fn merge_queue_runtime_config(
     catalog: &oxana::Catalog,
     queue_key: &str,
     mut config: oxana::QueueRuntimeConfig,
+    default_config: oxana::QueueRuntimeConfig,
 ) -> oxana::QueueRuntimeConfig {
     if !queue_uses_dynamic_concurrency(catalog, queue_key) {
         config.concurrency = None;
     }
 
-    config.with_defaults(default_queue_runtime_config(catalog, queue_key))
+    config.with_defaults(default_config)
+}
+
+fn queue_runtime_config_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> oxana::QueueRuntimeConfig {
+    let base_key = base_queue_key(queue_key);
+    let base_default = default_queue_runtime_config(catalog, base_key);
+    let base_config = stored_configs
+        .get(base_key)
+        .cloned()
+        .map(|config| merge_queue_runtime_config(catalog, base_key, config, base_default.clone()))
+        .unwrap_or(base_default);
+
+    if queue_key == base_key {
+        return base_config;
+    }
+
+    stored_configs
+        .get(queue_key)
+        .cloned()
+        .map(|config| merge_queue_runtime_config(catalog, queue_key, config, base_config.clone()))
+        .unwrap_or(base_config)
 }
 
 fn queue_uses_dynamic_concurrency(catalog: &oxana::Catalog, queue_key: &str) -> bool {
@@ -685,23 +675,19 @@ async fn queue_runtime_config_for(
     state: &OxanaWebState,
     queue_key: &str,
 ) -> Result<oxana::QueueRuntimeConfig, oxana::OxanaError> {
-    if let Some(config) = queue_runtime_config_by_key(&state.storage, queue_key).await? {
-        return Ok(merge_queue_runtime_config(
-            &state.catalog,
-            queue_key,
-            config,
-        ));
-    }
-
     let base_key = base_queue_key(queue_key);
+    let keys = if base_key == queue_key {
+        vec![base_key.to_string()]
+    } else {
+        vec![base_key.to_string(), queue_key.to_string()]
+    };
+    let stored_configs = state.storage.queue_configs(&keys).await?;
 
-    if base_key != queue_key
-        && let Some(config) = queue_runtime_config_by_key(&state.storage, base_key).await?
-    {
-        return Ok(merge_queue_runtime_config(&state.catalog, base_key, config));
-    }
-
-    Ok(default_queue_runtime_config(&state.catalog, base_key))
+    Ok(queue_runtime_config_from_map(
+        &state.catalog,
+        &stored_configs,
+        queue_key,
+    ))
 }
 
 fn default_queue_runtime_config(
@@ -718,14 +704,6 @@ fn default_queue_runtime_config(
             || oxana::QueueRuntimeConfig::new(1),
             |queue| oxana::QueueRuntimeConfig::new(queue.concurrency),
         )
-}
-
-async fn queue_runtime_config_by_key(
-    storage: &oxana::Storage,
-    queue_key: &str,
-) -> Result<Option<oxana::QueueRuntimeConfig>, oxana::OxanaError> {
-    let configs = storage.queue_configs(&[queue_key.to_string()]).await?;
-    Ok(configs.get(queue_key).cloned())
 }
 
 fn base_queue_key(queue_key: &str) -> &str {
@@ -1086,8 +1064,8 @@ fn build_on_demand_queue_views(queues: &[oxana::QueueInfo]) -> Vec<OnDemandQueue
 mod tests {
     use super::{
         CronEnqueueJobForm, OnDemandEnqueueJobForm, RawQueue, build_on_demand_queue_views,
-        cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form, sort_queues,
-        sorted_worker_metrics,
+        cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form,
+        queue_runtime_config_from_map, sort_queues, sorted_worker_metrics,
     };
     use crate::OxanaWebState;
     use axum::Form;
@@ -1221,6 +1199,65 @@ mod tests {
             queue.config().concurrency,
             oxana::QueueConcurrency::Dynamic { default: 7 }
         );
+    }
+
+    #[test]
+    fn dynamic_child_queue_inherits_base_runtime_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Paused,
+            },
+        )]);
+
+        let config = queue_runtime_config_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(config.concurrency, Some(5));
+        assert_eq!(config.state, oxana::QueueState::Paused);
+    }
+
+    #[test]
+    fn dynamic_child_queue_override_wins_over_base_runtime_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([
+            (
+                "tenant".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(5),
+                    state: oxana::QueueState::Paused,
+                },
+            ),
+            (
+                "tenant#acme".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(9),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+        ]);
+
+        let config = queue_runtime_config_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(config.concurrency, Some(9));
+        assert_eq!(config.state, oxana::QueueState::Active);
     }
 
     #[test]

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -425,12 +425,12 @@ pub(crate) async fn set_queue_concurrency(
         .into());
     }
 
-    let mut config = queue_runtime_config_for(&state, &queue_key).await?.config;
-    config.concurrency = Some(form.concurrency);
-
     state
         .storage
-        .set_queue_config(RawQueue::from_catalog(&state.catalog, &queue_key), &config)
+        .set_queue_concurrency(
+            RawQueue::from_catalog(&state.catalog, &queue_key),
+            form.concurrency,
+        )
         .await?;
 
     Ok(queue_redirect(&state.base_path, &queue_key))
@@ -473,35 +473,40 @@ pub(crate) async fn enqueue_job(
 struct RawQueue {
     key: String,
     #[serde(skip_serializing)]
+    base_key: String,
+    #[serde(skip_serializing)]
+    dynamic: bool,
+    #[serde(skip_serializing)]
     concurrency: oxana::QueueConcurrency,
 }
 
 impl RawQueue {
     fn fixed(key: String) -> Self {
         Self {
+            base_key: key.clone(),
             key,
+            dynamic: false,
             concurrency: oxana::QueueConcurrency::Fixed(1),
         }
     }
 
     fn from_catalog(catalog: &oxana::Catalog, key: &str) -> Self {
         let base_key = base_queue_key(key);
-        let concurrency = catalog
-            .queues
-            .iter()
-            .find(|queue| queue.key == base_key)
-            .map_or(oxana::QueueConcurrency::Fixed(1), |queue| {
-                if queue.dynamic_concurrency {
-                    oxana::QueueConcurrency::Dynamic {
-                        default: queue.concurrency,
-                    }
-                } else {
-                    oxana::QueueConcurrency::Fixed(queue.concurrency)
+        let queue_info = catalog.queues.iter().find(|queue| queue.key == base_key);
+        let concurrency = queue_info.map_or(oxana::QueueConcurrency::Fixed(1), |queue| {
+            if queue.dynamic_concurrency {
+                oxana::QueueConcurrency::Dynamic {
+                    default: queue.concurrency,
                 }
-            });
+            } else {
+                oxana::QueueConcurrency::Fixed(queue.concurrency)
+            }
+        });
 
         Self {
             key: key.to_string(),
+            base_key: base_key.to_string(),
+            dynamic: queue_info.is_some_and(|queue| queue.dynamic),
             concurrency,
         }
     }
@@ -517,13 +522,15 @@ impl oxana::Queue for RawQueue {
     }
 
     fn config(&self) -> oxana::QueueConfig {
+        let config = if self.dynamic {
+            oxana::QueueConfig::as_dynamic(self.base_key.clone())
+        } else {
+            oxana::QueueConfig::as_static(self.key.clone())
+        };
+
         match self.concurrency {
-            oxana::QueueConcurrency::Fixed(concurrency) => {
-                oxana::QueueConfig::as_static(self.key.clone()).concurrency(concurrency)
-            }
-            oxana::QueueConcurrency::Dynamic { default } => {
-                oxana::QueueConfig::as_static(self.key.clone()).dynamic_concurrency(default)
-            }
+            oxana::QueueConcurrency::Fixed(concurrency) => config.concurrency(concurrency),
+            oxana::QueueConcurrency::Dynamic { default } => config.dynamic_concurrency(default),
         }
     }
 }
@@ -779,12 +786,7 @@ async fn queue_runtime_config_for(
     state: &OxanaWebState,
     queue_key: &str,
 ) -> Result<QueueRuntimeConfigView, oxana::OxanaError> {
-    let base_key = base_queue_key(queue_key);
-    let keys = if base_key == queue_key {
-        vec![base_key.to_string()]
-    } else {
-        vec![base_key.to_string(), queue_key.to_string()]
-    };
+    let keys = queue_runtime_config_keys(queue_key);
     let stored_configs = state.storage.queue_configs(&keys).await?;
 
     Ok(queue_runtime_config_view_from_map(
@@ -792,6 +794,15 @@ async fn queue_runtime_config_for(
         &stored_configs,
         queue_key,
     ))
+}
+
+fn queue_runtime_config_keys(queue_key: &str) -> Vec<String> {
+    let base_key = base_queue_key(queue_key);
+    if base_key == queue_key {
+        vec![base_key.to_string()]
+    } else {
+        vec![base_key.to_string(), queue_key.to_string()]
+    }
 }
 
 fn default_queue_runtime_config(
@@ -1312,6 +1323,10 @@ mod tests {
             queue.config().concurrency,
             oxana::QueueConcurrency::Dynamic { default: 7 }
         );
+        assert!(matches!(
+            queue.config().kind,
+            oxana::QueueKind::Dynamic { ref prefix, .. } if prefix == "tenant"
+        ));
     }
 
     #[test]

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -12,7 +12,8 @@ use crate::error::OxanaWebError;
 use crate::templates::{
     BusyTemplate, CronRow, CronTemplate, CronWorkerView, DashboardTemplate, GlobalJobsTemplate,
     JobDetailTemplate, JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView,
-    OnDemandQueueView, OnDemandRow, OnDemandTemplate, QueueDetailTemplate, QueuesTemplate,
+    OnDemandQueueView, OnDemandRow, OnDemandTemplate, QueueConcurrencyStatus, QueueDetailTemplate,
+    QueueRuntimeConfigView, QueuesTemplate,
 };
 
 pub(crate) async fn dashboard(
@@ -412,6 +413,29 @@ pub(crate) async fn unpause_queue(
     Ok(queue_redirect(&state.base_path, &queue_key))
 }
 
+pub(crate) async fn set_queue_concurrency(
+    Extension(state): Extension<OxanaWebState>,
+    Path(queue_key): Path<String>,
+    Form(form): Form<QueueConcurrencyForm>,
+) -> Result<Redirect, OxanaWebError> {
+    if form.concurrency == 0 {
+        return Err(oxana::OxanaError::ConfigError(
+            "Queue concurrency must be at least 1".to_string(),
+        )
+        .into());
+    }
+
+    let mut config = queue_runtime_config_for(&state, &queue_key).await?.config;
+    config.concurrency = Some(form.concurrency);
+
+    state
+        .storage
+        .set_queue_config(RawQueue::from_catalog(&state.catalog, &queue_key), &config)
+        .await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
+}
+
 pub(crate) async fn delete_job(
     Extension(state): Extension<OxanaWebState>,
     Path((queue_key, job_id)): Path<(String, String)>,
@@ -565,6 +589,11 @@ pub(crate) struct OnDemandEnqueueJobForm {
 }
 
 #[derive(Deserialize)]
+pub(crate) struct QueueConcurrencyForm {
+    concurrency: usize,
+}
+
+#[derive(Deserialize)]
 pub(crate) struct OnDemandParams {
     #[serde(default)]
     scheduled: Option<String>,
@@ -589,7 +618,7 @@ async fn queue_config_map(
     storage: &oxana::Storage,
     catalog: &oxana::Catalog,
     stats: &oxana::Stats,
-) -> Result<HashMap<String, oxana::QueueRuntimeConfig>, oxana::OxanaError> {
+) -> Result<HashMap<String, QueueRuntimeConfigView>, oxana::OxanaError> {
     let mut keys = queue_config_keys(catalog, stats);
     keys.sort();
     keys.dedup();
@@ -599,7 +628,7 @@ async fn queue_config_map(
     Ok(keys
         .into_iter()
         .map(|key| {
-            let config = queue_runtime_config_from_map(catalog, &stored_configs, &key);
+            let config = queue_runtime_config_view_from_map(catalog, &stored_configs, &key);
             (key, config)
         })
         .collect())
@@ -662,6 +691,81 @@ fn queue_runtime_config_from_map(
         .unwrap_or(base_config)
 }
 
+fn queue_runtime_config_view_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> QueueRuntimeConfigView {
+    let config = queue_runtime_config_from_map(catalog, stored_configs, queue_key);
+    let concurrency_status = queue_concurrency_status_from_map(catalog, stored_configs, queue_key);
+
+    QueueRuntimeConfigView {
+        config,
+        concurrency_status,
+    }
+}
+
+fn queue_concurrency_status_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> QueueConcurrencyStatus {
+    if !queue_uses_dynamic_concurrency(catalog, queue_key) {
+        return QueueConcurrencyStatus::Fixed;
+    }
+
+    let base_key = base_queue_key(queue_key);
+    let configured_default = default_queue_runtime_config(catalog, base_key)
+        .concurrency
+        .unwrap_or(1);
+    let direct_concurrency = stored_configs
+        .get(queue_key)
+        .and_then(|config| config.concurrency);
+
+    if queue_key == base_key {
+        return match direct_concurrency {
+            Some(concurrency) if concurrency != configured_default => {
+                QueueConcurrencyStatus::Override {
+                    default: configured_default,
+                }
+            }
+            _ => QueueConcurrencyStatus::Default {
+                default: configured_default,
+            },
+        };
+    }
+
+    let inherited_default = queue_runtime_config_from_map(catalog, stored_configs, base_key)
+        .concurrency
+        .unwrap_or(configured_default);
+
+    if let Some(concurrency) = direct_concurrency {
+        return if concurrency != inherited_default {
+            QueueConcurrencyStatus::Override {
+                default: inherited_default,
+            }
+        } else {
+            QueueConcurrencyStatus::Default {
+                default: inherited_default,
+            }
+        };
+    }
+
+    match stored_configs
+        .get(base_key)
+        .and_then(|config| config.concurrency)
+    {
+        Some(concurrency) if concurrency != configured_default => {
+            QueueConcurrencyStatus::InheritedOverride {
+                default: configured_default,
+            }
+        }
+        _ => QueueConcurrencyStatus::Default {
+            default: configured_default,
+        },
+    }
+}
+
 fn queue_uses_dynamic_concurrency(catalog: &oxana::Catalog, queue_key: &str) -> bool {
     let base_key = base_queue_key(queue_key);
     catalog
@@ -674,7 +778,7 @@ fn queue_uses_dynamic_concurrency(catalog: &oxana::Catalog, queue_key: &str) -> 
 async fn queue_runtime_config_for(
     state: &OxanaWebState,
     queue_key: &str,
-) -> Result<oxana::QueueRuntimeConfig, oxana::OxanaError> {
+) -> Result<QueueRuntimeConfigView, oxana::OxanaError> {
     let base_key = base_queue_key(queue_key);
     let keys = if base_key == queue_key {
         vec![base_key.to_string()]
@@ -683,7 +787,7 @@ async fn queue_runtime_config_for(
     };
     let stored_configs = state.storage.queue_configs(&keys).await?;
 
-    Ok(queue_runtime_config_from_map(
+    Ok(queue_runtime_config_view_from_map(
         &state.catalog,
         &stored_configs,
         queue_key,
@@ -736,7 +840,7 @@ fn queue_redirect(base_path: &str, queue_key: &str) -> Redirect {
 
 fn sort_queues(
     queues: &mut [oxana::QueueStats],
-    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
     sort: &str,
     desc: bool,
 ) {
@@ -758,11 +862,11 @@ fn sort_queues(
                 "concurrency" => {
                     let ca = queue_configs
                         .get(&a.key)
-                        .and_then(|config| config.concurrency)
+                        .and_then(|config| config.config.concurrency)
                         .unwrap_or(0);
                     let cb = queue_configs
                         .get(&b.key)
-                        .and_then(|config| config.concurrency)
+                        .and_then(|config| config.config.concurrency)
                         .unwrap_or(0);
                     ca.cmp(&cb)
                 }
@@ -779,8 +883,8 @@ fn sort_queues(
     });
 }
 
-fn queue_state_order(queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>, key: &str) -> u8 {
-    match queue_configs.get(key).map(|config| config.state) {
+fn queue_state_order(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> u8 {
+    match queue_configs.get(key).map(|config| config.config.state) {
         Some(oxana::QueueState::Paused) => 1,
         _ => 0,
     }
@@ -1065,9 +1169,11 @@ mod tests {
     use super::{
         CronEnqueueJobForm, OnDemandEnqueueJobForm, RawQueue, build_on_demand_queue_views,
         cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form,
-        queue_runtime_config_from_map, sort_queues, sorted_worker_metrics,
+        queue_concurrency_status_from_map, queue_runtime_config_from_map,
+        queue_runtime_config_view_from_map, sort_queues, sorted_worker_metrics,
     };
     use crate::OxanaWebState;
+    use crate::templates::{QueueConcurrencyStatus, QueueRuntimeConfigView};
     use axum::Form;
     use axum::extract::Extension;
     use axum::http::{StatusCode, header};
@@ -1181,6 +1287,13 @@ mod tests {
         }
     }
 
+    fn queue_config_view(config: oxana::QueueRuntimeConfig) -> QueueRuntimeConfigView {
+        QueueRuntimeConfigView {
+            config,
+            concurrency_status: QueueConcurrencyStatus::Fixed,
+        }
+    }
+
     #[test]
     fn raw_queue_from_catalog_preserves_dynamic_concurrency_mode() {
         let mut dynamic_queue = queue_info("tenant", true);
@@ -1261,6 +1374,94 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_base_queue_reports_runtime_concurrency_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Active,
+            },
+        )]);
+
+        let view = queue_runtime_config_view_from_map(&catalog, &stored_configs, "tenant");
+
+        assert_eq!(view.config.concurrency, Some(5));
+        assert_eq!(
+            view.concurrency_status,
+            QueueConcurrencyStatus::Override { default: 3 }
+        );
+    }
+
+    #[test]
+    fn dynamic_child_queue_reports_inherited_base_concurrency_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Active,
+            },
+        )]);
+
+        let status = queue_concurrency_status_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(
+            status,
+            QueueConcurrencyStatus::InheritedOverride { default: 3 }
+        );
+    }
+
+    #[test]
+    fn dynamic_child_queue_reports_direct_override_defaulting_to_base_concurrency() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([
+            (
+                "tenant".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(5),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+            (
+                "tenant#acme".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(9),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+        ]);
+
+        let status = queue_concurrency_status_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(status, QueueConcurrencyStatus::Override { default: 5 });
+    }
+
+    #[test]
     fn eta_sort_ascending_places_unknown_last() {
         let mut queues = vec![
             queue_with_eta("never", None),
@@ -1302,13 +1503,16 @@ mod tests {
             queue_with_eta("missing", None),
         ];
         let mut queue_configs = HashMap::new();
-        queue_configs.insert("active".to_string(), oxana::QueueRuntimeConfig::new(1));
+        queue_configs.insert(
+            "active".to_string(),
+            queue_config_view(oxana::QueueRuntimeConfig::new(1)),
+        );
         queue_configs.insert(
             "paused".to_string(),
-            oxana::QueueRuntimeConfig {
+            queue_config_view(oxana::QueueRuntimeConfig {
                 concurrency: Some(1),
                 state: oxana::QueueState::Paused,
-            },
+            }),
         );
 
         sort_queues(&mut queues, &queue_configs, "state", false);

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -758,18 +758,8 @@ fn queue_concurrency_status_from_map(
         };
     }
 
-    match stored_configs
-        .get(base_key)
-        .and_then(|config| config.concurrency)
-    {
-        Some(concurrency) if concurrency != configured_default => {
-            QueueConcurrencyStatus::InheritedOverride {
-                default: configured_default,
-            }
-        }
-        _ => QueueConcurrencyStatus::Default {
-            default: configured_default,
-        },
+    QueueConcurrencyStatus::Default {
+        default: inherited_default,
     }
 }
 
@@ -1417,7 +1407,7 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_child_queue_reports_inherited_base_concurrency_override() {
+    fn dynamic_child_queue_treats_inherited_base_concurrency_as_default() {
         let mut dynamic_queue = queue_info("tenant", true);
         dynamic_queue.concurrency = 3;
         dynamic_queue.dynamic_concurrency = true;
@@ -1437,10 +1427,7 @@ mod tests {
 
         let status = queue_concurrency_status_from_map(&catalog, &stored_configs, "tenant#acme");
 
-        assert_eq!(
-            status,
-            QueueConcurrencyStatus::InheritedOverride { default: 3 }
-        );
+        assert_eq!(status, QueueConcurrencyStatus::Default { default: 5 });
     }
 
     #[test]

--- a/oxana-web/src/lib.rs
+++ b/oxana-web/src/lib.rs
@@ -3,8 +3,6 @@ mod filters;
 mod handlers;
 mod templates;
 
-use std::collections::HashMap;
-
 use axum::{
     Router,
     extract::Extension,
@@ -18,21 +16,14 @@ pub struct OxanaWebState {
     pub storage: oxana::Storage,
     pub catalog: oxana::Catalog,
     pub base_path: String,
-    pub concurrency_map: HashMap<String, usize>,
 }
 
 impl OxanaWebState {
     pub fn new(storage: oxana::Storage, catalog: oxana::Catalog, base_path: String) -> Self {
-        let concurrency_map = catalog
-            .queues
-            .iter()
-            .map(|q| (q.key.clone(), q.concurrency))
-            .collect();
         Self {
             storage,
             catalog,
             base_path,
-            concurrency_map,
         }
     }
 }
@@ -55,6 +46,8 @@ pub fn router(state: OxanaWebState) -> Router {
         .route("/jobs/{job_id}", get(handlers::job_detail))
         .route("/queues/{queue_key}", get(handlers::queue_detail))
         .route("/enqueue", post(handlers::enqueue_job))
+        .route("/queues/{queue_key}/pause", post(handlers::pause_queue))
+        .route("/queues/{queue_key}/unpause", post(handlers::unpause_queue))
         .route("/queues/{queue_key}/wipe", post(handlers::wipe_queue))
         .route(
             "/queues/{queue_key}/jobs/{job_id}/delete",

--- a/oxana-web/src/lib.rs
+++ b/oxana-web/src/lib.rs
@@ -48,6 +48,10 @@ pub fn router(state: OxanaWebState) -> Router {
         .route("/enqueue", post(handlers::enqueue_job))
         .route("/queues/{queue_key}/pause", post(handlers::pause_queue))
         .route("/queues/{queue_key}/unpause", post(handlers::unpause_queue))
+        .route(
+            "/queues/{queue_key}/concurrency",
+            post(handlers::set_queue_concurrency),
+        )
         .route("/queues/{queue_key}/wipe", post(handlers::wipe_queue))
         .route(
             "/queues/{queue_key}/jobs/{job_id}/delete",

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -22,10 +22,31 @@ fn busy_for_process(stats: &oxana::Stats, process: &oxana::Process) -> usize {
         .count()
 }
 
-fn concurrency_for(concurrency_map: &HashMap<String, usize>, key: &str) -> String {
-    concurrency_map
+fn concurrency_for(
+    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    key: &str,
+) -> String {
+    queue_configs
         .get(key)
-        .map_or_else(|| "—".to_string(), |c| c.to_string())
+        .and_then(|config| config.concurrency)
+        .map_or_else(|| "—".to_string(), |concurrency| concurrency.to_string())
+}
+
+fn state_for(queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>, key: &str) -> String {
+    queue_configs.get(key).map_or_else(
+        || "Active".to_string(),
+        |config| config.state.label().to_string(),
+    )
+}
+
+fn state_class_for(
+    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    key: &str,
+) -> &'static str {
+    match queue_configs.get(key).map(|config| config.state) {
+        Some(oxana::QueueState::Paused) => "text-yellow-300",
+        _ => "text-green-300",
+    }
 }
 
 #[derive(Template, WebTemplate)]
@@ -34,12 +55,24 @@ pub(crate) struct DashboardTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub concurrency_map: HashMap<String, usize>,
+    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
 }
 
 impl DashboardTemplate {
     pub fn concurrency_for(&self, key: &str) -> String {
-        concurrency_for(&self.concurrency_map, key)
+        concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn state_for(&self, key: &str) -> String {
+        state_for(&self.queue_configs, key)
+    }
+
+    pub fn state_class_for(&self, key: &str) -> &'static str {
+        state_class_for(&self.queue_configs, key)
+    }
+
+    pub fn dynamic_queue_key(&self, key: &str, suffix: &str) -> String {
+        format!("{key}#{suffix}")
     }
 
     pub fn busy_for(&self, key: &str) -> usize {
@@ -57,12 +90,24 @@ pub(crate) struct BusyTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub concurrency_map: HashMap<String, usize>,
+    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
 }
 
 impl BusyTemplate {
     pub fn concurrency_for(&self, key: &str) -> String {
-        concurrency_for(&self.concurrency_map, key)
+        concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn state_for(&self, key: &str) -> String {
+        state_for(&self.queue_configs, key)
+    }
+
+    pub fn state_class_for(&self, key: &str) -> &'static str {
+        state_class_for(&self.queue_configs, key)
+    }
+
+    pub fn dynamic_queue_key(&self, key: &str, suffix: &str) -> String {
+        format!("{key}#{suffix}")
     }
 
     pub fn busy_for(&self, key: &str) -> usize {
@@ -80,7 +125,7 @@ pub(crate) struct QueuesTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub concurrency_map: HashMap<String, usize>,
+    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
     pub queue_lengths: oxana::QueueLengthMetricsSnapshot,
     pub sort: String,
     pub dir: String,
@@ -118,7 +163,19 @@ impl QueuesTemplate {
     }
 
     pub fn concurrency_for(&self, key: &str) -> String {
-        concurrency_for(&self.concurrency_map, key)
+        concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn state_for(&self, key: &str) -> String {
+        state_for(&self.queue_configs, key)
+    }
+
+    pub fn state_class_for(&self, key: &str) -> &'static str {
+        state_class_for(&self.queue_configs, key)
+    }
+
+    pub fn dynamic_queue_key(&self, key: &str, suffix: &str) -> String {
+        format!("{key}#{suffix}")
     }
 
     pub fn queue_length_chart_data_json(&self) -> String {
@@ -175,7 +232,7 @@ mod tests {
                 processing: Vec::new(),
                 queues: Vec::new(),
             },
-            concurrency_map: HashMap::new(),
+            queue_configs: HashMap::new(),
             queue_lengths,
             sort: "key".to_string(),
             dir: "asc".to_string(),
@@ -602,6 +659,7 @@ pub(crate) struct QueueDetailTemplate {
     pub active_tab: &'static str,
     pub queue_key: String,
     pub queue_stats: Option<oxana::QueueStats>,
+    pub queue_config: oxana::QueueRuntimeConfig,
     pub active_jobs: Vec<oxana::StatsProcessing>,
     pub busy: usize,
     pub jobs: Vec<oxana::JobEnvelope>,
@@ -611,6 +669,27 @@ pub(crate) struct QueueDetailTemplate {
 }
 
 impl QueueDetailTemplate {
+    pub fn state_label(&self) -> &'static str {
+        self.queue_config.state.label()
+    }
+
+    pub fn state_class(&self) -> &'static str {
+        match self.queue_config.state {
+            oxana::QueueState::Active => "text-green-300 border-green-800 bg-green-900/30",
+            oxana::QueueState::Paused => "text-yellow-300 border-yellow-800 bg-yellow-900/30",
+        }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        matches!(self.queue_config.state, oxana::QueueState::Paused)
+    }
+
+    pub fn concurrency_label(&self) -> String {
+        self.queue_config
+            .concurrency
+            .map_or_else(|| "—".to_string(), |concurrency| concurrency.to_string())
+    }
+
     pub fn range_start(&self) -> usize {
         (self.page - 1) * JOBS_PER_PAGE + 1
     }

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -10,7 +10,6 @@ pub(crate) enum QueueConcurrencyStatus {
     Fixed,
     Default { default: usize },
     Override { default: usize },
-    InheritedOverride { default: usize },
 }
 
 #[derive(Debug, Clone)]
@@ -30,8 +29,7 @@ impl QueueRuntimeConfigView {
         match self.concurrency_status {
             QueueConcurrencyStatus::Fixed => self.concurrency_label(),
             QueueConcurrencyStatus::Default { default }
-            | QueueConcurrencyStatus::Override { default }
-            | QueueConcurrencyStatus::InheritedOverride { default } => default.to_string(),
+            | QueueConcurrencyStatus::Override { default } => default.to_string(),
         }
     }
 
@@ -43,7 +41,6 @@ impl QueueRuntimeConfigView {
         matches!(
             self.concurrency_status,
             QueueConcurrencyStatus::Override { .. }
-                | QueueConcurrencyStatus::InheritedOverride { .. }
         )
     }
 }

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -5,6 +5,49 @@ use std::collections::HashMap;
 use crate::JOBS_PER_PAGE;
 use crate::filters;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum QueueConcurrencyStatus {
+    Fixed,
+    Default { default: usize },
+    Override { default: usize },
+    InheritedOverride { default: usize },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueueRuntimeConfigView {
+    pub config: oxana::QueueRuntimeConfig,
+    pub concurrency_status: QueueConcurrencyStatus,
+}
+
+impl QueueRuntimeConfigView {
+    fn concurrency_label(&self) -> String {
+        self.config
+            .concurrency
+            .map_or_else(|| "-".to_string(), |concurrency| concurrency.to_string())
+    }
+
+    fn concurrency_default_label(&self) -> String {
+        match self.concurrency_status {
+            QueueConcurrencyStatus::Fixed => self.concurrency_label(),
+            QueueConcurrencyStatus::Default { default }
+            | QueueConcurrencyStatus::Override { default }
+            | QueueConcurrencyStatus::InheritedOverride { default } => default.to_string(),
+        }
+    }
+
+    fn can_change_concurrency(&self) -> bool {
+        !matches!(self.concurrency_status, QueueConcurrencyStatus::Fixed)
+    }
+
+    fn has_concurrency_override(&self) -> bool {
+        matches!(
+            self.concurrency_status,
+            QueueConcurrencyStatus::Override { .. }
+                | QueueConcurrencyStatus::InheritedOverride { .. }
+        )
+    }
+}
+
 fn busy_for(stats: &oxana::Stats, key: &str) -> usize {
     stats
         .processing
@@ -22,31 +65,55 @@ fn busy_for_process(stats: &oxana::Stats, process: &oxana::Process) -> usize {
         .count()
 }
 
-fn concurrency_for(
-    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+fn concurrency_for(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> String {
+    queue_configs.get(key).map_or_else(
+        || "-".to_string(),
+        QueueRuntimeConfigView::concurrency_label,
+    )
+}
+
+fn default_concurrency_for(
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
     key: &str,
 ) -> String {
     queue_configs
         .get(key)
-        .and_then(|config| config.concurrency)
-        .map_or_else(|| "—".to_string(), |concurrency| concurrency.to_string())
+        .map_or_else(String::new, |config| config.concurrency_default_label())
 }
 
-fn state_for(queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>, key: &str) -> String {
+fn has_concurrency_override_for(
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    key: &str,
+) -> bool {
+    queue_configs
+        .get(key)
+        .is_some_and(QueueRuntimeConfigView::has_concurrency_override)
+}
+
+fn state_for(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> String {
     queue_configs.get(key).map_or_else(
         || "Active".to_string(),
-        |config| config.state.label().to_string(),
+        |config| config.config.state.label().to_string(),
     )
 }
 
 fn state_class_for(
-    queue_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
     key: &str,
 ) -> &'static str {
-    match queue_configs.get(key).map(|config| config.state) {
+    match queue_configs.get(key).map(|config| config.config.state) {
         Some(oxana::QueueState::Paused) => "text-yellow-300",
         _ => "text-green-300",
     }
+}
+
+fn queue_action_path(base_path: &str, key: &str, action: &str) -> String {
+    format!(
+        "{}/queues/{}/{}",
+        base_path,
+        urlencoding::encode(key),
+        action
+    )
 }
 
 #[derive(Template, WebTemplate)]
@@ -55,12 +122,20 @@ pub(crate) struct DashboardTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
 }
 
 impl DashboardTemplate {
     pub fn concurrency_for(&self, key: &str) -> String {
         concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn default_concurrency_for(&self, key: &str) -> String {
+        default_concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn has_concurrency_override_for(&self, key: &str) -> bool {
+        has_concurrency_override_for(&self.queue_configs, key)
     }
 
     pub fn state_for(&self, key: &str) -> String {
@@ -90,12 +165,20 @@ pub(crate) struct BusyTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
 }
 
 impl BusyTemplate {
     pub fn concurrency_for(&self, key: &str) -> String {
         concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn default_concurrency_for(&self, key: &str) -> String {
+        default_concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn has_concurrency_override_for(&self, key: &str) -> bool {
+        has_concurrency_override_for(&self.queue_configs, key)
     }
 
     pub fn state_for(&self, key: &str) -> String {
@@ -125,7 +208,7 @@ pub(crate) struct QueuesTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub stats: oxana::Stats,
-    pub queue_configs: HashMap<String, oxana::QueueRuntimeConfig>,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
     pub queue_lengths: oxana::QueueLengthMetricsSnapshot,
     pub sort: String,
     pub dir: String,
@@ -164,6 +247,14 @@ impl QueuesTemplate {
 
     pub fn concurrency_for(&self, key: &str) -> String {
         concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn default_concurrency_for(&self, key: &str) -> String {
+        default_concurrency_for(&self.queue_configs, key)
+    }
+
+    pub fn has_concurrency_override_for(&self, key: &str) -> bool {
+        has_concurrency_override_for(&self.queue_configs, key)
     }
 
     pub fn state_for(&self, key: &str) -> String {
@@ -210,7 +301,8 @@ impl QueuesTemplate {
 
 #[cfg(test)]
 mod tests {
-    use super::QueuesTemplate;
+    use super::{QueueConcurrencyStatus, QueueRuntimeConfigView, QueuesTemplate};
+    use askama::Template;
     use std::collections::HashMap;
 
     fn queues_template(queue_lengths: oxana::QueueLengthMetricsSnapshot) -> QueuesTemplate {
@@ -236,6 +328,20 @@ mod tests {
             queue_lengths,
             sort: "key".to_string(),
             dir: "asc".to_string(),
+        }
+    }
+
+    fn queue_stats(key: &str) -> oxana::QueueStats {
+        oxana::QueueStats {
+            key: key.to_string(),
+            enqueued: 0,
+            processed: 0,
+            succeeded: 0,
+            panicked: 0,
+            failed: 0,
+            latency_s: 0.0,
+            rate: oxana::QueueRateStats::default(),
+            queues: Vec::new(),
         }
     }
 
@@ -297,6 +403,32 @@ mod tests {
             payload["series"],
             serde_json::json!([{ "label": "default", "data": [2, 5] }])
         );
+    }
+
+    #[test]
+    fn queues_template_renders_compact_concurrency_override_without_change_form() {
+        let mut template = queues_template(oxana::QueueLengthMetricsSnapshot {
+            starts_at: 0,
+            ends_at: 0,
+            minutes: 60,
+            queues: Vec::new(),
+        });
+        template.stats.queues = vec![queue_stats("emails")];
+        template.queue_configs.insert(
+            "emails".to_string(),
+            QueueRuntimeConfigView {
+                config: oxana::QueueRuntimeConfig::new(5),
+                concurrency_status: QueueConcurrencyStatus::Override { default: 2 },
+            },
+        );
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains(
+            "5 <span class=\"text-gray-500\">(<span class=\"line-through\">2</span>)</span>"
+        ));
+        assert!(!rendered.contains("action=\"/admin/queues/emails/concurrency\""));
+        assert!(!rendered.contains("data-default-concurrency=\"2\""));
     }
 }
 
@@ -659,7 +791,7 @@ pub(crate) struct QueueDetailTemplate {
     pub active_tab: &'static str,
     pub queue_key: String,
     pub queue_stats: Option<oxana::QueueStats>,
-    pub queue_config: oxana::QueueRuntimeConfig,
+    pub queue_config: QueueRuntimeConfigView,
     pub active_jobs: Vec<oxana::StatsProcessing>,
     pub busy: usize,
     pub jobs: Vec<oxana::JobEnvelope>,
@@ -670,24 +802,38 @@ pub(crate) struct QueueDetailTemplate {
 
 impl QueueDetailTemplate {
     pub fn state_label(&self) -> &'static str {
-        self.queue_config.state.label()
+        self.queue_config.config.state.label()
     }
 
     pub fn state_class(&self) -> &'static str {
-        match self.queue_config.state {
+        match self.queue_config.config.state {
             oxana::QueueState::Active => "text-green-300 border-green-800 bg-green-900/30",
             oxana::QueueState::Paused => "text-yellow-300 border-yellow-800 bg-yellow-900/30",
         }
     }
 
     pub fn is_paused(&self) -> bool {
-        matches!(self.queue_config.state, oxana::QueueState::Paused)
+        matches!(self.queue_config.config.state, oxana::QueueState::Paused)
     }
 
     pub fn concurrency_label(&self) -> String {
-        self.queue_config
-            .concurrency
-            .map_or_else(|| "—".to_string(), |concurrency| concurrency.to_string())
+        self.queue_config.concurrency_label()
+    }
+
+    pub fn concurrency_default_label(&self) -> String {
+        self.queue_config.concurrency_default_label()
+    }
+
+    pub fn can_change_concurrency(&self) -> bool {
+        self.queue_config.can_change_concurrency()
+    }
+
+    pub fn has_concurrency_override(&self) -> bool {
+        self.queue_config.has_concurrency_override()
+    }
+
+    pub fn queue_action_path(&self, action: &str) -> String {
+        queue_action_path(&self.base_path, &self.queue_key, action)
     }
 
     pub fn range_start(&self) -> usize {

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -62,6 +62,7 @@
                         <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
                             <th class="pb-3 pr-4">Queue</th>
                             <th class="pb-3 pr-4 text-right">Concurrency</th>
+                            <th class="pb-3 pr-4 text-right">State</th>
                             <th class="pb-3 pr-4 text-right">Busy</th>
                             <th class="pb-3 pr-4 text-right">Enqueued</th>
                             <th class="pb-3 text-right">Latency</th>
@@ -74,15 +75,18 @@
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
                             <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-purple-400">{{ busy }}</td>
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                             <td class="py-3 text-right text-purple-400">{{ queue.latency_s|format_latency }}</td>
                         </tr>
                         {% for dq in &queue.queues %}
                         {% if dq.enqueued > 0 %}
+                        {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                             <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                             <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
                             <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>
                             <td class="py-2 text-right text-xs text-purple-400">{{ dq.latency_s|format_latency }}</td>

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -74,7 +74,7 @@
                         {% if queue.enqueued > 0 || busy > 0 %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
-                            <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-3 pr-4 text-right text-gray-300">{{ self.concurrency_for(&queue.key) }}{% if self.has_concurrency_override_for(&queue.key) %} <span class="text-gray-500">(<span class="line-through">{{ self.default_concurrency_for(&queue.key) }}</span>)</span>{% endif %}</td>
                             <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-purple-400">{{ busy }}</td>
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
@@ -85,7 +85,7 @@
                         {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                             <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-400">{{ self.concurrency_for(&dq_key) }}{% if self.has_concurrency_override_for(&dq_key) %} <span class="text-gray-600">(<span class="line-through">{{ self.default_concurrency_for(&dq_key) }}</span>)</span>{% endif %}</td>
                             <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                             <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
                             <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>

--- a/oxana-web/templates/dashboard.html
+++ b/oxana-web/templates/dashboard.html
@@ -64,6 +64,7 @@
                         <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
                             <th class="pb-3 pr-4">Queue</th>
                             <th class="pb-3 pr-4 text-right">Concurrency</th>
+                            <th class="pb-3 pr-4 text-right">State</th>
                             <th class="pb-3 pr-4 text-right">Busy</th>
                             <th class="pb-3 pr-4 text-right">Enqueued</th>
                             <th class="pb-3 text-right">Latency</th>
@@ -74,15 +75,18 @@
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
                             <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-purple-400">{{ self.busy_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                             <td class="py-3 text-right text-purple-400">{{ queue.latency_s|format_latency }}</td>
                         </tr>
                         {% for dq in &queue.queues %}
                         {% if dq.enqueued > 0 %}
+                        {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                             <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                             <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
                             <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>
                             <td class="py-2 text-right text-xs text-purple-400">{{ dq.latency_s|format_latency }}</td>

--- a/oxana-web/templates/dashboard.html
+++ b/oxana-web/templates/dashboard.html
@@ -74,7 +74,7 @@
                         {% for queue in &stats.queues %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                             <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
-                            <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                            <td class="py-3 pr-4 text-right text-gray-300">{{ self.concurrency_for(&queue.key) }}{% if self.has_concurrency_override_for(&queue.key) %} <span class="text-gray-500">(<span class="line-through">{{ self.default_concurrency_for(&queue.key) }}</span>)</span>{% endif %}</td>
                             <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-purple-400">{{ self.busy_for(&queue.key) }}</td>
                             <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
@@ -85,7 +85,7 @@
                         {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                         <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                             <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                            <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                            <td class="py-2 pr-4 text-right text-xs text-gray-400">{{ self.concurrency_for(&dq_key) }}{% if self.has_concurrency_override_for(&dq_key) %} <span class="text-gray-600">(<span class="line-through">{{ self.default_concurrency_for(&dq_key) }}</span>)</span>{% endif %}</td>
                             <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                             <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
                             <td class="py-2 pr-4 text-right text-xs text-blue-400">{{ dq.enqueued }}</td>

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -14,13 +14,26 @@
 
         {% include "_tabs.html" %}
 
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
             <div class="flex items-center gap-3">
                 <h2 class="text-lg font-semibold font-mono">{{ queue_key }}</h2>
             </div>
-            <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/wipe" onsubmit="return confirmWipe('{{ queue_key }}')">
-                <button type="submit" class="px-3 py-1.5 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-sm transition-colors">Wipe Queue</button>
-            </form>
+            <div class="flex flex-wrap items-center gap-2">
+                <span class="px-2.5 py-1 rounded border text-xs font-medium {{ self.state_class() }}">{{ self.state_label() }}</span>
+                <span class="px-2.5 py-1 rounded border border-gray-800 bg-gray-900 text-gray-300 text-xs">Concurrency {{ self.concurrency_label() }}</span>
+                {% if self.is_paused() %}
+                <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/unpause">
+                    <button type="submit" class="px-3 py-1.5 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-sm transition-colors">Unpause</button>
+                </form>
+                {% else %}
+                <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/pause">
+                    <button type="submit" class="px-3 py-1.5 rounded bg-yellow-900/50 border border-yellow-800 hover:bg-yellow-800 text-yellow-300 text-sm transition-colors">Pause</button>
+                </form>
+                {% endif %}
+                <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/wipe" onsubmit="return confirmWipe('{{ queue_key }}')">
+                    <button type="submit" class="px-3 py-1.5 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-sm transition-colors">Wipe Queue</button>
+                </form>
+            </div>
         </div>
 
         {% match queue_stats %}

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -19,7 +19,7 @@
                 <h2 class="text-lg font-semibold font-mono">{{ queue_key }}</h2>
                 <span class="px-2.5 py-1 rounded border text-xs font-medium {{ self.state_class() }}">{{ self.state_label() }}</span>
                 <span class="px-2.5 py-1 rounded border border-gray-800 bg-gray-900 text-gray-300 text-xs">
-                    Concurrency {{ self.concurrency_label() }}
+                    Concurrency: {{ self.concurrency_label() }}
                     {% if self.has_concurrency_override() %}
                     <span class="text-gray-500">(<span class="line-through">{{ self.concurrency_default_label() }}</span>)</span>
                     {% endif %}

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -15,12 +15,23 @@
         {% include "_tabs.html" %}
 
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-            <div class="flex items-center gap-3">
+            <div class="flex flex-wrap items-center gap-3">
                 <h2 class="text-lg font-semibold font-mono">{{ queue_key }}</h2>
+                <span class="px-2.5 py-1 rounded border text-xs font-medium {{ self.state_class() }}">{{ self.state_label() }}</span>
+                <span class="px-2.5 py-1 rounded border border-gray-800 bg-gray-900 text-gray-300 text-xs">
+                    Concurrency {{ self.concurrency_label() }}
+                    {% if self.has_concurrency_override() %}
+                    <span class="text-gray-500">(<span class="line-through">{{ self.concurrency_default_label() }}</span>)</span>
+                    {% endif %}
+                </span>
             </div>
             <div class="flex flex-wrap items-center gap-2">
-                <span class="px-2.5 py-1 rounded border text-xs font-medium {{ self.state_class() }}">{{ self.state_label() }}</span>
-                <span class="px-2.5 py-1 rounded border border-gray-800 bg-gray-900 text-gray-300 text-xs">Concurrency {{ self.concurrency_label() }}</span>
+                {% if self.can_change_concurrency() %}
+                <form method="POST" action="{{ self.queue_action_path("concurrency") }}" onsubmit="return promptConcurrency(this)" data-queue-key="{{ queue_key }}" data-current-concurrency="{{ self.concurrency_label() }}" data-default-concurrency="{{ self.concurrency_default_label() }}">
+                    <input type="hidden" name="concurrency" value="">
+                    <button type="submit" class="px-3 py-1.5 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300 text-sm transition-colors">Change concurrency</button>
+                </form>
+                {% endif %}
                 {% if self.is_paused() %}
                 <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/unpause">
                     <button type="submit" class="px-3 py-1.5 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-sm transition-colors">Unpause</button>
@@ -253,6 +264,31 @@
         {% endif %}
     </div>
     <script>
+        function promptConcurrency(form) {
+            var current = form.dataset.currentConcurrency || '';
+            var defaultConcurrency = form.dataset.defaultConcurrency || '';
+            var queueKey = form.dataset.queueKey || 'queue';
+            var promptText = 'Set concurrency for ' + queueKey;
+
+            if (defaultConcurrency) {
+                promptText += ' (default ' + defaultConcurrency + ')';
+            }
+
+            var input = prompt(promptText, current);
+            if (input === null) {
+                return false;
+            }
+
+            input = input.trim();
+            if (!/^[1-9][0-9]*$/.test(input)) {
+                alert('Concurrency must be a positive integer.');
+                return false;
+            }
+
+            form.elements.concurrency.value = input;
+            return true;
+        }
+
         function confirmWipe(queueKey) {
             var input = prompt('Type the queue name to confirm wipe: ' + queueKey);
             return input === queueKey;

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -42,7 +42,7 @@
                 </form>
                 {% endif %}
                 <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/wipe" onsubmit="return confirmWipe('{{ queue_key }}')">
-                    <button type="submit" class="px-3 py-1.5 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-sm transition-colors">Wipe Queue</button>
+                    <button type="submit" class="px-3 py-1.5 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-sm transition-colors">Wipe</button>
                 </form>
             </div>
         </div>

--- a/oxana-web/templates/queues.html
+++ b/oxana-web/templates/queues.html
@@ -79,6 +79,7 @@
                     <tr class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide">
                         <th class="pb-3 pr-4"><a href="{{ self.sort_href("key") }}" class="hover:text-gray-200">Queue{{ self.sort_arrow("key") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("concurrency") }}" class="hover:text-gray-200">Concurrency{{ self.sort_arrow("concurrency") }}</a></th>
+                        <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("state") }}" class="hover:text-gray-200">State{{ self.sort_arrow("state") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("enqueued") }}" class="hover:text-gray-200">Enqueued{{ self.sort_arrow("enqueued") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("rate") }}" class="hover:text-gray-200">Rate{{ self.sort_arrow("rate") }}</a></th>
                         <th class="pb-3 pr-4 text-right"><a href="{{ self.sort_href("eta") }}" class="hover:text-gray-200">ETA{{ self.sort_arrow("eta") }}</a></th>
@@ -94,6 +95,7 @@
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                         <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
                         <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                        <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                         <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                         <td class="py-3 pr-4 text-right text-cyan-400">{{ queue.rate.processed_per_minute|format_rate_per_minute }}</td>
                         <td class="py-3 pr-4 text-right text-yellow-400">{{ queue.rate.eta_s|format_eta_s }}</td>
@@ -104,9 +106,11 @@
                         <td class="py-3 text-right text-purple-400">{{ queue.latency_s|format_latency }}</td>
                     </tr>
                     {% for dq in &queue.queues %}
+                    {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                         <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                        <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&queue.key) }}</td>
+                        <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                        <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.enqueued }}</td>
                         <td class="py-2 pr-4 text-right text-xs text-cyan-400">{{ dq.rate.processed_per_minute|format_rate_per_minute }}</td>
                         <td class="py-2 pr-4 text-right text-xs text-yellow-400">{{ dq.rate.eta_s|format_eta_s }}</td>

--- a/oxana-web/templates/queues.html
+++ b/oxana-web/templates/queues.html
@@ -94,7 +94,7 @@
                     {% for queue in &stats.queues %}
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50">
                         <td class="py-3 pr-4 font-mono text-sm">{% if queue.queues.is_empty() %}<a href="{{ base_path }}/queues/{{ queue.key|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ queue.key }}</a>{% else %}{{ queue.key }}{% endif %}</td>
-                        <td class="py-3 pr-4 text-right text-gray-400">{{ self.concurrency_for(&queue.key) }}</td>
+                        <td class="py-3 pr-4 text-right text-gray-300">{{ self.concurrency_for(&queue.key) }}{% if self.has_concurrency_override_for(&queue.key) %} <span class="text-gray-500">(<span class="line-through">{{ self.default_concurrency_for(&queue.key) }}</span>)</span>{% endif %}</td>
                         <td class="py-3 pr-4 text-right {{ self.state_class_for(&queue.key) }}">{{ self.state_for(&queue.key) }}</td>
                         <td class="py-3 pr-4 text-right text-blue-400">{{ queue.enqueued }}</td>
                         <td class="py-3 pr-4 text-right text-cyan-400">{{ queue.rate.processed_per_minute|format_rate_per_minute }}</td>
@@ -109,7 +109,7 @@
                     {% let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix) %}
                     <tr class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500">
                         <td class="py-2 pr-4 pl-10 font-mono text-xs">&#8627; <a href="{{ base_path }}/queues/{{ queue.key }}%23{{ dq.suffix|urlencode }}" class="text-blue-400 hover:text-blue-300 hover:underline">{{ dq.suffix }}</a></td>
-                        <td class="py-2 pr-4 text-right text-xs text-gray-500">{{ self.concurrency_for(&dq_key) }}</td>
+                        <td class="py-2 pr-4 text-right text-xs text-gray-400">{{ self.concurrency_for(&dq_key) }}{% if self.has_concurrency_override_for(&dq_key) %} <span class="text-gray-600">(<span class="line-through">{{ self.default_concurrency_for(&dq_key) }}</span>)</span>{% endif %}</td>
                         <td class="py-2 pr-4 text-right text-xs {{ self.state_class_for(&dq_key) }}">{{ self.state_for(&dq_key) }}</td>
                         <td class="py-2 pr-4 text-right text-xs">{{ dq.enqueued }}</td>
                         <td class="py-2 pr-4 text-right text-xs text-cyan-400">{{ dq.rate.processed_per_minute|format_rate_per_minute }}</td>

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -21,6 +21,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 - **Scheduled Jobs** - run jobs at specific times or after delays
 - **Cron Jobs** - periodic jobs using cron expressions
 - **Dynamic Queues** - create and manage queues at runtime
+- **Runtime Queue Controls** - pause queues and adjust dynamic concurrency without restarting workers
 - **Throttling** - rate-limit job processing per queue
 - **Unique Jobs** - deduplicate jobs so only one instance runs at a time
 - **Resumable Jobs** - resume from where a job left off on retry
@@ -117,7 +118,7 @@ The dashboard exposes these pages:
 - `/retries` - Jobs pending retry
 - `/dead` - Dead letter queue
 
-It also provides management actions for wiping queues and deleting individual jobs.
+It also provides management actions for pausing and unpausing queues, changing dynamic queue concurrency from queue detail pages, wiping queues, and deleting individual jobs.
 
 ## Core Concepts
 
@@ -156,7 +157,8 @@ Queue attributes:
 
 - `#[oxana(key = "my_queue")]` - Set static queue key
 - `#[oxana(prefix = "dynamic")]` - Set prefix for dynamic queues
-- `#[oxana(concurrency = 2)]` - Set concurrency limit
+- `#[oxana(concurrency = 2)]` - Set a fixed concurrency limit
+- `#[oxana(concurrency = Dynamic(2))]` - Set a runtime-adjustable concurrency limit with default `2`
 - `#[oxana(throttle(window_ms = 2000, limit = 5))]` - Configure throttling
 
 ### Component Registry

--- a/oxana/benches/concurrency.rs
+++ b/oxana/benches/concurrency.rs
@@ -49,7 +49,7 @@ impl oxana::Queue for QueueOne {
             kind: oxana::QueueKind::Static {
                 key: "one".to_string(),
             },
-            concurrency: 1,
+            concurrency: oxana::QueueConcurrency::Fixed(1),
             throttle: None,
         }
     }

--- a/oxana/examples/dynamic_concurrency.rs
+++ b/oxana/examples/dynamic_concurrency.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+#[derive(oxana::Registry)]
+struct ComponentRegistry(oxana::ComponentRegistry<WorkerContext, WorkerError>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Clone)]
+struct WorkerContext {}
+
+#[derive(Debug, Serialize, Deserialize, oxana::Job)]
+struct OneSecJob {
+    id: usize,
+}
+
+#[derive(oxana::Worker)]
+struct OneSecWorker;
+
+impl OneSecWorker {
+    async fn process(&self, job: OneSecJob, _ctx: &oxana::JobContext) -> Result<(), WorkerError> {
+        println!("job {} started", job.id);
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        println!("job {} finished", job.id);
+        Ok(())
+    }
+}
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(key = "dynamic_concurrency", concurrency = Dynamic(1))]
+struct DynamicConcurrencyQueue;
+
+#[tokio::main]
+pub async fn main() -> Result<(), oxana::OxanaError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let ctx = oxana::ContextValue::new(WorkerContext {});
+    let storage = oxana::Storage::builder().build_from_env()?;
+
+    storage
+        .set_queue_config(
+            DynamicConcurrencyQueue,
+            &oxana::QueueRuntimeConfig {
+                concurrency: Some(1),
+                state: oxana::QueueState::Active,
+            },
+        )
+        .await?;
+
+    let config = ComponentRegistry::build_config(&storage).exit_when_processed(30);
+
+    for id in 1..=30 {
+        storage
+            .enqueue(DynamicConcurrencyQueue, OneSecJob { id })
+            .await?;
+    }
+
+    let update_storage = storage.clone();
+    let handle = tokio::runtime::Handle::current();
+    let update_thread = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(5));
+
+        handle.block_on(async move {
+            update_storage
+                .set_queue_concurrency(DynamicConcurrencyQueue, 0)
+                .await?;
+            println!("processing has been paused");
+
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            println!("processing is resuming");
+
+            update_storage
+                .set_queue_concurrency(DynamicConcurrencyQueue, 10)
+                .await
+        })
+    });
+
+    let run_result = oxana::run(config, ctx).await;
+    let update_result = update_thread.join().map_err(|_| {
+        oxana::OxanaError::GenericError("concurrency update thread panicked".into())
+    })?;
+    update_result?;
+    run_result?;
+
+    Ok(())
+}

--- a/oxana/examples/dynamic_concurrency.rs
+++ b/oxana/examples/dynamic_concurrency.rs
@@ -42,15 +42,7 @@ pub async fn main() -> Result<(), oxana::OxanaError> {
     let ctx = oxana::ContextValue::new(WorkerContext {});
     let storage = oxana::Storage::builder().build_from_env()?;
 
-    storage
-        .set_queue_config(
-            DynamicConcurrencyQueue,
-            &oxana::QueueRuntimeConfig {
-                concurrency: Some(1),
-                state: oxana::QueueState::Active,
-            },
-        )
-        .await?;
+    storage.reset_queue_config(DynamicConcurrencyQueue).await?;
 
     let config = ComponentRegistry::build_config(&storage).exit_when_processed(30);
 

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::Storage;
-use crate::queue::{Queue, QueueConfig};
+use crate::queue::{Queue, QueueConcurrency, QueueConfig};
 use crate::storage_types::{
     Catalog, CronWorkerInfo, OnDemandJobInfo, QueueInfo, QueueThrottleInfo, WorkerInfo,
 };
@@ -60,7 +60,7 @@ impl<DT, ET> Config<DT, ET> {
         Q: Queue,
     {
         let mut config = Q::to_config();
-        config.concurrency = concurrency;
+        config.concurrency = QueueConcurrency::Fixed(concurrency);
         self.register_queue_with(config);
         self
     }
@@ -212,7 +212,8 @@ impl<DT, ET> Config<DT, ET> {
                 QueueInfo {
                     key,
                     dynamic,
-                    concurrency: q.concurrency,
+                    concurrency: q.concurrency.default_concurrency(),
+                    dynamic_concurrency: q.concurrency.is_dynamic(),
                     throttle: q.throttle.as_ref().map(|t| QueueThrottleInfo {
                         window_ms: t.window_ms,
                         limit: t.limit,

--- a/oxana/src/coordinator.rs
+++ b/oxana/src/coordinator.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{Mutex, OwnedSemaphorePermit, mpsc};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinSet;
+use tokio::time::MissedTickBehavior;
 
 use crate::WorkerBatchConfig;
 use crate::config::Config;
@@ -9,9 +10,9 @@ use crate::context::ContextValue;
 use crate::error::OxanaError;
 use crate::executor::{ExecutionError, ExecutionOutcome};
 use crate::job_envelope::JobEnvelope;
-use crate::queue::{QueueConfig, QueueKind};
+use crate::queue::{QueueConfig, QueueKind, QueueRuntimeConfig};
 use crate::result_collector::{WorkerResult, WorkerResultKind};
-use crate::semaphores_map::SemaphoresMap;
+use crate::semaphores_map::{QueueControlsMap, QueuePermit};
 use crate::worker_event::WorkerJob;
 use crate::{
     dispatcher, executor,
@@ -28,11 +29,11 @@ where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    let concurrency = queue_config.concurrency;
-    let (result_tx, result_rx) = mpsc::channel::<WorkerResult>(concurrency);
-    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(concurrency);
-    let (batch_error_tx, mut batch_error_rx) = mpsc::channel::<OxanaError>(concurrency.max(1));
-    let semaphores = Arc::new(SemaphoresMap::new(concurrency));
+    let channel_capacity = queue_config.concurrency.default_concurrency().max(1);
+    let (result_tx, result_rx) = mpsc::channel::<WorkerResult>(channel_capacity);
+    let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(channel_capacity);
+    let (batch_error_tx, mut batch_error_rx) = mpsc::channel::<OxanaError>(channel_capacity);
+    let queue_controls = Arc::new(QueueControlsMap::new());
     let mut joinset = JoinSet::new();
     let mut batchers: HashMap<BatchKey, mpsc::Sender<PendingJob>> = HashMap::new();
 
@@ -45,7 +46,7 @@ where
         Arc::clone(&config),
         queue_config.clone(),
         job_tx.clone(),
-        Arc::clone(&semaphores),
+        Arc::clone(&queue_controls),
     ));
 
     loop {
@@ -79,7 +80,7 @@ where
     }
 
     drop(batchers);
-    wait_for_workers_to_finish(config, Arc::clone(&semaphores)).await;
+    wait_for_workers_to_finish(config, Arc::clone(&queue_controls)).await;
     drop(result_tx);
     drop(batch_error_tx);
 
@@ -107,7 +108,7 @@ impl BatchKey {
 
 struct PendingJob {
     envelope: JobEnvelope,
-    permit: OwnedSemaphorePermit,
+    permit: QueuePermit,
 }
 
 async fn route_job<DT, ET>(
@@ -613,13 +614,22 @@ async fn run_queue_watcher<DT, ET>(
     config: Arc<Config<DT, ET>>,
     queue_config: QueueConfig,
     job_tx: mpsc::Sender<WorkerJob>,
-    semaphores: Arc<SemaphoresMap>,
+    queue_controls: Arc<QueueControlsMap>,
 ) -> Result<(), OxanaError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
     let mut tracked_queues = HashSet::new();
+    let queue_concurrency = queue_config.concurrency;
+    let default_runtime_config = queue_concurrency.stored_runtime_default();
+    let base_queue_key = queue_config.key_or_prefix();
+
+    config
+        .storage
+        .internal
+        .ensure_queue_config(&base_queue_key, default_runtime_config.clone())
+        .await?;
 
     loop {
         let all_queues: HashSet<String> = match &queue_config.kind {
@@ -627,13 +637,8 @@ where
             QueueKind::Dynamic { prefix, .. } => config
                 .storage
                 .internal
-                .track_redis_result(
-                    config
-                        .storage
-                        .internal
-                        .queue_keys(&format!("{prefix}*"))
-                        .await,
-                )?
+                .track_redis_result(config.storage.internal.queues(&format!("{prefix}*")).await)?
+                .map(|queues| queues.into_iter().collect())
                 .unwrap_or_default(),
         };
         let new_queues: HashSet<String> = all_queues.difference(&tracked_queues).cloned().collect();
@@ -645,10 +650,49 @@ where
                 "Tracking queue"
             );
 
+            let queue_default_config = if queue == base_queue_key {
+                default_runtime_config.clone()
+            } else {
+                config
+                    .storage
+                    .internal
+                    .queue_config(&base_queue_key)
+                    .await?
+                    .unwrap_or_else(|| default_runtime_config.clone())
+            };
+            let runtime_config = config
+                .storage
+                .internal
+                .ensure_queue_config(&queue, queue_default_config.clone())
+                .await?;
+            let runtime_config = queue_concurrency.effective_runtime_config(runtime_config);
+            let queue_control = queue_controls
+                .get_or_create(queue.clone(), runtime_config.clone())
+                .await;
+            queue_control.apply_config(runtime_config);
+
+            let watcher_config = Arc::clone(&config);
+            let watcher_queue = queue.clone();
+            let watcher_control = Arc::clone(&queue_control);
+            let watcher_default_config = queue_default_config;
+            tokio::spawn(async move {
+                if let Err(e) = run_queue_config_watcher(
+                    watcher_config,
+                    watcher_queue,
+                    watcher_default_config,
+                    queue_concurrency,
+                    watcher_control,
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "Queue config watcher exited with error");
+                }
+            });
+
             let dispatcher_config = Arc::clone(&config);
             let dispatcher_queue_config = queue_config.clone();
             let dispatcher_job_tx = job_tx.clone();
-            let dispatcher_semaphores = Arc::clone(&semaphores);
+            let dispatcher_queue_control = Arc::clone(&queue_control);
             let dispatcher_queue = queue.clone();
             tokio::spawn(async move {
                 if let Err(e) = dispatcher::run(
@@ -656,7 +700,7 @@ where
                     dispatcher_queue_config,
                     dispatcher_queue,
                     dispatcher_job_tx,
-                    dispatcher_semaphores,
+                    dispatcher_queue_control,
                 )
                 .await
                 {
@@ -669,17 +713,52 @@ where
 
         if config.cancel_token.is_cancelled() {
             return Ok(());
-        } else if let QueueKind::Dynamic { sleep_period, .. } = queue_config.kind {
-            tokio::time::sleep(sleep_period).await;
+        } else if let QueueKind::Dynamic { sleep_period, .. } = &queue_config.kind {
+            tokio::time::sleep(*sleep_period).await;
         } else {
             return Ok(());
         }
     }
 }
 
+async fn run_queue_config_watcher<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    queue_key: String,
+    default_config: QueueRuntimeConfig,
+    queue_concurrency: crate::QueueConcurrency,
+    queue_control: Arc<crate::semaphores_map::QueueControl>,
+) -> Result<(), OxanaError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = config.cancel_token.cancelled() => {
+                return Ok(());
+            }
+            _ = interval.tick() => {
+                if let Some(runtime_config) = config.storage.internal.track_redis_result(
+                    config
+                        .storage
+                        .internal
+                        .ensure_queue_config(&queue_key, default_config.clone())
+                        .await,
+                )? {
+                    let runtime_config = queue_concurrency.effective_runtime_config(runtime_config);
+                    queue_control.apply_config(runtime_config);
+                }
+            }
+        }
+    }
+}
+
 async fn wait_for_workers_to_finish<DT, ET>(
     config: Arc<Config<DT, ET>>,
-    semaphores: Arc<SemaphoresMap>,
+    queue_controls: Arc<QueueControlsMap>,
 ) where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
@@ -690,7 +769,7 @@ async fn wait_for_workers_to_finish<DT, ET>(
     loop {
         ticks += 1;
 
-        let busy_count = semaphores.busy_count().await;
+        let busy_count = queue_controls.busy_count().await;
         if busy_count == 0 {
             break;
         }
@@ -711,13 +790,15 @@ async fn wait_for_workers_to_finish<DT, ET>(
 #[cfg(test)]
 mod tests {
     use super::{PendingJob, process_pending_batch};
+    use crate::QueueRuntimeConfig;
+    use crate::semaphores_map::QueueControlsMap;
     use crate::test_helper::{random_string, redis_pool};
     use crate::worker_registry::{self, BatchBuild, InvalidBatchJob, WorkerConfigKind};
     use crate::{Config, ContextValue, Job, JobEnvelope, Storage, Worker, WorkerConfig};
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
     use testresult::TestResult;
-    use tokio::sync::{Semaphore, mpsc};
+    use tokio::sync::mpsc;
 
     #[derive(Debug, Serialize, Deserialize)]
     struct UnsortedInvalidJob;
@@ -803,12 +884,15 @@ mod tests {
             storage.internal.dequeue(&queue).await?;
         }
 
-        let semaphore = Arc::new(Semaphore::new(envelopes.len()));
+        let queue_controls = QueueControlsMap::new();
+        let queue_control = queue_controls
+            .get_or_create(queue.clone(), QueueRuntimeConfig::new(envelopes.len()))
+            .await;
         let mut pending = Vec::with_capacity(envelopes.len());
         for envelope in envelopes {
             pending.push(PendingJob {
                 envelope,
-                permit: Arc::clone(&semaphore).acquire_owned().await?,
+                permit: queue_control.acquire().await,
             });
         }
         let (result_tx, _result_rx) = mpsc::channel(1);

--- a/oxana/src/coordinator.rs
+++ b/oxana/src/coordinator.rs
@@ -625,12 +625,6 @@ where
     let default_runtime_config = queue_concurrency.stored_runtime_default();
     let base_queue_key = queue_config.key_or_prefix();
 
-    config
-        .storage
-        .internal
-        .ensure_queue_config(&base_queue_key, default_runtime_config.clone())
-        .await?;
-
     loop {
         let all_queues: HashSet<String> = match &queue_config.kind {
             QueueKind::Static { key } => HashSet::from([key.clone()]),
@@ -650,21 +644,13 @@ where
                 "Tracking queue"
             );
 
-            let queue_default_config = if queue == base_queue_key {
-                default_runtime_config.clone()
-            } else {
-                config
-                    .storage
-                    .internal
-                    .queue_config(&base_queue_key)
-                    .await?
-                    .unwrap_or_else(|| default_runtime_config.clone())
-            };
-            let runtime_config = config
-                .storage
-                .internal
-                .ensure_queue_config(&queue, queue_default_config.clone())
-                .await?;
+            let runtime_config = runtime_queue_config(
+                &config,
+                &queue,
+                &base_queue_key,
+                default_runtime_config.clone(),
+            )
+            .await?;
             let runtime_config = queue_concurrency.effective_runtime_config(runtime_config);
             let queue_control = queue_controls
                 .get_or_create(queue.clone(), runtime_config.clone())
@@ -674,12 +660,14 @@ where
             let watcher_config = Arc::clone(&config);
             let watcher_queue = queue.clone();
             let watcher_control = Arc::clone(&queue_control);
-            let watcher_default_config = queue_default_config;
+            let watcher_base_queue_key = base_queue_key.clone();
+            let watcher_default_runtime_config = default_runtime_config.clone();
             tokio::spawn(async move {
                 if let Err(e) = run_queue_config_watcher(
                     watcher_config,
                     watcher_queue,
-                    watcher_default_config,
+                    watcher_base_queue_key,
+                    watcher_default_runtime_config,
                     queue_concurrency,
                     watcher_control,
                 )
@@ -721,10 +709,42 @@ where
     }
 }
 
+async fn runtime_queue_config<DT, ET>(
+    config: &Config<DT, ET>,
+    queue_key: &str,
+    base_queue_key: &str,
+    default_runtime_config: QueueRuntimeConfig,
+) -> Result<QueueRuntimeConfig, OxanaError>
+where
+    DT: Send + Sync + Clone + 'static,
+    ET: std::error::Error + Send + Sync + 'static,
+{
+    if queue_key == base_queue_key {
+        return config
+            .storage
+            .internal
+            .queue_config_or_default(queue_key, default_runtime_config)
+            .await;
+    }
+
+    let base_runtime_config = config
+        .storage
+        .internal
+        .queue_config_or_default(base_queue_key, default_runtime_config)
+        .await?;
+
+    config
+        .storage
+        .internal
+        .queue_config_or_default(queue_key, base_runtime_config)
+        .await
+}
+
 async fn run_queue_config_watcher<DT, ET>(
     config: Arc<Config<DT, ET>>,
     queue_key: String,
-    default_config: QueueRuntimeConfig,
+    base_queue_key: String,
+    default_runtime_config: QueueRuntimeConfig,
     queue_concurrency: crate::QueueConcurrency,
     queue_control: Arc<crate::semaphores_map::QueueControl>,
 ) -> Result<(), OxanaError>
@@ -742,11 +762,13 @@ where
             }
             _ = interval.tick() => {
                 if let Some(runtime_config) = config.storage.internal.track_redis_result(
-                    config
-                        .storage
-                        .internal
-                        .ensure_queue_config(&queue_key, default_config.clone())
-                        .await,
+                    runtime_queue_config(
+                        &config,
+                        &queue_key,
+                        &base_queue_key,
+                        default_runtime_config.clone(),
+                    )
+                    .await,
                 )? {
                     let runtime_config = queue_concurrency.effective_runtime_config(runtime_config);
                     queue_control.apply_config(runtime_config);

--- a/oxana/src/dispatcher.rs
+++ b/oxana/src/dispatcher.rs
@@ -5,7 +5,7 @@ use tokio::time::sleep;
 
 use crate::error::OxanaError;
 use crate::queue::{QueueConfig, QueueThrottle};
-use crate::semaphores_map::SemaphoresMap;
+use crate::semaphores_map::QueueControl;
 use crate::storage_internal::StorageInternal;
 use crate::throttler::Throttler;
 use crate::worker_event::WorkerJob;
@@ -16,25 +16,33 @@ pub async fn run<DT, ET>(
     queue_config: QueueConfig,
     queue_key: String,
     job_tx: mpsc::Sender<WorkerJob>,
-    semaphores: Arc<SemaphoresMap>,
+    queue_control: Arc<QueueControl>,
 ) -> Result<(), OxanaError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
     loop {
-        let semaphore = semaphores.get_or_create(queue_key.clone()).await;
-        let permit = semaphore.acquire_owned().await.unwrap();
+        let permit = tokio::select! {
+            permit = queue_control.acquire() => permit,
+            _ = config.cancel_token.cancelled() => {
+                tracing::debug!("Stopping dispatcher for queue {}", queue_key);
+                break;
+            }
+        };
 
         tokio::select! {
             result = pop_queue_message(&config.storage.internal, &queue_config, &queue_key) => {
                 match config.storage.internal.track_redis_result(result)? {
-                    Some(job_id) => {
+                    Some(Some(job_id)) => {
                         let job = WorkerJob { job_id, permit };
                         job_tx
                             .send(job)
                             .await
                             .expect("Failed to send job to worker");
+                    }
+                    Some(None) => {
+                        drop(permit);
                     }
                     None => {
                         drop(permit);
@@ -57,10 +65,10 @@ async fn pop_queue_message(
     storage: &StorageInternal,
     queue_config: &QueueConfig,
     queue_key: &str,
-) -> Result<String, OxanaError> {
+) -> Result<Option<JobId>, OxanaError> {
     match &queue_config.throttle {
         Some(throttle) => pop_queue_message_w_throttle(storage, queue_key, throttle).await,
-        None => pop_queue_message_wo_throttle(storage, queue_key, 10.0).await,
+        None => pop_queue_message_wo_throttle(storage, queue_key, 1.0).await,
     }
 }
 
@@ -68,39 +76,34 @@ async fn pop_queue_message_wo_throttle(
     storage: &StorageInternal,
     queue_key: &str,
     timeout: f64,
-) -> Result<String, OxanaError> {
-    loop {
-        if let Some(job_id) = storage.blocking_dequeue(queue_key, timeout).await? {
-            return Ok(job_id);
-        }
-    }
+) -> Result<Option<JobId>, OxanaError> {
+    storage.blocking_dequeue(queue_key, timeout).await
 }
 
 async fn pop_queue_message_w_throttle(
     storage: &StorageInternal,
     queue_key: &str,
     throttle: &QueueThrottle,
-) -> Result<JobId, OxanaError> {
+) -> Result<Option<JobId>, OxanaError> {
     let pool = storage.pool().await?;
-    loop {
-        let throttler = Throttler::new(pool.clone(), queue_key, throttle.limit, throttle.window_ms);
+    let throttler = Throttler::new(pool, queue_key, throttle.limit, throttle.window_ms);
 
-        let state = throttler.state().await?;
+    let state = throttler.state().await?;
 
-        if state.is_allowed
-            && let Some(job_id) = storage.dequeue(queue_key).await?
-        {
-            let cost = storage
-                .get_job(&job_id)
-                .await?
-                .and_then(|envelope| envelope.meta.throttle_cost);
-            throttler.consume(cost).await?;
-            return Ok(job_id);
-        }
-
-        sleep(Duration::from_millis(
-            u64::try_from(state.throttled_for.unwrap_or(100)).unwrap_or(100),
-        ))
-        .await;
+    if state.is_allowed
+        && let Some(job_id) = storage.dequeue(queue_key).await?
+    {
+        let cost = storage
+            .get_job(&job_id)
+            .await?
+            .and_then(|envelope| envelope.meta.throttle_cost);
+        throttler.consume(cost).await?;
+        return Ok(Some(job_id));
     }
+
+    sleep(Duration::from_millis(
+        u64::try_from(state.throttled_for.unwrap_or(100)).unwrap_or(100),
+    ))
+    .await;
+    Ok(None)
 }

--- a/oxana/src/lib.rs
+++ b/oxana/src/lib.rs
@@ -117,7 +117,9 @@ pub use crate::job_envelope::{JobConflictStrategy, JobData, JobEnvelope, JobId, 
 pub use crate::job_state::{JobProgress, JobProgressIterator, JobState};
 pub use crate::launcher::run;
 pub use crate::metrics::*;
-pub use crate::queue::{Queue, QueueConfig, QueueKind, QueueThrottle};
+pub use crate::queue::{
+    Queue, QueueConcurrency, QueueConfig, QueueKind, QueueRuntimeConfig, QueueState, QueueThrottle,
+};
 pub use crate::stats::*;
 pub use crate::storage::Storage;
 pub use crate::storage_builder::{StorageBuilder, StorageBuilderTimeouts};

--- a/oxana/src/queue.rs
+++ b/oxana/src/queue.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     hash::{Hash, Hasher},
     time::Duration,
@@ -23,7 +23,7 @@ pub trait Queue: Send + Sync + Serialize {
 #[derive(Debug, Clone)]
 pub struct QueueConfig {
     pub kind: QueueKind,
-    pub concurrency: usize,
+    pub concurrency: QueueConcurrency,
     pub throttle: Option<QueueThrottle>,
 }
 
@@ -48,7 +48,7 @@ impl QueueConfig {
                 prefix: prefix.into(),
                 sleep_period: Duration::from_millis(500),
             },
-            concurrency: 1,
+            concurrency: QueueConcurrency::Fixed(1),
             throttle: None,
         }
     }
@@ -56,13 +56,24 @@ impl QueueConfig {
     pub fn as_static(key: impl Into<String>) -> Self {
         Self {
             kind: QueueKind::Static { key: key.into() },
-            concurrency: 1,
+            concurrency: QueueConcurrency::Fixed(1),
             throttle: None,
         }
     }
 
     pub fn concurrency(mut self, concurrency: usize) -> Self {
-        self.concurrency = concurrency;
+        self.concurrency = QueueConcurrency::Fixed(concurrency);
+        self
+    }
+
+    /// Sets the default concurrency used by the runtime queue configuration.
+    ///
+    /// Runtime queue config is persisted in Redis, so this value is used when a
+    /// queue does not have an existing runtime override yet.
+    pub fn dynamic_concurrency(mut self, default_concurrency: usize) -> Self {
+        self.concurrency = QueueConcurrency::Dynamic {
+            default: default_concurrency,
+        };
         self
     }
 
@@ -75,6 +86,54 @@ impl QueueConfig {
         match &self.kind {
             QueueKind::Static { key } => Some(key.clone()),
             QueueKind::Dynamic { .. } => None,
+        }
+    }
+
+    pub fn key_or_prefix(&self) -> String {
+        match &self.kind {
+            QueueKind::Static { key } => key.clone(),
+            QueueKind::Dynamic { prefix, .. } => prefix.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum QueueConcurrency {
+    Fixed(usize),
+    Dynamic { default: usize },
+}
+
+impl QueueConcurrency {
+    pub fn default_concurrency(self) -> usize {
+        match self {
+            Self::Fixed(concurrency) => concurrency,
+            Self::Dynamic { default } => default,
+        }
+    }
+
+    pub fn is_dynamic(self) -> bool {
+        matches!(self, Self::Dynamic { .. })
+    }
+
+    pub(crate) fn stored_runtime_default(self) -> QueueRuntimeConfig {
+        QueueRuntimeConfig {
+            concurrency: self.is_dynamic().then_some(self.default_concurrency()),
+            state: QueueState::Active,
+        }
+    }
+
+    pub(crate) fn effective_runtime_config(
+        self,
+        runtime_config: QueueRuntimeConfig,
+    ) -> QueueRuntimeConfig {
+        let concurrency = match self {
+            Self::Fixed(concurrency) => concurrency,
+            Self::Dynamic { default } => runtime_config.concurrency.unwrap_or(default),
+        };
+
+        QueueRuntimeConfig {
+            concurrency: Some(concurrency),
+            state: runtime_config.state,
         }
     }
 }
@@ -127,6 +186,49 @@ impl QueueKind {
 pub struct QueueThrottle {
     pub window_ms: i64,
     pub limit: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueState {
+    #[default]
+    Active,
+    Paused,
+}
+
+impl QueueState {
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Active => "Active",
+            Self::Paused => "Paused",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QueueRuntimeConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<usize>,
+    #[serde(default)]
+    pub state: QueueState,
+}
+
+impl QueueRuntimeConfig {
+    pub fn new(concurrency: usize) -> Self {
+        Self {
+            concurrency: Some(concurrency),
+            state: QueueState::Active,
+        }
+    }
+
+    pub fn with_defaults(mut self, defaults: Self) -> Self {
+        self.concurrency = self.concurrency.or(defaults.concurrency);
+        self
+    }
 }
 
 fn value_to_queue_key(value: serde_json::Value) -> String {
@@ -203,21 +305,48 @@ mod tests {
         struct DefaultQueue;
 
         assert_eq!(DefaultQueue.key(), "default_queue");
-        assert_eq!(DefaultQueue.config().concurrency, 1);
+        assert_eq!(
+            DefaultQueue.config().concurrency,
+            QueueConcurrency::Fixed(1)
+        );
 
         #[derive(Serialize, oxana::Queue)]
         #[oxana(key = "static_queue")]
         struct QueueWithKey;
 
         assert_eq!(QueueWithKey.key(), "static_queue");
-        assert_eq!(QueueWithKey.config().concurrency, 1);
+        assert_eq!(
+            QueueWithKey.config().concurrency,
+            QueueConcurrency::Fixed(1)
+        );
 
         #[derive(Serialize, oxana::Queue)]
         #[oxana(concurrency = 2)]
         struct QueueWithConcurrency;
 
         assert_eq!(QueueWithConcurrency.key(), "queue_with_concurrency");
-        assert_eq!(QueueWithConcurrency.config().concurrency, 2);
+        assert_eq!(
+            QueueWithConcurrency.config().concurrency,
+            QueueConcurrency::Fixed(2)
+        );
+
+        #[derive(Serialize, oxana::Queue)]
+        #[oxana(concurrency = Fixed(2))]
+        struct QueueWithFixedConcurrency;
+
+        assert_eq!(
+            QueueWithFixedConcurrency.config().concurrency,
+            QueueConcurrency::Fixed(2)
+        );
+
+        #[derive(Serialize, oxana::Queue)]
+        #[oxana(concurrency = Dynamic(2))]
+        struct QueueWithDynamicConcurrency;
+
+        assert_eq!(
+            QueueWithDynamicConcurrency.config().concurrency,
+            QueueConcurrency::Dynamic { default: 2 }
+        );
 
         #[derive(Serialize, oxana::Queue)]
         #[oxana(concurrency = 2)]
@@ -225,7 +354,10 @@ mod tests {
         struct QueueWithThrottle;
 
         assert_eq!(QueueWithThrottle.key(), "queue_with_throttle");
-        assert_eq!(QueueWithThrottle.config().concurrency, 2);
+        assert_eq!(
+            QueueWithThrottle.config().concurrency,
+            QueueConcurrency::Fixed(2)
+        );
         assert_eq!(QueueWithThrottle.config().throttle.unwrap().window_ms, 3);
         assert_eq!(QueueWithThrottle.config().throttle.unwrap().limit, 4);
 
@@ -235,14 +367,20 @@ mod tests {
         struct QueueWithKeyAndConcurrency;
 
         assert_eq!(QueueWithKeyAndConcurrency.key(), "static_queue_key");
-        assert_eq!(QueueWithKeyAndConcurrency.config().concurrency, 2);
+        assert_eq!(
+            QueueWithKeyAndConcurrency.config().concurrency,
+            QueueConcurrency::Fixed(2)
+        );
 
         #[derive(Serialize, oxana::Queue)]
         #[oxana(key = "static_queue_key", concurrency = 3)]
         struct QueueWithKeyAndConcurrency1 {}
 
         assert_eq!(QueueWithKeyAndConcurrency1 {}.key(), "static_queue_key");
-        assert_eq!(QueueWithKeyAndConcurrency1 {}.config().concurrency, 3);
+        assert_eq!(
+            QueueWithKeyAndConcurrency1 {}.config().concurrency,
+            QueueConcurrency::Fixed(3)
+        );
 
         #[derive(Serialize, oxana::Queue)]
         #[oxana(prefix = "dyn_queue", concurrency = 2)]
@@ -251,6 +389,40 @@ mod tests {
         }
 
         assert_eq!(DynQueue { i: 2 }.key(), "dyn_queue#i=2");
-        assert_eq!(DynQueue::to_config().concurrency, 2);
+        assert_eq!(
+            DynQueue::to_config().concurrency,
+            QueueConcurrency::Fixed(2)
+        );
+
+        #[derive(Serialize, oxana::Queue)]
+        #[oxana(key = "runtime_queue", concurrency = Dynamic(4))]
+        struct RuntimeQueue;
+
+        assert_eq!(RuntimeQueue.key(), "runtime_queue");
+        assert_eq!(
+            RuntimeQueue.config().concurrency,
+            QueueConcurrency::Dynamic { default: 4 }
+        );
+    }
+
+    #[test]
+    fn runtime_config_can_store_state_without_concurrency() {
+        let config = QueueRuntimeConfig {
+            state: QueueState::Paused,
+            ..QueueRuntimeConfig::default()
+        };
+
+        assert_eq!(
+            serde_json::to_string(&config).unwrap(),
+            r#"{"state":"paused"}"#
+        );
+        assert_eq!(config.concurrency.unwrap_or(4), 4);
+        assert_eq!(
+            config.with_defaults(QueueRuntimeConfig::new(4)),
+            QueueRuntimeConfig {
+                concurrency: Some(4),
+                state: QueueState::Paused,
+            }
+        );
     }
 }

--- a/oxana/src/semaphores_map.rs
+++ b/oxana/src/semaphores_map.rs
@@ -1,32 +1,176 @@
 use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::{Mutex, Semaphore};
+use std::sync::{Arc, Mutex, MutexGuard};
 
-pub struct SemaphoresMap {
-    permits: usize,
-    inner: Mutex<HashMap<String, Arc<Semaphore>>>,
+use tokio::sync::{Mutex as TokioMutex, Notify};
+
+use crate::queue::{QueueRuntimeConfig, QueueState};
+
+pub struct QueueControlsMap {
+    inner: TokioMutex<HashMap<String, Arc<QueueControl>>>,
 }
 
-impl SemaphoresMap {
-    pub fn new(permits: usize) -> Self {
+impl QueueControlsMap {
+    pub fn new() -> Self {
         Self {
-            permits,
-            inner: Mutex::new(HashMap::new()),
+            inner: TokioMutex::new(HashMap::new()),
         }
     }
 
-    pub async fn get_or_create(&self, key: String) -> Arc<Semaphore> {
+    pub async fn get_or_create(
+        &self,
+        key: String,
+        config: QueueRuntimeConfig,
+    ) -> Arc<QueueControl> {
         let mut map = self.inner.lock().await;
         Arc::clone(
             map.entry(key)
-                .or_insert_with(|| Arc::new(Semaphore::new(self.permits))),
+                .or_insert_with(|| Arc::new(QueueControl::new(config))),
         )
     }
 
     pub async fn busy_count(&self) -> usize {
         let map = self.inner.lock().await;
-        map.values()
-            .map(|sem| self.permits - sem.available_permits())
-            .sum()
+        map.values().map(|control| control.active_count()).sum()
+    }
+}
+
+pub struct QueueControl {
+    inner: Mutex<QueueControlState>,
+    notify: Notify,
+}
+
+struct QueueControlState {
+    concurrency: usize,
+    active: usize,
+    queue_state: QueueState,
+}
+
+pub struct QueuePermit {
+    control: Arc<QueueControl>,
+}
+
+impl std::fmt::Debug for QueuePermit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueuePermit").finish_non_exhaustive()
+    }
+}
+
+impl QueueControl {
+    fn new(config: QueueRuntimeConfig) -> Self {
+        Self {
+            inner: Mutex::new(QueueControlState {
+                concurrency: config.concurrency.unwrap_or(1),
+                active: 0,
+                queue_state: config.state,
+            }),
+            notify: Notify::new(),
+        }
+    }
+
+    pub async fn acquire(self: &Arc<Self>) -> QueuePermit {
+        loop {
+            let notified = self.notify.notified();
+            {
+                let mut state = self.lock_state();
+                if state.queue_state.is_active() && state.active < state.concurrency {
+                    state.active += 1;
+                    return QueuePermit {
+                        control: Arc::clone(self),
+                    };
+                }
+            }
+            notified.await;
+        }
+    }
+
+    pub fn apply_config(&self, config: QueueRuntimeConfig) {
+        {
+            let mut state = self.lock_state();
+            if let Some(concurrency) = config.concurrency {
+                state.concurrency = concurrency;
+            }
+            state.queue_state = config.state;
+        }
+        self.notify.notify_waiters();
+    }
+
+    fn active_count(&self) -> usize {
+        self.lock_state().active
+    }
+
+    fn release(&self) {
+        {
+            let mut state = self.lock_state();
+            state.active = state.active.saturating_sub(1);
+        }
+        self.notify.notify_waiters();
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, QueueControlState> {
+        self.inner.lock().unwrap_or_else(|err| err.into_inner())
+    }
+}
+
+impl Drop for QueuePermit {
+    fn drop(&mut self) {
+        self.control.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{Duration, timeout};
+
+    #[tokio::test]
+    async fn paused_control_blocks_until_active() {
+        let control = Arc::new(QueueControl::new(QueueRuntimeConfig {
+            concurrency: Some(1),
+            state: QueueState::Paused,
+        }));
+
+        assert!(
+            timeout(Duration::from_millis(20), control.acquire())
+                .await
+                .is_err()
+        );
+
+        control.apply_config(QueueRuntimeConfig::new(1));
+
+        assert!(
+            timeout(Duration::from_millis(20), control.acquire())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn reducing_concurrency_waits_for_active_permits_to_finish() {
+        let control = Arc::new(QueueControl::new(QueueRuntimeConfig::new(2)));
+
+        let first = control.acquire().await;
+        let second = control.acquire().await;
+
+        control.apply_config(QueueRuntimeConfig::new(1));
+
+        assert!(
+            timeout(Duration::from_millis(20), control.acquire())
+                .await
+                .is_err()
+        );
+
+        drop(second);
+        assert!(
+            timeout(Duration::from_millis(20), control.acquire())
+                .await
+                .is_err()
+        );
+
+        drop(first);
+        assert!(
+            timeout(Duration::from_millis(20), control.acquire())
+                .await
+                .is_ok()
+        );
     }
 }

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -7,7 +7,7 @@ use crate::{
         JobMetricsDetail, JobMetricsQuery, JobMetricsSnapshot, MetricIdentity,
         QueueLengthMetricsSnapshot,
     },
-    queue::Queue,
+    queue::{Queue, QueueConcurrency, QueueRuntimeConfig, QueueState},
     stats::{Process, QueueStats, Stats},
     storage_builder::StorageBuilder,
     storage_internal::StorageInternal,
@@ -321,6 +321,85 @@ impl Storage {
         self.internal.queue_length_metrics(query).await
     }
 
+    /// Returns the effective persisted runtime config for a queue, if one exists.
+    pub async fn queue_config(
+        &self,
+        queue: impl Queue,
+    ) -> Result<Option<QueueRuntimeConfig>, OxanaError> {
+        let queue_key = queue.key();
+        let concurrency = queue.config().concurrency;
+        Ok(self
+            .internal
+            .queue_config(&queue_key)
+            .await?
+            .map(|config| concurrency.effective_runtime_config(config)))
+    }
+
+    /// Returns persisted runtime configs for the provided queue keys.
+    pub async fn queue_configs(
+        &self,
+        queues: &[String],
+    ) -> Result<std::collections::HashMap<String, QueueRuntimeConfig>, OxanaError> {
+        self.internal.queue_configs(queues).await
+    }
+
+    /// Stores the full runtime config for a queue.
+    pub async fn set_queue_config(
+        &self,
+        queue: impl Queue,
+        config: &QueueRuntimeConfig,
+    ) -> Result<(), OxanaError> {
+        let queue_key = queue.key();
+        validate_runtime_concurrency(&queue_key, queue.config().concurrency, config)?;
+        self.internal.set_queue_config(&queue_key, config).await
+    }
+
+    /// Updates the runtime concurrency for a queue without restarting workers.
+    pub async fn set_queue_concurrency(
+        &self,
+        queue: impl Queue,
+        concurrency: usize,
+    ) -> Result<(), OxanaError> {
+        let queue_key = queue.key();
+        validate_dynamic_concurrency(&queue_key, queue.config().concurrency)?;
+        self.internal
+            .set_queue_concurrency(&queue_key, concurrency)
+            .await
+    }
+
+    /// Updates the runtime processing state for a queue.
+    pub async fn set_queue_state(
+        &self,
+        queue: impl Queue,
+        state: QueueState,
+    ) -> Result<(), OxanaError> {
+        let queue_key = queue.key();
+        let concurrency = queue.config().concurrency;
+        if concurrency.is_dynamic() {
+            return self.internal.set_queue_state(&queue_key, state).await;
+        }
+
+        let mut config = self
+            .internal
+            .queue_config(&queue_key)
+            .await?
+            .unwrap_or_default();
+        config.concurrency = None;
+        config.state = state;
+
+        self.internal.set_queue_config(&queue_key, &config).await
+    }
+
+    /// Pauses job processing for a queue. Enqueueing is not affected.
+    pub async fn pause_queue(&self, queue: impl Queue) -> Result<(), OxanaError> {
+        self.set_queue_state(queue, QueueState::Paused).await
+    }
+
+    /// Resumes job processing for a paused queue.
+    pub async fn unpause_queue(&self, queue: impl Queue) -> Result<(), OxanaError> {
+        self.set_queue_state(queue, QueueState::Active).await
+    }
+
     /// Returns the list of processes that are currently running.
     ///
     /// # Returns
@@ -461,5 +540,30 @@ impl Storage {
     pub async fn metrics(&self) -> Result<PrometheusMetrics, OxanaError> {
         let stats = self.stats().await?;
         Ok(PrometheusMetrics::from_stats(&stats))
+    }
+}
+
+fn validate_runtime_concurrency(
+    queue_key: &str,
+    concurrency: QueueConcurrency,
+    config: &QueueRuntimeConfig,
+) -> Result<(), OxanaError> {
+    if config.concurrency.is_some() {
+        validate_dynamic_concurrency(queue_key, concurrency)?;
+    }
+
+    Ok(())
+}
+
+fn validate_dynamic_concurrency(
+    queue_key: &str,
+    concurrency: QueueConcurrency,
+) -> Result<(), OxanaError> {
+    if concurrency.is_dynamic() {
+        Ok(())
+    } else {
+        Err(OxanaError::ConfigError(format!(
+            "Queue {queue_key} has fixed concurrency and cannot be overridden"
+        )))
     }
 }

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -354,6 +354,11 @@ impl Storage {
         self.internal.set_queue_config(&queue_key, config).await
     }
 
+    /// Removes any persisted runtime config for a queue.
+    pub async fn reset_queue_config(&self, queue: impl Queue) -> Result<(), OxanaError> {
+        self.internal.reset_queue_config(&queue.key()).await
+    }
+
     /// Updates the runtime concurrency for a queue without restarting workers.
     pub async fn set_queue_concurrency(
         &self,

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -7,7 +7,7 @@ use crate::{
         JobMetricsDetail, JobMetricsQuery, JobMetricsSnapshot, MetricIdentity,
         QueueLengthMetricsSnapshot,
     },
-    queue::{Queue, QueueConcurrency, QueueRuntimeConfig, QueueState},
+    queue::{Queue, QueueConcurrency, QueueKind, QueueRuntimeConfig, QueueState},
     stats::{Process, QueueStats, Stats},
     storage_builder::StorageBuilder,
     storage_internal::StorageInternal,
@@ -361,10 +361,46 @@ impl Storage {
         concurrency: usize,
     ) -> Result<(), OxanaError> {
         let queue_key = queue.key();
-        validate_dynamic_concurrency(&queue_key, queue.config().concurrency)?;
-        self.internal
-            .set_queue_concurrency(&queue_key, concurrency)
-            .await
+        let queue_config = queue.config();
+        let queue_concurrency = queue_config.concurrency;
+        validate_dynamic_concurrency(&queue_key, queue_concurrency)?;
+
+        let default_concurrency = self
+            .runtime_concurrency_reset_default(&queue_key, &queue_config.kind, queue_concurrency)
+            .await?;
+        let existing_config = self.internal.queue_config(&queue_key).await?;
+
+        if concurrency == default_concurrency && existing_config.is_none() {
+            return Ok(());
+        }
+
+        let mut config = existing_config.unwrap_or_default();
+        config.concurrency = (concurrency != default_concurrency).then_some(concurrency);
+
+        self.internal.set_queue_config(&queue_key, &config).await
+    }
+
+    async fn runtime_concurrency_reset_default(
+        &self,
+        queue_key: &str,
+        queue_kind: &QueueKind,
+        queue_concurrency: QueueConcurrency,
+    ) -> Result<usize, OxanaError> {
+        let configured_default = queue_concurrency.default_concurrency();
+        let QueueKind::Dynamic { prefix, .. } = queue_kind else {
+            return Ok(configured_default);
+        };
+
+        if queue_key == prefix {
+            return Ok(configured_default);
+        }
+
+        let base_config = self
+            .internal
+            .queue_config_or_default(prefix, queue_concurrency.stored_runtime_default())
+            .await?;
+
+        Ok(base_config.concurrency.unwrap_or(configured_default))
     }
 
     /// Updates the runtime processing state for a queue.

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -22,6 +22,7 @@ use crate::{
         histogram_bitfield_increment_args, histogram_buckets_from_counts, metric_minutes,
         queue_length_series_from_hashes, queue_metric_field,
     },
+    queue::{QueueRuntimeConfig, QueueState},
     result_collector::QueueResultStats,
     stats::{
         DynamicQueueStats, Process, QueueRateStats, QueueStats, Stats, StatsGlobal, StatsProcessing,
@@ -170,14 +171,126 @@ impl StorageInternal {
         Ok(keys.into_iter().collect())
     }
 
+    #[cfg(test)]
     pub async fn queue_keys(&self, pattern: &str) -> Result<HashSet<String>, OxanaError> {
         let mut conn = self.connection().await?;
         self.scan_keys_w_conn(&mut conn, &self.namespace_queue(pattern))
             .await
     }
 
-    #[allow(dead_code)]
-    async fn queues(&self, pattern: &str) -> Result<Vec<String>, OxanaError> {
+    pub async fn ensure_queue_config(
+        &self,
+        queue: &str,
+        default_config: QueueRuntimeConfig,
+    ) -> Result<QueueRuntimeConfig, OxanaError> {
+        let mut redis = self.connection().await?;
+        self.ensure_queue_config_w_conn(&mut redis, queue, default_config)
+            .await
+    }
+
+    async fn ensure_queue_config_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        queue: &str,
+        default_config: QueueRuntimeConfig,
+    ) -> Result<QueueRuntimeConfig, OxanaError> {
+        let inserted: bool = redis::cmd("HSETNX")
+            .arg(&self.keys.queue_configs)
+            .arg(queue)
+            .arg(serde_json::to_string(&default_config)?)
+            .query_async(redis)
+            .await?;
+
+        if inserted {
+            Ok(default_config)
+        } else {
+            let config = self.queue_config_w_conn(redis, queue).await?;
+            Ok(config
+                .map(|config| config.with_defaults(default_config.clone()))
+                .unwrap_or(default_config))
+        }
+    }
+
+    pub async fn queue_config(
+        &self,
+        queue: &str,
+    ) -> Result<Option<QueueRuntimeConfig>, OxanaError> {
+        let mut redis = self.connection().await?;
+        self.queue_config_w_conn(&mut redis, queue).await
+    }
+
+    async fn queue_config_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        queue: &str,
+    ) -> Result<Option<QueueRuntimeConfig>, OxanaError> {
+        let config: Option<String> = (*redis).hget(&self.keys.queue_configs, queue).await?;
+        config
+            .map(|config| serde_json::from_str(&config).map_err(OxanaError::from))
+            .transpose()
+    }
+
+    pub async fn queue_configs(
+        &self,
+        queues: &[String],
+    ) -> Result<HashMap<String, QueueRuntimeConfig>, OxanaError> {
+        if queues.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut redis = self.connection().await?;
+        let configs: Vec<Option<String>> = redis::cmd("HMGET")
+            .arg(&self.keys.queue_configs)
+            .arg(queues)
+            .query_async(&mut redis)
+            .await?;
+        let mut map = HashMap::new();
+
+        for (queue, config) in queues.iter().zip(configs) {
+            if let Some(config) = config {
+                map.insert(queue.clone(), serde_json::from_str(&config)?);
+            }
+        }
+
+        Ok(map)
+    }
+
+    pub async fn set_queue_config(
+        &self,
+        queue: &str,
+        config: &QueueRuntimeConfig,
+    ) -> Result<(), OxanaError> {
+        let mut redis = self.connection().await?;
+        let _: () = (*redis)
+            .hset(
+                &self.keys.queue_configs,
+                queue,
+                serde_json::to_string(config)?,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_queue_concurrency(
+        &self,
+        queue: &str,
+        concurrency: usize,
+    ) -> Result<(), OxanaError> {
+        let mut config = self
+            .queue_config(queue)
+            .await?
+            .unwrap_or_else(|| QueueRuntimeConfig::new(concurrency));
+        config.concurrency = Some(concurrency);
+        self.set_queue_config(queue, &config).await
+    }
+
+    pub async fn set_queue_state(&self, queue: &str, state: QueueState) -> Result<(), OxanaError> {
+        let mut config = self.queue_config(queue).await?.unwrap_or_default();
+        config.state = state;
+        self.set_queue_config(queue, &config).await
+    }
+
+    pub(crate) async fn queues(&self, pattern: &str) -> Result<Vec<String>, OxanaError> {
         let mut redis = self.connection().await?;
         self.queues_w_conn(&mut redis, pattern).await
     }
@@ -2289,6 +2402,69 @@ mod tests {
                 "prefix-a".to_string(),
             ]
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_queue_config_defaults_and_updates() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        let default_config = QueueRuntimeConfig::new(3);
+        let config = storage
+            .ensure_queue_config(&queue, default_config.clone())
+            .await?;
+        assert_eq!(config, default_config);
+
+        storage.set_queue_concurrency(&queue, 7).await?;
+        storage.set_queue_state(&queue, QueueState::Paused).await?;
+
+        let config = storage
+            .queue_config(&queue)
+            .await?
+            .expect("queue config should exist");
+        assert_eq!(config.concurrency, Some(7));
+        assert_eq!(config.state, QueueState::Paused);
+
+        let preserved = storage
+            .ensure_queue_config(&queue, QueueRuntimeConfig::new(1))
+            .await?;
+        assert_eq!(preserved.concurrency, Some(7));
+        assert_eq!(preserved.state, QueueState::Paused);
+
+        let configs = storage.queue_configs(std::slice::from_ref(&queue)).await?;
+        assert_eq!(configs.get(&queue), Some(&preserved));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_queue_state_update_without_config_does_not_store_concurrency() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+
+        storage.set_queue_state(&queue, QueueState::Paused).await?;
+
+        let stored = storage
+            .queue_config(&queue)
+            .await?
+            .expect("queue config should exist");
+        assert_eq!(stored.concurrency, None);
+        assert_eq!(stored.state, QueueState::Paused);
+
+        let runtime_config = storage
+            .ensure_queue_config(&queue, QueueRuntimeConfig::new(4))
+            .await?;
+        assert_eq!(runtime_config.concurrency, Some(4));
+        assert_eq!(runtime_config.state, QueueState::Paused);
+
+        let stored = storage
+            .queue_config(&queue)
+            .await?
+            .expect("queue config should still exist");
+        assert_eq!(stored.concurrency, None);
+        assert_eq!(stored.state, QueueState::Paused);
 
         Ok(())
     }

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -178,37 +178,26 @@ impl StorageInternal {
             .await
     }
 
-    pub async fn ensure_queue_config(
+    pub async fn queue_config_or_default(
         &self,
         queue: &str,
         default_config: QueueRuntimeConfig,
     ) -> Result<QueueRuntimeConfig, OxanaError> {
         let mut redis = self.connection().await?;
-        self.ensure_queue_config_w_conn(&mut redis, queue, default_config)
+        self.queue_config_or_default_w_conn(&mut redis, queue, default_config)
             .await
     }
 
-    async fn ensure_queue_config_w_conn(
+    async fn queue_config_or_default_w_conn(
         &self,
         redis: &mut deadpool_redis::Connection,
         queue: &str,
         default_config: QueueRuntimeConfig,
     ) -> Result<QueueRuntimeConfig, OxanaError> {
-        let inserted: bool = redis::cmd("HSETNX")
-            .arg(&self.keys.queue_configs)
-            .arg(queue)
-            .arg(serde_json::to_string(&default_config)?)
-            .query_async(redis)
-            .await?;
-
-        if inserted {
-            Ok(default_config)
-        } else {
-            let config = self.queue_config_w_conn(redis, queue).await?;
-            Ok(config
-                .map(|config| config.with_defaults(default_config.clone()))
-                .unwrap_or(default_config))
-        }
+        let config = self.queue_config_w_conn(redis, queue).await?;
+        Ok(config
+            .map(|config| config.with_defaults(default_config.clone()))
+            .unwrap_or(default_config))
     }
 
     pub async fn queue_config(
@@ -2413,9 +2402,23 @@ mod tests {
 
         let default_config = QueueRuntimeConfig::new(3);
         let config = storage
-            .ensure_queue_config(&queue, default_config.clone())
+            .queue_config_or_default(&queue, default_config.clone())
             .await?;
         assert_eq!(config, default_config);
+        assert_eq!(storage.queue_config(&queue).await?, None);
+        assert!(
+            storage
+                .queue_configs(std::slice::from_ref(&queue))
+                .await?
+                .is_empty()
+        );
+
+        let changed_default = storage
+            .queue_config_or_default(&queue, QueueRuntimeConfig::new(5))
+            .await?;
+        assert_eq!(changed_default.concurrency, Some(5));
+        assert_eq!(changed_default.state, QueueState::Active);
+        assert_eq!(storage.queue_config(&queue).await?, None);
 
         storage.set_queue_concurrency(&queue, 7).await?;
         storage.set_queue_state(&queue, QueueState::Paused).await?;
@@ -2428,7 +2431,7 @@ mod tests {
         assert_eq!(config.state, QueueState::Paused);
 
         let preserved = storage
-            .ensure_queue_config(&queue, QueueRuntimeConfig::new(1))
+            .queue_config_or_default(&queue, QueueRuntimeConfig::new(1))
             .await?;
         assert_eq!(preserved.concurrency, Some(7));
         assert_eq!(preserved.state, QueueState::Paused);
@@ -2454,7 +2457,7 @@ mod tests {
         assert_eq!(stored.state, QueueState::Paused);
 
         let runtime_config = storage
-            .ensure_queue_config(&queue, QueueRuntimeConfig::new(4))
+            .queue_config_or_default(&queue, QueueRuntimeConfig::new(4))
             .await?;
         assert_eq!(runtime_config.concurrency, Some(4));
         assert_eq!(runtime_config.state, QueueState::Paused);

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -260,19 +260,6 @@ impl StorageInternal {
         Ok(())
     }
 
-    pub async fn set_queue_concurrency(
-        &self,
-        queue: &str,
-        concurrency: usize,
-    ) -> Result<(), OxanaError> {
-        let mut config = self
-            .queue_config(queue)
-            .await?
-            .unwrap_or_else(|| QueueRuntimeConfig::new(concurrency));
-        config.concurrency = Some(concurrency);
-        self.set_queue_config(queue, &config).await
-    }
-
     pub async fn set_queue_state(&self, queue: &str, state: QueueState) -> Result<(), OxanaError> {
         let mut config = self.queue_config(queue).await?.unwrap_or_default();
         config.state = state;
@@ -2420,7 +2407,9 @@ mod tests {
         assert_eq!(changed_default.state, QueueState::Active);
         assert_eq!(storage.queue_config(&queue).await?, None);
 
-        storage.set_queue_concurrency(&queue, 7).await?;
+        storage
+            .set_queue_config(&queue, &QueueRuntimeConfig::new(7))
+            .await?;
         storage.set_queue_state(&queue, QueueState::Paused).await?;
 
         let config = storage

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -260,6 +260,12 @@ impl StorageInternal {
         Ok(())
     }
 
+    pub async fn reset_queue_config(&self, queue: &str) -> Result<(), OxanaError> {
+        let mut redis = self.connection().await?;
+        let _: () = (*redis).hdel(&self.keys.queue_configs, queue).await?;
+        Ok(())
+    }
+
     pub async fn set_queue_state(&self, queue: &str, state: QueueState) -> Result<(), OxanaError> {
         let mut config = self.queue_config(queue).await?.unwrap_or_default();
         config.state = state;
@@ -2427,6 +2433,9 @@ mod tests {
 
         let configs = storage.queue_configs(std::slice::from_ref(&queue)).await?;
         assert_eq!(configs.get(&queue), Some(&preserved));
+
+        storage.reset_queue_config(&queue).await?;
+        assert_eq!(storage.queue_config(&queue).await?, None);
 
         Ok(())
     }

--- a/oxana/src/storage_keys.rs
+++ b/oxana/src/storage_keys.rs
@@ -27,6 +27,9 @@ pub(crate) struct StorageKeys {
     /// Redis hash that stores per-queue counters (processed, succeeded, panicked,
     /// failed) keyed as `<queue_full_key>:<metric>`.
     pub(crate) stats: String,
+    /// Redis hash that stores serialized runtime queue configuration keyed by
+    /// queue name.
+    pub(crate) queue_configs: String,
     /// Prefix for Redis keys that store Sidekiq-style job execution metrics.
     pub(crate) metrics_prefix: String,
 }
@@ -52,6 +55,7 @@ impl StorageKeys {
             processes: format!("{namespace}:processes"),
             processes_data: format!("{namespace}:processes_data"),
             stats: format!("{namespace}:stats"),
+            queue_configs: format!("{namespace}:queue_configs"),
             metrics_prefix: format!("{namespace}:metrics"),
             namespace,
         }

--- a/oxana/src/storage_types.rs
+++ b/oxana/src/storage_types.rs
@@ -55,6 +55,8 @@ pub struct QueueInfo {
     pub dynamic: bool,
     /// The concurrency limit for this queue.
     pub concurrency: usize,
+    /// Whether queue concurrency can be changed at runtime.
+    pub dynamic_concurrency: bool,
     /// Throttle configuration, if any.
     pub throttle: Option<QueueThrottleInfo>,
 }

--- a/oxana/src/worker_event.rs
+++ b/oxana/src/worker_event.rs
@@ -1,7 +1,7 @@
-use tokio::sync::OwnedSemaphorePermit;
+use crate::semaphores_map::QueuePermit;
 
 #[derive(Debug)]
 pub struct WorkerJob {
     pub job_id: String,
-    pub permit: OwnedSemaphorePermit,
+    pub permit: QueuePermit,
 }

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -1,5 +1,6 @@
 use crate::shared::*;
 use deadpool_redis::redis::AsyncCommands;
+use std::time::Duration;
 use testresult::TestResult;
 
 #[tokio::test]
@@ -41,6 +42,75 @@ pub async fn test_standard() -> TestResult {
     assert_eq!(value, Some(random_value));
     assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
     assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_paused_queue_resumes_after_runtime_config_update() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = oxana::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    storage
+        .set_queue_state(QueueOne, oxana::QueueState::Paused)
+        .await?;
+
+    let config = oxana::Config::new(&storage)
+        .register_queue::<QueueOne>()
+        .register_worker::<WorkerRedisSet, WorkerRedisSetJob>()
+        .exit_when_processed(1);
+
+    let random_key = uuid::Uuid::new_v4().to_string();
+    let random_value = uuid::Uuid::new_v4().to_string();
+
+    storage
+        .enqueue(
+            QueueOne,
+            WorkerRedisSetJob {
+                key: random_key.clone(),
+                value: random_value.clone(),
+            },
+        )
+        .await?;
+
+    let handle = tokio::spawn(async move { oxana::run(config, ctx).await });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let value: Option<String> = redis_conn.get(&random_key).await?;
+    assert_eq!(value, None);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
+
+    storage.unpause_queue(QueueOne).await?;
+
+    tokio::time::timeout(Duration::from_secs(5), handle).await???;
+    let value: Option<String> = redis_conn.get(random_key).await?;
+
+    assert_eq!(value, Some(random_value));
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_fixed_queue_rejects_runtime_concurrency_override() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+
+    let error = storage
+        .set_queue_concurrency(QueueOne, 2)
+        .await
+        .expect_err("fixed queues should reject runtime concurrency overrides");
+
+    assert!(matches!(error, oxana::OxanaError::ConfigError(_)));
 
     Ok(())
 }

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -194,6 +194,12 @@ pub async fn test_dynamic_queue_unsets_runtime_concurrency_when_default_is_set()
     assert_eq!(config.concurrency, None);
     assert_eq!(config.state, oxana::QueueState::Paused);
 
+    storage.reset_queue_config(DynamicConcurrencyQueue).await?;
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&queue_key))
+        .await?;
+    assert!(configs.is_empty());
+
     Ok(())
 }
 

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -1,7 +1,41 @@
 use crate::shared::*;
 use deadpool_redis::redis::AsyncCommands;
+use oxana::Queue as _;
 use std::time::Duration;
 use testresult::TestResult;
+
+#[derive(serde::Serialize)]
+struct DynamicConcurrencyQueue;
+
+impl oxana::Queue for DynamicConcurrencyQueue {
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_static("dynamic_concurrency").dynamic_concurrency(3)
+    }
+}
+
+#[derive(serde::Serialize)]
+struct DynamicTenantBase;
+
+impl oxana::Queue for DynamicTenantBase {
+    fn key(&self) -> String {
+        "tenant".to_string()
+    }
+
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(3)
+    }
+}
+
+#[derive(serde::Serialize)]
+struct DynamicTenantQueue {
+    tenant: String,
+}
+
+impl oxana::Queue for DynamicTenantQueue {
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(3)
+    }
+}
 
 #[tokio::test]
 pub async fn test_standard() -> TestResult {
@@ -111,6 +145,103 @@ pub async fn test_fixed_queue_rejects_runtime_concurrency_override() -> TestResu
         .expect_err("fixed queues should reject runtime concurrency overrides");
 
     assert!(matches!(error, oxana::OxanaError::ConfigError(_)));
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_dynamic_queue_unsets_runtime_concurrency_when_default_is_set() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let queue_key = "dynamic_concurrency".to_string();
+
+    storage
+        .set_queue_concurrency(DynamicConcurrencyQueue, 3)
+        .await?;
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&queue_key))
+        .await?;
+    assert!(configs.is_empty());
+
+    storage
+        .set_queue_concurrency(DynamicConcurrencyQueue, 5)
+        .await?;
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&queue_key))
+        .await?;
+    assert_eq!(
+        configs
+            .get(&queue_key)
+            .and_then(|config| config.concurrency),
+        Some(5)
+    );
+
+    storage
+        .set_queue_state(DynamicConcurrencyQueue, oxana::QueueState::Paused)
+        .await?;
+    storage
+        .set_queue_concurrency(DynamicConcurrencyQueue, 3)
+        .await?;
+
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&queue_key))
+        .await?;
+    let config = configs
+        .get(&queue_key)
+        .expect("queue state should preserve runtime config");
+    assert_eq!(config.concurrency, None);
+    assert_eq!(config.state, oxana::QueueState::Paused);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_dynamic_child_queue_unsets_runtime_concurrency_when_inherited_default_is_set()
+-> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let child_queue = DynamicTenantQueue {
+        tenant: "acme".to_string(),
+    };
+    let child_queue_key = child_queue.key();
+
+    storage.set_queue_concurrency(DynamicTenantBase, 5).await?;
+    storage.set_queue_concurrency(child_queue, 5).await?;
+
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&child_queue_key))
+        .await?;
+    assert!(configs.is_empty());
+
+    let child_queue = DynamicTenantQueue {
+        tenant: "acme".to_string(),
+    };
+    storage.set_queue_concurrency(child_queue, 9).await?;
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&child_queue_key))
+        .await?;
+    assert_eq!(
+        configs
+            .get(&child_queue_key)
+            .and_then(|config| config.concurrency),
+        Some(9)
+    );
+
+    let child_queue = DynamicTenantQueue {
+        tenant: "acme".to_string(),
+    };
+    storage.set_queue_concurrency(child_queue, 5).await?;
+    let configs = storage
+        .queue_configs(std::slice::from_ref(&child_queue_key))
+        .await?;
+    let config = configs
+        .get(&child_queue_key)
+        .expect("child runtime config should remain after clearing override");
+    assert_eq!(config.concurrency, None);
 
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/pragmaplatform/oxana/issues/97

## Summary

- Add storage-level handling for dynamic concurrency defaults.
- Clear persisted concurrency overrides when the requested value matches the queue’s effective default.
- Treat a dynamic child queue’s effective default as the inherited base queue runtime concurrency.
- Add `reset_queue_config` for clearing persisted queue runtime config directly.
- Update the dynamic concurrency example to use `reset_queue_config`.
- Add dashboard support for changing dynamic concurrency from queue detail pages.
- Show runtime concurrency overrides in the dashboard with the default value struck through.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core queue dispatch/execution and Redis persistence by introducing runtime queue state/concurrency overrides and applying them live, which could impact throughput or stall processing if misapplied.
> 
> **Overview**
> Adds **runtime queue configuration** persisted in Redis (`QueueRuntimeConfig` with `QueueState` and optional concurrency) plus new `Storage` APIs to `pause_queue`/`unpause_queue`, set/reset queue config, and adjust *dynamic* queue concurrency while avoiding writes when values match the effective default.
> 
> Refactors queue concurrency to a `QueueConcurrency` enum (fixed vs dynamic default), updates the queue derive macro to support `#[oxana(concurrency = Dynamic(n))]`, and changes the coordinator/dispatcher to use per-queue `QueueControl` permits that can be reconfigured live via a periodic runtime-config watcher.
> 
> Updates the web dashboard to display queue state and concurrency overrides (with default struck through), adds queue detail actions to pause/unpause and change dynamic concurrency, and expands examples/tests (including dynamic tenant queues) to cover the new runtime controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54444f6c23a8005a92f3c256523e3d0055c5a255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->