### PR TITLE
docs: add MIT license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add a root MIT license file and README license section.
 - Add batch workers with `#[oxana(batch_size = ..., batch_timeout_ms = ...)]`, `process_batch`, `BatchItem`, and `WorkerBatchConfig` for high-throughput workloads that can process jobs together.
 - Add on-demand jobs: annotate a job with `#[oxana(on_demand)]` to expose it in the web dashboard with editable JSON arguments and type-aware argument templates.
 - Add worker execution metrics, including per-minute success, failure, panic, execution-time, and histogram data through `Storage::job_metrics`, `Storage::job_metrics_for`, and the new `/metrics` dashboard pages.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Oxana contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -246,3 +246,7 @@ let output = metrics.encode_to_string()?;
 **rusty-sidekiq** is wire-compatible with Ruby Sidekiq, making it ideal for teams migrating from or coexisting with Ruby services. It can share queues with Ruby Sidekiq workers and use the existing Sidekiq web UI.
 
 **Fang** is SQL-database-backed (no Redis dependency) with both async and threaded execution modes. A good fit for projects that prefer Postgres/SQLite over Redis.
+
+## License
+
+Oxana is licensed under the MIT License.


### PR DESCRIPTION
## Summary

- Add a root `LICENSE` file with the standard MIT license text.
- Add a README license section for Oxana.
- Note the license documentation update in `CHANGELOG.md`.

## Test Coverage

Docs-only change. No new application code paths.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Plan Completion

No plan file detected.

## TODOs

No `TODOS.md` file exists in this repository.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --all`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --workspace` (152 passed, 3 ignored)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only licensing files; no application code or behavior changes.
> 
> **Overview**
> Adds formal **MIT** licensing for the repo: a root **`LICENSE`** with standard text (copyright **2026 Oxana contributors**), a **License** section in **`oxana/README.md`**, and a matching bullet under **`[2.0.0-rc]` → Added** in **`CHANGELOG.md`**.
> 
> No runtime, API, or dependency changes—documentation and legal clarity only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45efea2c41f5af053fee19c6f60ecfd55292b94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->