### PR TITLE
fix: correct dashboard job timing and links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
  "urlencoding",
  "uuid",
 ]

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -33,3 +33,4 @@ oxana = { path = "../oxana", default-features = false, features = [
 serde = { version = "^1.0", features = ["derive"] }
 thiserror = "^2.0"
 tokio = { version = "^1.52", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }

--- a/oxana-web/src/filters.rs
+++ b/oxana-web/src/filters.rs
@@ -241,11 +241,12 @@ fn should_show_progress(val: &serde_json::Value) -> bool {
 
 fn progress_eta_s(
     val: &serde_json::Value,
-    scheduled_at_micros: i64,
+    started_at_micros: Option<i64>,
     now_micros: i64,
 ) -> Option<f64> {
     let progress = progress_parts(val)?;
-    if progress.total <= 0 || progress.cursor <= 0 || scheduled_at_micros <= 0 {
+    let started_at_micros = started_at_micros?;
+    if progress.total <= 0 || progress.cursor <= 0 || started_at_micros <= 0 {
         return None;
     }
 
@@ -254,7 +255,7 @@ fn progress_eta_s(
         return Some(0.0);
     }
 
-    let elapsed_s = (now_micros - scheduled_at_micros) as f64 / 1_000_000.0;
+    let elapsed_s = (now_micros - started_at_micros) as f64 / 1_000_000.0;
     if elapsed_s <= 0.0 {
         return None;
     }
@@ -329,11 +330,11 @@ pub fn job_progress_note(
 pub fn job_progress_eta(
     val: &serde_json::Value,
     _env: &dyn askama::Values,
-    scheduled_at_micros: &i64,
+    started_at_micros: &Option<i64>,
 ) -> askama::Result<String> {
     Ok(progress_eta_s(
         val,
-        *scheduled_at_micros,
+        *started_at_micros,
         chrono::Utc::now().timestamp_micros(),
     )
     .map(format_duration_from_secs)
@@ -461,13 +462,29 @@ mod tests {
     }
 
     #[test]
-    fn progress_eta_uses_scheduled_time_and_progress_rate() {
+    fn progress_eta_uses_started_time_and_progress_rate() {
         let state = json!({
             "cursor": 25,
             "total": 100
         });
 
-        assert_eq!(progress_eta_s(&state, 1_000_000, 11_000_000), Some(30.0));
+        assert_eq!(
+            progress_eta_s(&state, Some(9_000_000), 19_000_000),
+            Some(30.0)
+        );
+    }
+
+    #[test]
+    fn progress_eta_ignores_time_spent_waiting_in_queue() {
+        let state = json!({
+            "cursor": 25,
+            "total": 100
+        });
+
+        assert_eq!(
+            progress_eta_s(&state, Some(43_201_000_000), 43_211_000_000),
+            Some(30.0)
+        );
     }
 
     #[test]
@@ -478,22 +495,22 @@ mod tests {
                     "cursor": 0,
                     "total": 100
                 }),
-                1_000_000,
+                Some(1_000_000),
                 11_000_000
             ),
             None
         );
-        assert_eq!(progress_eta_s(&json!([25, 100]), 0, 11_000_000), None);
+        assert_eq!(progress_eta_s(&json!([25, 100]), None, 11_000_000), None);
     }
 
     #[test]
     fn progress_eta_is_zero_when_complete() {
         assert_eq!(
-            progress_eta_s(&json!([100, 100]), 1_000_000, 11_000_000),
+            progress_eta_s(&json!([100, 100]), Some(1_000_000), 11_000_000),
             Some(0.0)
         );
         assert_eq!(
-            progress_eta_s(&json!([125, 100]), 1_000_000, 11_000_000),
+            progress_eta_s(&json!([125, 100]), Some(1_000_000), 11_000_000),
             Some(0.0)
         );
     }

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -143,13 +143,9 @@ pub(crate) async fn enqueue_cron_job(
     Form(form): Form<CronEnqueueJobForm>,
 ) -> Result<Redirect, OxanaWebError> {
     let envelope = cron_envelope_from_form(&state.catalog, &form)?;
-
     state.storage.enqueue_envelope(envelope).await?;
 
-    Ok(Redirect::to(&format!(
-        "{}/cron?enqueued=1",
-        state.base_path
-    )))
+    Ok(cron_enqueued_redirect(&state.base_path))
 }
 
 pub(crate) async fn on_demand_jobs(
@@ -999,6 +995,10 @@ fn parse_optional_json(
         .transpose()
 }
 
+fn cron_enqueued_redirect(base_path: &str) -> Redirect {
+    Redirect::to(&format!("{base_path}/cron?enqueued=1"))
+}
+
 fn immediate_envelope(
     queue: String,
     name: String,
@@ -1169,9 +1169,10 @@ fn build_on_demand_queue_views(queues: &[oxana::QueueInfo]) -> Vec<OnDemandQueue
 mod tests {
     use super::{
         CronEnqueueJobForm, OnDemandEnqueueJobForm, RawQueue, build_on_demand_queue_views,
-        cron_envelope_from_form, enqueue_on_demand_job, on_demand_envelope_from_form,
-        queue_concurrency_status_from_map, queue_runtime_config_from_map,
-        queue_runtime_config_view_from_map, sort_queues, sorted_worker_metrics,
+        cron_enqueued_redirect, cron_envelope_from_form, enqueue_on_demand_job,
+        on_demand_envelope_from_form, queue_concurrency_status_from_map,
+        queue_runtime_config_from_map, queue_runtime_config_view_from_map, sort_queues,
+        sorted_worker_metrics,
     };
     use crate::OxanaWebState;
     use crate::templates::{QueueConcurrencyStatus, QueueRuntimeConfigView};
@@ -1618,6 +1619,18 @@ mod tests {
         assert!(envelope.meta.on_conflict.is_none());
         assert!(!envelope.meta.resurrect);
         assert_eq!(envelope.meta.scheduled_at, envelope.meta.created_at);
+    }
+
+    #[test]
+    fn cron_enqueue_redirects_to_cron_notice() {
+        let redirect = cron_enqueued_redirect("/admin");
+        let response = redirect.into_response();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/admin/cron?enqueued=1"
+        );
     }
 
     #[test]

--- a/oxana-web/src/lib.rs
+++ b/oxana-web/src/lib.rs
@@ -43,7 +43,7 @@ pub fn router(state: OxanaWebState) -> Router {
         .route("/dead", get(handlers::dead_jobs))
         .route("/dead/wipe", post(handlers::wipe_dead))
         .route("/retries", get(handlers::retry_jobs))
-        .route("/jobs/{job_id}", get(handlers::job_detail))
+        .route("/jobs/{*job_id}", get(handlers::job_detail))
         .route("/queues/{queue_key}", get(handlers::queue_detail))
         .route("/enqueue", post(handlers::enqueue_job))
         .route("/queues/{queue_key}/pause", post(handlers::pause_queue))
@@ -58,4 +58,64 @@ pub fn router(state: OxanaWebState) -> Router {
             post(handlers::delete_job),
         )
         .layer(Extension(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        extract::Path,
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn job_detail_route_captures_slash_job_ids() {
+        let app = Router::new().route(
+            "/jobs/{*job_id}",
+            get(|Path(job_id): Path<String>| async move { job_id }),
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/jobs/crate%3A%3AWorker%2Ftype-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"crate::Worker/type-123");
+    }
+
+    #[tokio::test]
+    async fn delete_job_route_captures_strictly_encoded_slash_job_ids() {
+        let app = Router::new().route(
+            "/queues/{queue_key}/jobs/{job_id}/delete",
+            get(
+                |Path((queue_key, job_id)): Path<(String, String)>| async move {
+                    format!("{queue_key}:{job_id}")
+                },
+            ),
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/queues/default/jobs/crate%3A%3AWorker%2Ftype-123/delete")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"default:crate::Worker/type-123");
+    }
 }

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -1099,15 +1099,19 @@ mod job_card_tests {
     use serde_json::json;
 
     fn job_envelope(args: serde_json::Value) -> oxana::JobEnvelope {
+        job_envelope_with_id("job-1", args)
+    }
+
+    fn job_envelope_with_id(id: &str, args: serde_json::Value) -> oxana::JobEnvelope {
         oxana::JobEnvelope {
-            id: "job-1".to_string(),
+            id: id.to_string(),
             queue: "default".to_string(),
             job: oxana::JobData {
                 name: "crate::ImportGame".to_string(),
                 args,
             },
             meta: oxana::JobMeta {
-                id: "job-1".to_string(),
+                id: id.to_string(),
                 retries: 0,
                 unique: false,
                 on_conflict: None,
@@ -1172,6 +1176,23 @@ mod job_card_tests {
                 "<summary class=\"text-xs text-gray-500 cursor-pointer hover:text-gray-300\">Arguments</summary>"
             )
         );
+    }
+
+    #[test]
+    fn global_job_cards_encode_slashes_in_job_links() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            jobs: vec![job_envelope_with_id("crate::Worker/type-123", json!({}))],
+            page: 1,
+            total: 1,
+            has_next: false,
+        };
+
+        let rendered = template.render().unwrap();
+
+        assert!(rendered.contains("href=\"/admin/jobs/crate%3A%3AWorker%2Ftype-123\""));
     }
 }
 

--- a/oxana-web/templates/_job_progress.html
+++ b/oxana-web/templates/_job_progress.html
@@ -8,7 +8,7 @@
         </div>
         <div class="shrink-0 text-right">
             <div class="text-sm font-semibold text-cyan-200">{{ state|job_progress_percent }}%</div>
-            <div class="mt-1 text-[11px] text-cyan-200/70">ETA {{ state|job_progress_eta(progress_scheduled_at) }}</div>
+            <div class="mt-1 text-[11px] text-cyan-200/70">ETA {{ state|job_progress_eta(progress_started_at) }}</div>
         </div>
     </div>
     <div class="mt-3 h-2 overflow-hidden rounded-full bg-gray-800">

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -116,7 +116,7 @@
                             <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
                             <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
                         </div>
-                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
+                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode_strict }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
                     </div>
                     <div class="grid grid-cols-1 sm:grid-cols-5 gap-2 text-xs text-gray-400 mt-2">
                         <div>
@@ -154,7 +154,7 @@
                     {% when Some with (state) %}
                     {% if state|has_args %}
                     {% if state|show_job_progress %}
-                    {% let progress_scheduled_at = item.job_envelope.meta.scheduled_at %}
+                    {% let progress_started_at = item.job_envelope.meta.started_at %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <div class="mt-3">
@@ -168,7 +168,7 @@
                     {% when None %}
                     {% endmatch %}
                     <div class="mt-3 flex justify-end">
-                        <form method="POST" action="{{ base_path }}/queues/{{ item.job_envelope.queue|urlencode }}/jobs/{{ item.job_envelope.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
+                        <form method="POST" action="{{ base_path }}/queues/{{ item.job_envelope.queue|urlencode }}/jobs/{{ item.job_envelope.id|urlencode_strict }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
                             <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
                         </form>
                     </div>

--- a/oxana-web/templates/global_jobs.html
+++ b/oxana-web/templates/global_jobs.html
@@ -56,7 +56,7 @@
                         <span class="inline-block w-2 h-2 rounded-full {{ kind.dot_class() }}"></span>
                         <span class="font-semibold text-sm">{{ job.job.name }}</span>
                     </div>
-                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
+                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode_strict }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
                     <div>
@@ -102,7 +102,7 @@
                 {% when Some with (state) %}
                 {% if state|has_args %}
                 {% if state|show_job_progress %}
-                {% let progress_scheduled_at = job.meta.scheduled_at %}
+                {% let progress_started_at = job.meta.started_at %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">

--- a/oxana-web/templates/job_detail.html
+++ b/oxana-web/templates/job_detail.html
@@ -81,7 +81,7 @@
             {% match job.meta.state %}
             {% when Some with (state) %}
             {% if state|show_job_progress %}
-            {% let progress_scheduled_at = job.meta.scheduled_at %}
+            {% let progress_started_at = job.meta.started_at %}
             {% include "_job_progress.html" %}
             {% else %}
             <details class="mt-3" open>

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -113,7 +113,7 @@
                             <span class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
                             <span class="font-semibold text-sm">{{ item.job_envelope.job.name }}</span>
                         </div>
-                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
+                        <a href="{{ base_path }}/jobs/{{ item.job_envelope.id|urlencode_strict }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ item.job_envelope.id }}</a>
                     </div>
                     <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2">
                         <div>
@@ -145,7 +145,7 @@
                     {% when Some with (state) %}
                     {% if state|has_args %}
                     {% if state|show_job_progress %}
-                    {% let progress_scheduled_at = item.job_envelope.meta.scheduled_at %}
+                    {% let progress_started_at = item.job_envelope.meta.started_at %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <details class="mt-3">
@@ -157,7 +157,7 @@
                     {% when None %}
                     {% endmatch %}
                     <div class="mt-3 flex justify-end">
-                        <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ item.job_envelope.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
+                        <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ item.job_envelope.id|urlencode_strict }}/delete" onsubmit="return confirmDeleteJob('{{ item.job_envelope.id }}')">
                             <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
                         </form>
                     </div>
@@ -202,7 +202,7 @@
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
                 <div class="flex items-start justify-between mb-2">
                     <span class="font-semibold text-sm">{{ job.job.name }}</span>
-                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
+                    <a href="{{ base_path }}/jobs/{{ job.id|urlencode_strict }}" class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono">{{ job.id }}</a>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs text-gray-400 mt-2">
                     <div>
@@ -230,7 +230,7 @@
                 {% when Some with (state) %}
                 {% if state|has_args %}
                 {% if state|show_job_progress %}
-                {% let progress_scheduled_at = job.meta.scheduled_at %}
+                {% let progress_started_at = job.meta.started_at %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">
@@ -242,7 +242,7 @@
                 {% when None %}
                 {% endmatch %}
                 <div class="mt-3 flex justify-end">
-                    <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ job.id|urlencode }}/delete" onsubmit="return confirmDeleteJob('{{ job.id }}')">
+                    <form method="POST" action="{{ base_path }}/queues/{{ queue_key|urlencode }}/jobs/{{ job.id|urlencode_strict }}/delete" onsubmit="return confirmDeleteJob('{{ job.id }}')">
                         <button type="submit" class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors">Delete Job</button>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- Compute dashboard progress ETA from job start time instead of scheduled time, so queued time does not inflate ETA estimates.
- Keep cron \"Enqueue now\" on the cron page with the existing success notice, avoiding redirects to jobs that may already be completed and removed.
- Encode slash-containing job IDs safely in dashboard job links and delete form actions, and use Axum tail capture for job detail routes.
- Add regression tests for cron redirects, slash-containing job IDs, and progress ETA behavior.

## Pre-Landing Review
No unresolved issues. The earlier cron enqueue redirect concern was fixed before opening this PR.

## Test Plan
- [x] cargo test -p oxana-web
- [x] cargo check --all
- [x] git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped oxana-web UI and routing fixes with regression tests; no auth, storage, or worker behavior changes.
> 
> **Overview**
> Fixes three dashboard UX bugs in **oxana-web**: progress ETAs, cron enqueue flow, and job IDs that contain slashes.
> 
> **Progress ETA** now uses `meta.started_at` instead of `scheduled_at`, so time waiting in the queue no longer skews the estimate. Jobs without a start time show an unknown ETA.
> 
> **Cron “Enqueue now”** redirects to `/cron?enqueued=1` via a shared `cron_enqueued_redirect` helper so users stay on the cron page with the success notice instead of being sent to a job detail that may already be gone.
> 
> **Slash-containing job IDs** (e.g. `crate::Worker/type-123`) use `urlencode_strict` on job detail and delete links, and the job detail route uses Axum tail capture (`/jobs/{*job_id}`) so encoded paths resolve correctly.
> 
> Regression tests cover ETA math, cron redirect, route capture, and rendered link encoding; `tower` is added as a dev dependency for router tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d37780c530dcc3e700add14e68dab119fce38d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->