### PR TITLE
fix: clear retry state on unique replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Avoid persisting runtime queue config when a queue is only using its default configuration.
+- Clear stale retry and schedule membership when replacing a unique job so the old retry attempt cannot run after the replacement resets the retry counter.
 
 ## [1.1.1]
 

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -50,7 +50,7 @@ pub(crate) struct StorageInternal {
 enum JobEnqueueAction {
     Default,
     Skip,
-    Replace,
+    Replace { existing_queue: String },
 }
 
 #[derive(Default)]
@@ -310,16 +310,10 @@ impl StorageInternal {
 
                 return Ok(envelope.id);
             }
-            JobEnqueueAction::Replace => {
+            JobEnqueueAction::Replace { existing_queue } => {
                 tracing::warn!("Unique job {} already exists, replacing", envelope.id);
 
-                let _: () = deadpool_redis::redis::pipe()
-                    .hset(
-                        &self.keys.jobs,
-                        &envelope.id,
-                        serde_json::to_string(&envelope)?,
-                    )
-                    .query_async(&mut *redis)
+                self.replace_enqueued_w_conn(redis, &existing_queue, &envelope)
                     .await?;
             }
             JobEnqueueAction::Default => {
@@ -352,11 +346,80 @@ impl StorageInternal {
         if exists {
             match envelope.meta.on_conflict {
                 Some(JobConflictStrategy::Skip) | None => Ok(JobEnqueueAction::Skip),
-                Some(JobConflictStrategy::Replace) => Ok(JobEnqueueAction::Replace),
+                Some(JobConflictStrategy::Replace) => {
+                    match self.get_job_w_conn(redis, &envelope.id).await? {
+                        Some(existing) => Ok(JobEnqueueAction::Replace {
+                            existing_queue: existing.queue,
+                        }),
+                        None => Ok(JobEnqueueAction::Default),
+                    }
+                }
             }
         } else {
             Ok(JobEnqueueAction::Default)
         }
+    }
+
+    async fn replace_enqueued_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        existing_queue: &str,
+        envelope: &JobEnvelope,
+    ) -> Result<(), OxanaError> {
+        let old_queue = self.namespace_queue(existing_queue);
+        let new_queue = self.namespace_queue(&envelope.queue);
+
+        let mut pipe = redis::pipe();
+        pipe.hset(
+            &self.keys.jobs,
+            &envelope.id,
+            serde_json::to_string(envelope)?,
+        )
+        .zrem(&self.keys.schedule, &envelope.id)
+        .zrem(&self.keys.retry, &envelope.id)
+        .lrem(old_queue, 0, &envelope.id);
+
+        if existing_queue != envelope.queue.as_str() {
+            pipe.lrem(new_queue.clone(), 0, &envelope.id);
+        }
+
+        pipe.lpush(new_queue, &envelope.id);
+
+        let _: () = pipe.query_async(&mut *redis).await?;
+        Ok(())
+    }
+
+    async fn replace_scheduled_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        existing_queue: &str,
+        envelope: &JobEnvelope,
+    ) -> Result<(), OxanaError> {
+        let old_queue = self.namespace_queue(existing_queue);
+        let new_queue = self.namespace_queue(&envelope.queue);
+
+        let mut pipe = redis::pipe();
+        pipe.hset(
+            &self.keys.jobs,
+            &envelope.id,
+            serde_json::to_string(envelope)?,
+        )
+        .zrem(&self.keys.schedule, &envelope.id)
+        .zrem(&self.keys.retry, &envelope.id)
+        .lrem(old_queue, 0, &envelope.id);
+
+        if existing_queue != envelope.queue.as_str() {
+            pipe.lrem(new_queue, 0, &envelope.id);
+        }
+
+        pipe.zadd(
+            &self.keys.schedule,
+            &envelope.id,
+            envelope.meta.scheduled_at,
+        );
+
+        let _: () = pipe.query_async(&mut *redis).await?;
+        Ok(())
     }
 
     pub async fn enqueue_in(
@@ -385,21 +448,10 @@ impl StorageInternal {
 
                 return Ok(envelope.id);
             }
-            JobEnqueueAction::Replace => {
+            JobEnqueueAction::Replace { existing_queue } => {
                 tracing::warn!("Unique job {} already exists, replacing", envelope.id);
 
-                let _: () = redis::pipe()
-                    .hset(
-                        &self.keys.jobs,
-                        &envelope.id,
-                        serde_json::to_string(&envelope)?,
-                    )
-                    .zadd(
-                        &self.keys.schedule,
-                        &envelope.id,
-                        envelope.meta.scheduled_at,
-                    )
-                    .query_async(&mut redis)
+                self.replace_scheduled_w_conn(&mut redis, &existing_queue, &envelope)
                     .await?;
             }
             JobEnqueueAction::Default => {

--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -110,6 +110,54 @@ impl oxana::Worker<WorkerUniqueReplaceJob> for WorkerUniqueReplace {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkerUniqueReplaceRetryJob {
+    pub id: i32,
+    pub marker: i32,
+}
+
+pub struct WorkerUniqueReplaceRetry;
+
+impl oxana::Job for WorkerUniqueReplaceRetryJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<WorkerUniqueReplaceRetry>()
+    }
+
+    fn unique_id(&self) -> Option<String> {
+        Some(format!("unique:{}", self.id))
+    }
+
+    fn on_conflict(&self) -> oxana::JobConflictStrategy {
+        oxana::JobConflictStrategy::Replace
+    }
+}
+
+impl oxana::FromContext<WorkerState> for WorkerUniqueReplaceRetry {
+    fn from_context(_ctx: &WorkerState) -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<WorkerUniqueReplaceRetryJob> for WorkerUniqueReplaceRetry {
+    type Error = WorkerError;
+
+    async fn run_batch(
+        &self,
+        _jobs: Vec<oxana::BatchItem<WorkerUniqueReplaceRetryJob>>,
+    ) -> Result<(), WorkerError> {
+        Err(WorkerError::Generic("retry later".to_string()))
+    }
+
+    fn retry_delay(&self, _job: &WorkerUniqueReplaceRetryJob, _retries: u32) -> u64 {
+        60
+    }
+
+    fn max_retries(&self, _job: &WorkerUniqueReplaceRetryJob) -> u32 {
+        1
+    }
+}
+
 #[tokio::test]
 pub async fn test_unique_skip() -> TestResult {
     let redis_pool = setup();
@@ -180,6 +228,69 @@ pub async fn test_unique_skip() -> TestResult {
     assert_eq!(value, Some(1));
     let value: Option<i32> = redis_conn.get(key2).await?;
     assert_eq!(value, Some(3));
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_unique_replace_clears_stale_retry_entry() -> TestResult {
+    let redis_pool = setup();
+    let ctx = oxana::ContextValue::new(WorkerState {
+        redis: redis_pool.clone(),
+    });
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let config = oxana::Config::new(&storage)
+        .register_queue::<QueueOne>()
+        .register_worker::<WorkerUniqueReplaceRetry, WorkerUniqueReplaceRetryJob>()
+        .exit_when_processed(1);
+
+    let job_id = storage
+        .enqueue(QueueOne, WorkerUniqueReplaceRetryJob { id: 1, marker: 1 })
+        .await?;
+
+    oxana::run(config, ctx).await?;
+
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.retries_count().await?, 1);
+
+    let retry_jobs = storage
+        .list_retries(&oxana::QueueListOpts {
+            count: 10,
+            offset: 0,
+        })
+        .await?;
+    let retried = retry_jobs
+        .iter()
+        .find(|job| job.id == job_id)
+        .expect("job should be pending retry");
+    assert_eq!(retried.meta.retries, 1);
+
+    storage
+        .enqueue(QueueOne, WorkerUniqueReplaceRetryJob { id: 1, marker: 2 })
+        .await?;
+
+    assert_eq!(storage.retries_count().await?, 0);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
+
+    let replacement = storage
+        .get_job(&job_id)
+        .await?
+        .expect("replacement should still exist");
+    assert_eq!(replacement.meta.retries, 0);
+    assert_eq!(
+        replacement.job.args.get("marker"),
+        Some(&serde_json::json!(2))
+    );
+
+    let retry_jobs = storage
+        .list_retries(&oxana::QueueListOpts {
+            count: 10,
+            offset: 0,
+        })
+        .await?;
+    assert!(retry_jobs.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Clear stale retry and schedule membership when replacing an existing unique job.
- Re-enqueue or reschedule the replacement as a fresh job with `meta.retries = 0`.
- Add a regression test for replacing a unique job while it is pending retry.
- Update the changelog for the 2.0 release candidate.

## Verification

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --all-features --workspace --all-targets -- -D warnings`
- `cargo check --all`

## Notes

Replacing a retrying unique job now nukes the old retry path. The old retry ZSET entry is removed, so it cannot wake up later and run after replacement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Redis enqueue/replace semantics for unique jobs in core storage; incorrect cleanup could drop or duplicate work, but scope is narrow and covered by a new integration test.
> 
> **Overview**
> Fixes **unique job replace** so a replacement is a clean enqueue, not a partial metadata overwrite.
> 
> When `JobConflictStrategy::Replace` hits an existing job, storage now loads the **previous queue**, then runs dedicated replace paths for immediate enqueue and `enqueue_at`. Those pipelines update the job hash, **remove the job from retry and schedule ZSETs**, strip it from the old (and if needed new) queue list, and place it on the target queue or schedule—so a job sitting in **retry** cannot fire again after replace.
> 
> A new integration test covers replacing a unique job while it is pending retry; the changelog notes the fix for the 2.0 RC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a7d05ea667aa3cad1839138b15f7d96e80cdfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->