### PR TITLE
chore: bump rc version to 2.0.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.9", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.9", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.10", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.10", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump all Oxana workspace crate versions from 2.0.0-rc.9 to 2.0.0-rc.10
- Align workspace dependency constraints and Cargo.lock package entries

## Verification
- cargo check --all
- cargo metadata --no-deps reports oxana, oxana-macros, and oxana-web at 2.0.0-rc.10
- rg found no stale 2.0.0-rc.9 references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or API code changes.
> 
> **Overview**
> Bumps the Oxana workspace release candidate from **2.0.0-rc.9** to **2.0.0-rc.10** with no source or dependency changes beyond version strings.
> 
> Updates `[package].version` on `oxana`, `oxana-macros`, and `oxana-web`, aligns `[workspace.dependencies]` version constraints in the root `Cargo.toml`, and refreshes the corresponding entries in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5cb54907125cea07755c5dd58f8c3f78819ef4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->