### PR TITLE
fix: keep heartbeat during graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 
 - Avoid persisting runtime queue config when a queue is only using its default configuration.
 - Clear stale retry and schedule membership when replacing a unique job so the old retry attempt cannot run after the replacement resets the retry counter.
+- Keep worker heartbeats active while graceful shutdown drains in-flight jobs, preventing another process from treating those jobs as abandoned.
 
 ## [1.1.1]
 

--- a/oxana/src/launcher.rs
+++ b/oxana/src/launcher.rs
@@ -61,8 +61,9 @@ where
     let mut joinset = JoinSet::new();
     let mut coordinator_joinset = JoinSet::new();
     let stats = Arc::new(Mutex::new(Stats::default()));
+    let ping_cancel_token = CancellationToken::new();
 
-    joinset.spawn(ping_loop(Arc::clone(&config)));
+    joinset.spawn(ping_loop(Arc::clone(&config), ping_cancel_token.clone()));
     joinset.spawn(retry_loop(Arc::clone(&config)));
     joinset.spawn(schedule_loop(Arc::clone(&config)));
     joinset.spawn(resurrect_loop(Arc::clone(&config)));
@@ -109,6 +110,15 @@ where
     tracing::info!("Shutting down");
 
     coordinator_joinset.join_all().await;
+    ping_cancel_token.cancel();
+    while let Some(task_result) = joinset.join_next().await {
+        let task_result = task_result?;
+        if result.is_ok()
+            && let Err(e) = task_result
+        {
+            result = Err(e);
+        }
+    }
 
     config.storage.internal.self_cleanup().await?;
 
@@ -176,16 +186,15 @@ where
     Ok(())
 }
 
-async fn ping_loop<DT, ET>(config: Arc<Config<DT, ET>>) -> Result<(), OxanaError>
+async fn ping_loop<DT, ET>(
+    config: Arc<Config<DT, ET>>,
+    cancel_token: CancellationToken,
+) -> Result<(), OxanaError>
 where
     DT: Send + Sync + Clone + 'static,
     ET: std::error::Error + Send + Sync + 'static,
 {
-    config
-        .storage
-        .internal
-        .ping_loop(config.cancel_token.clone())
-        .await?;
+    config.storage.internal.ping_loop(cancel_token).await?;
 
     tracing::trace!("Ping loop finished");
 

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -1,8 +1,10 @@
 use crate::shared::*;
 use deadpool_redis::redis::AsyncCommands;
 use oxana::Queue as _;
+use std::sync::Arc;
 use std::time::Duration;
 use testresult::TestResult;
+use tokio::sync::{Notify, oneshot};
 
 #[derive(serde::Serialize)]
 struct DynamicConcurrencyQueue;
@@ -34,6 +36,59 @@ struct DynamicTenantQueue {
 impl oxana::Queue for DynamicTenantQueue {
     fn to_config() -> oxana::QueueConfig {
         oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(3)
+    }
+}
+
+#[derive(Clone)]
+struct ShutdownDrainState {
+    started: Arc<Notify>,
+    finished: Arc<Notify>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ShutdownProgressJob;
+
+impl oxana::Job for ShutdownProgressJob {
+    fn worker_name() -> &'static str {
+        std::any::type_name::<ShutdownProgressWorker>()
+    }
+
+    fn should_resurrect() -> bool {
+        false
+    }
+}
+
+struct ShutdownProgressWorker {
+    state: ShutdownDrainState,
+}
+
+impl oxana::FromContext<ShutdownDrainState> for ShutdownProgressWorker {
+    fn from_context(ctx: &ShutdownDrainState) -> Self {
+        Self { state: ctx.clone() }
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<ShutdownProgressJob> for ShutdownProgressWorker {
+    type Error = oxana::OxanaError;
+
+    async fn run_batch(
+        &self,
+        jobs: Vec<oxana::BatchItem<ShutdownProgressJob>>,
+    ) -> Result<(), oxana::OxanaError> {
+        let job = jobs
+            .into_iter()
+            .next()
+            .expect("shutdown progress worker receives one job");
+        self.state.started.notify_one();
+        tokio::time::sleep(Duration::from_millis(8500)).await;
+        job.ctx.state.update_progress((1, 1)).await?;
+        self.state.finished.notify_one();
+        Ok(())
+    }
+
+    fn max_retries(&self, _job: &ShutdownProgressJob) -> u32 {
+        0
     }
 }
 
@@ -76,6 +131,56 @@ pub async fn test_standard() -> TestResult {
     assert_eq!(value, Some(random_value));
     assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
     assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_shutdown_keeps_heartbeat_until_workers_finish() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let state = ShutdownDrainState {
+        started: Arc::new(Notify::new()),
+        finished: Arc::new(Notify::new()),
+    };
+    let ctx = oxana::ContextValue::new(state.clone());
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let config = oxana::Config::new(&storage)
+        .register_queue::<QueueOne>()
+        .register_worker::<ShutdownProgressWorker, ShutdownProgressJob>()
+        .with_graceful_shutdown(async move {
+            shutdown_rx
+                .await
+                .map_err(|_| std::io::Error::other("shutdown sender dropped"))
+        });
+    let job_id = storage.enqueue(QueueOne, ShutdownProgressJob).await?;
+    let old_worker = tokio::spawn(async move { oxana::run(config, ctx).await });
+
+    state.started.notified().await;
+    shutdown_tx
+        .send(())
+        .expect("old worker shutdown receiver should be alive");
+
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    let new_ctx = oxana::ContextValue::new(state.clone());
+    let new_config = oxana::Config::new(&storage)
+        .register_queue::<QueueOne>()
+        .register_worker::<ShutdownProgressWorker, ShutdownProgressJob>()
+        .with_graceful_shutdown(async move {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            Ok(())
+        });
+    let new_worker = tokio::spawn(async move { oxana::run(new_config, new_ctx).await });
+
+    tokio::time::timeout(Duration::from_secs(5), new_worker).await???;
+    tokio::time::timeout(Duration::from_secs(5), state.finished.notified()).await?;
+    tokio::time::timeout(Duration::from_secs(5), old_worker).await???;
+
+    assert!(storage.get_job(&job_id).await?.is_none());
+    assert_eq!(storage.dead_count().await?, 0);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Keep the worker heartbeat loop alive while graceful shutdown waits for in-flight workers to finish.
- Stop the heartbeat only after coordinators drain, then clean up the current process metadata.
- Add an integration regression test covering the stale-process window where another worker could otherwise delete a non-resurrectable in-flight job.
- Document the fix in the 2.0.0-rc changelog.

## Test Coverage

All new code paths have regression coverage via `test_shutdown_keeps_heartbeat_until_workers_finish`.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed — design review skipped.

## Scope Drift

Scope clean: branch only changes launcher shutdown heartbeat behavior, regression coverage, and changelog documentation.

## TODOS

No TODO items completed in this PR.

## Test plan

- `cargo test -p oxana test_shutdown_keeps_heartbeat_until_workers_finish --test integration`
- `cargo test --workspace --lib --tests`
- `cargo check --all`
- `cargo clippy --all-features --workspace`
- `cargo fmt --all -- --check`
- `git diff --check origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shutdown ordering and process liveness in Redis, which affects job abandonment and resurrection behavior during deploys or restarts.
> 
> **Overview**
> During graceful shutdown, the worker **heartbeat (`ping_loop`) no longer stops when the global cancel token fires**. It uses a dedicated `ping_cancel_token` that is cancelled only **after** queue coordinators finish draining in-flight work, then background tasks are joined before `self_cleanup`.
> 
> This closes a window where another Oxana process could treat a still-running job as abandoned (especially harmful for jobs that do not resurrect). The **2.0.0-rc changelog** documents the fix, and **`test_shutdown_keeps_heartbeat_until_workers_finish`** regression-tests overlapping workers during a long in-flight job on shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807bd2c1deeda0c6a226df89311eef6fc1b6b3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->