### PR TITLE
chore: bump crates to 2.0.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.8", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.8", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.9", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.9", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxana, oxana-macros, and oxana-web to 2.0.0-rc.9.
- Update workspace dependency pins and Cargo.lock package versions.

## Verification
- cargo test: 104 passed (3 suites, 26.32s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or API code in the diff.
> 
> **Overview**
> Bumps the workspace release candidate from **2.0.0-rc.8** to **2.0.0-rc.9** for `oxana`, `oxana-macros`, and `oxana-web`.
> 
> Updates each crate’s `[package].version`, the `[workspace.dependencies]` version pins in the root `Cargo.toml`, and the corresponding entries in `Cargo.lock`. No application or library source changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0435a4cb0b841d58173002af2599fa5eedd68530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->