### PR TITLE
fix: prevent idle dispatchers from starving redis

### DIFF
--- a/oxana/src/coordinator.rs
+++ b/oxana/src/coordinator.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinSet;
@@ -33,6 +34,8 @@ where
     let (result_tx, result_rx) = mpsc::channel::<WorkerResult>(channel_capacity);
     let (job_tx, mut job_rx) = mpsc::channel::<WorkerJob>(channel_capacity);
     let (batch_error_tx, mut batch_error_rx) = mpsc::channel::<OxanaError>(channel_capacity);
+    let (queue_task_error_tx, mut queue_task_error_rx) =
+        mpsc::channel::<OxanaError>(channel_capacity);
     let queue_controls = Arc::new(QueueControlsMap::new());
     let mut joinset = JoinSet::new();
     let mut batchers: HashMap<BatchKey, mpsc::Sender<PendingJob>> = HashMap::new();
@@ -47,6 +50,7 @@ where
         queue_config.clone(),
         job_tx.clone(),
         Arc::clone(&queue_controls),
+        queue_task_error_tx,
     ));
 
     loop {
@@ -71,6 +75,17 @@ where
             batch_error = batch_error_rx.recv() => {
                 if let Some(error) = batch_error {
                     return Err(error);
+                }
+            }
+            queue_task_error = queue_task_error_rx.recv() => {
+                match queue_task_error {
+                    Some(error) => return Err(error),
+                    None if config.cancel_token.is_cancelled() => break,
+                    None => {
+                        return Err(OxanaError::GenericError(
+                            "Queue task monitor closed unexpectedly".to_string(),
+                        ));
+                    }
                 }
             }
             _ = config.cancel_token.cancelled() => {
@@ -615,6 +630,7 @@ async fn run_queue_watcher<DT, ET>(
     queue_config: QueueConfig,
     job_tx: mpsc::Sender<WorkerJob>,
     queue_controls: Arc<QueueControlsMap>,
+    queue_task_error_tx: mpsc::Sender<OxanaError>,
 ) -> Result<(), OxanaError>
 where
     DT: Send + Sync + Clone + 'static,
@@ -662,39 +678,35 @@ where
             let watcher_control = Arc::clone(&queue_control);
             let watcher_base_queue_key = base_queue_key.clone();
             let watcher_default_runtime_config = default_runtime_config.clone();
-            tokio::spawn(async move {
-                if let Err(e) = run_queue_config_watcher(
+            spawn_queue_task(
+                "queue config watcher",
+                queue_task_error_tx.clone(),
+                run_queue_config_watcher(
                     watcher_config,
                     watcher_queue,
                     watcher_base_queue_key,
                     watcher_default_runtime_config,
                     queue_concurrency,
                     watcher_control,
-                )
-                .await
-                {
-                    tracing::error!(error = %e, "Queue config watcher exited with error");
-                }
-            });
+                ),
+            );
 
             let dispatcher_config = Arc::clone(&config);
             let dispatcher_queue_config = queue_config.clone();
             let dispatcher_job_tx = job_tx.clone();
             let dispatcher_queue_control = Arc::clone(&queue_control);
             let dispatcher_queue = queue.clone();
-            tokio::spawn(async move {
-                if let Err(e) = dispatcher::run(
+            spawn_queue_task(
+                "dispatcher",
+                queue_task_error_tx.clone(),
+                dispatcher::run(
                     dispatcher_config,
                     dispatcher_queue_config,
                     dispatcher_queue,
                     dispatcher_job_tx,
                     dispatcher_queue_control,
-                )
-                .await
-                {
-                    tracing::error!(error = %e, "Dispatcher exited with error");
-                }
-            });
+                ),
+            );
 
             tracked_queues.insert(queue);
         }
@@ -707,6 +719,18 @@ where
             return Ok(());
         }
     }
+}
+
+fn spawn_queue_task<F>(task: &'static str, error_tx: mpsc::Sender<OxanaError>, future: F)
+where
+    F: Future<Output = Result<(), OxanaError>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        if let Err(error) = future.await {
+            tracing::error!(task, error = %error, "Queue task exited with error");
+            let _ = error_tx.try_send(error);
+        }
+    });
 }
 
 async fn runtime_queue_config<DT, ET>(
@@ -811,14 +835,14 @@ async fn wait_for_workers_to_finish<DT, ET>(
 
 #[cfg(test)]
 mod tests {
-    use super::{PendingJob, process_pending_batch};
+    use super::{PendingJob, process_pending_batch, spawn_queue_task};
     use crate::QueueRuntimeConfig;
     use crate::semaphores_map::QueueControlsMap;
     use crate::test_helper::{random_string, redis_pool};
     use crate::worker_registry::{self, BatchBuild, InvalidBatchJob, WorkerConfigKind};
     use crate::{Config, ContextValue, Job, JobEnvelope, Storage, Worker, WorkerConfig};
     use serde::{Deserialize, Serialize};
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
     use testresult::TestResult;
     use tokio::sync::mpsc;
 
@@ -923,6 +947,28 @@ mod tests {
 
         assert_eq!(storage.dead_count().await?, 2);
         assert_eq!(storage.jobs_count().await?, 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn queue_task_errors_are_forwarded() -> TestResult {
+        let (error_tx, mut error_rx) = mpsc::channel(1);
+
+        spawn_queue_task("test queue task", error_tx, async {
+            Err(crate::OxanaError::GenericError(
+                "dispatcher failed".to_string(),
+            ))
+        });
+
+        let error = tokio::time::timeout(Duration::from_secs(1), error_rx.recv())
+            .await?
+            .expect("queue task error should be forwarded");
+
+        assert!(matches!(
+            error,
+            crate::OxanaError::GenericError(message) if message == "dispatcher failed"
+        ));
 
         Ok(())
     }

--- a/oxana/src/dispatcher.rs
+++ b/oxana/src/dispatcher.rs
@@ -77,7 +77,11 @@ async fn pop_queue_message_wo_throttle(
     queue_key: &str,
     timeout: f64,
 ) -> Result<Option<JobId>, OxanaError> {
-    storage.blocking_dequeue(queue_key, timeout).await
+    let job_id = storage.dequeue(queue_key).await?;
+    if job_id.is_none() {
+        sleep(Duration::from_secs_f64(timeout)).await;
+    }
+    Ok(job_id)
 }
 
 async fn pop_queue_message_w_throttle(
@@ -106,4 +110,53 @@ async fn pop_queue_message_w_throttle(
     ))
     .await;
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use testresult::TestResult;
+    use tokio::sync::mpsc;
+
+    use super::run;
+    use crate::semaphores_map::QueueControlsMap;
+    use crate::test_helper::random_string;
+    use crate::worker_event::WorkerJob;
+    use crate::{Config, QueueConfig, QueueRuntimeConfig, Storage, StorageBuilderTimeouts};
+
+    #[tokio::test]
+    async fn idle_dispatcher_does_not_hold_pool_connection() -> TestResult {
+        dotenvy::from_filename(".env.test").ok();
+        let redis_url = std::env::var("REDIS_URL")?;
+        let queue = random_string();
+        let storage = Storage::builder()
+            .namespace(random_string())
+            .max_pool_size(1)
+            .timeouts(StorageBuilderTimeouts::new(Duration::from_millis(50)))
+            .build_from_redis_url(redis_url)?;
+        let config = Arc::new(Config::<(), std::io::Error>::new(&storage));
+        let (job_tx, _job_rx) = mpsc::channel::<WorkerJob>(1);
+        let queue_controls = QueueControlsMap::new();
+        let queue_control = queue_controls
+            .get_or_create(queue.clone(), QueueRuntimeConfig::new(1))
+            .await;
+
+        let handle = tokio::spawn(run(
+            Arc::clone(&config),
+            QueueConfig::as_static(&queue),
+            queue.clone(),
+            job_tx,
+            queue_control,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(storage.internal.enqueued_count(&queue).await?, 0);
+
+        config.cancel_token.cancel();
+        tokio::time::timeout(Duration::from_secs(2), handle).await???;
+
+        Ok(())
+    }
 }

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -459,24 +459,6 @@ impl StorageInternal {
         Ok(())
     }
 
-    pub async fn blocking_dequeue(
-        &self,
-        queue: &str,
-        timeout: f64,
-    ) -> Result<Option<JobId>, OxanaError> {
-        let mut redis = self.connection().await?;
-        let job_id: Option<String> = redis
-            .blmove(
-                self.namespace_queue(queue),
-                self.current_processing_queue(),
-                redis::Direction::Right,
-                redis::Direction::Left,
-                timeout,
-            )
-            .await?;
-        Ok(job_id)
-    }
-
     pub async fn dequeue(&self, queue: &str) -> Result<Option<JobId>, OxanaError> {
         let mut redis = self.connection().await?;
         let job_id: Option<JobId> = redis


### PR DESCRIPTION
## Summary
- replace idle unthrottled queue polling with nonblocking dequeue plus sleep so empty queues do not hold Redis pool connections
- forward dispatcher and queue config watcher errors back to the coordinator so queue task failures surface and the worker can restart
- remove the now-unused blocking dequeue path and add regressions for pool starvation and error forwarding

## Production Evidence
- Render `firstlook-api-worker` logged Redis pool timeouts at 2026-05-29T17:35:41Z with `consecutive_failures` reaching 33
- queue config watchers exited with Deadpool pool timeout errors while the Render instance count stayed at 1
- no `playergg_firstlook_games_index` jobs started after that failure window in the queried log range

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --all`
- `cargo clippy --all-features --workspace`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core queue polling and coordinator lifecycle for dispatchers/watchers; mitigates production pool timeouts but alters failure and restart behavior for workers.
> 
> **Overview**
> Fixes **Redis pool starvation** on idle queues by replacing blocking dequeue (`BLMOVE` with timeout) with a quick **`lmove`** plus sleep when the queue is empty, so dispatchers no longer hold connections while waiting. **`blocking_dequeue`** is removed from storage.
> 
> **Queue task failures** (dispatcher and queue config watcher) are no longer only logged: a shared **`spawn_queue_task`** helper sends errors on a channel, and the coordinator **`select!`** returns **`Err`** so the worker process can restart instead of running with dead background tasks.
> 
> Regression tests cover error forwarding and a size-1 pool with a short timeout while the dispatcher idles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367f25f14da45d489b2c0b9c34fd59d5af4f1703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->