### PR TITLE
Bump Oxana crates to 2.0.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.8"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.7"
+version = "2.0.0-rc.8"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.6", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.6", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.8", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.8", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.8"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.7"
+version = "2.0.0-rc.8"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.8"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -34,7 +34,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.6
+cargo add oxana@2.0.0-rc.8
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- Bump oxana and oxana-macros from 2.0.0-rc.6 to 2.0.0-rc.8
- Bump oxana-web from 2.0.0-rc.7 to 2.0.0-rc.8
- Refresh Cargo.lock and README install snippet for the aligned RC

## Test plan
- cargo check --all
- cargo test --all --no-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-alignment change limited to crate metadata/lockfile updates with no runtime code changes. Main risk is inadvertent dependency resolution/regression from the refreshed `Cargo.lock`.
> 
> **Overview**
> Bumps the workspace crates to `2.0.0-rc.8`, aligning `oxana`, `oxana-macros`, and `oxana-web` versions.
> 
> Updates `Cargo.toml`/crate manifests and refreshes `Cargo.lock`, and adjusts the `oxana` README install snippet to reference `2.0.0-rc.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c600cd7f9ed320b9dc292fd489ce2a90ac74eff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->