### PR TITLE
chore: bump rc versions to 2.0.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.10", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.10", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.11", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.11", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."


### PR DESCRIPTION
## Summary
- Bump oxana, oxana-macros, and oxana-web from 2.0.0-rc.10 to 2.0.0-rc.11
- Update workspace dependency pins and Cargo.lock to keep crate versions aligned

## Verification
- cargo check --all
- cargo metadata --no-deps --format-version 1
- rg 2.0.0-rc.10 (no stale references outside build artifacts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or API logic modified.
> 
> **Overview**
> Bumps the workspace release candidate from **2.0.0-rc.10** to **2.0.0-rc.11** for `oxana`, `oxana-macros`, and `oxana-web`.
> 
> Updates `[workspace.dependencies]` in the root `Cargo.toml`, each crate’s `[package].version`, and the corresponding entries in `Cargo.lock` so internal path dependencies stay aligned. No application or library code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674ce00e8daec9913ddfda5fa1f42e120404b890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->